### PR TITLE
Adapt qtox to new conferences state change callback.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:qt.bzl", "qt_moc", "qt_rcc", "qt_ui_library")
+load("//third_party/qt:build_defs.bzl", "qt_moc", "qt_rcc", "qt_ui_library")
 
 # User interface headers
 # =========================================================

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -515,7 +515,7 @@ void Core::onConnectionStatusChanged(Tox*, uint32_t friendId, TOX_CONNECTION sta
     }
 }
 
-void Core::onGroupInvite(Tox*, uint32_t friendId, TOX_CONFERENCE_TYPE type, const uint8_t* cookie,
+void Core::onGroupInvite(Tox* tox, uint32_t friendId, TOX_CONFERENCE_TYPE type, const uint8_t* cookie,
                          size_t length, void* vCore)
 {
     Core* core = static_cast<Core*>(vCore);
@@ -525,11 +525,22 @@ void Core::onGroupInvite(Tox*, uint32_t friendId, TOX_CONFERENCE_TYPE type, cons
     switch (type) {
     case TOX_CONFERENCE_TYPE_TEXT:
         qDebug() << QString("Text group invite by %1").arg(friendId);
+        if (friendId == UINT32_MAX) {
+            // Rejoining existing (persistent) conference after disconnect and reconnect.
+            tox_conference_join(tox, friendId, cookie, length, nullptr);
+            return;
+        }
         emit core->groupInviteReceived(inviteInfo);
         break;
 
     case TOX_CONFERENCE_TYPE_AV:
         qDebug() << QString("AV group invite by %1").arg(friendId);
+        if (friendId == UINT32_MAX) {
+            // Rejoining existing (persistent) AV conference after disconnect and reconnect.
+            toxav_join_av_groupchat(tox, friendId, cookie, length,
+                                    CoreAV::groupCallCallback, core);
+            return;
+        }
         emit core->groupInviteReceived(inviteInfo);
         break;
 
@@ -551,7 +562,7 @@ void Core::onGroupNamelistChange(Tox*, uint32_t groupId, uint32_t peerId,
                                  TOX_CONFERENCE_STATE_CHANGE change, void* core)
 {
     CoreAV* coreAv = static_cast<Core*>(core)->getAv();
-    if (change == TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT && coreAv->isGroupAvEnabled(groupId)) {
+    if (change == TOX_CONFERENCE_STATE_CHANGE_LIST_CHANGED && coreAv->isGroupAvEnabled(groupId)) {
         CoreAV::invalidateGroupCallPeerSource(groupId, peerId);
     }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1741,18 +1741,8 @@ void Widget::onGroupNamelistChanged(int groupnumber, int peernumber, uint8_t Cha
     }
 
     TOX_CONFERENCE_STATE_CHANGE change = static_cast<TOX_CONFERENCE_STATE_CHANGE>(Change);
-    if (change == TOX_CONFERENCE_STATE_CHANGE_PEER_JOIN) {
-        // g->addPeer(peernumber,name);
+    if (change == TOX_CONFERENCE_STATE_CHANGE_LIST_CHANGED) {
         g->regeneratePeerList();
-        // g->getChatForm()->addSystemInfoMessage(tr("%1 has joined the chat").arg(name), "white",
-        // QDateTime::currentDateTime());
-        // we can't display these messages until toxcore fixes peernumbers
-        // https://github.com/irungentoo/toxcore/issues/1128
-    } else if (change == TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT) {
-        // g->removePeer(peernumber);
-        g->regeneratePeerList();
-        // g->getChatForm()->addSystemInfoMessage(tr("%1 has left the chat").arg(name), "white",
-        // QDateTime::currentDateTime());
     } else if (change == TOX_CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE) // core overwrites old name
                                                                        // before telling us it
                                                                        // changed...

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:qt.bzl", "qt_moc")
+load("//third_party/qt:build_defs.bzl", "qt_moc")
 
 SRCS = glob(["*/*_test.cpp"])
 


### PR DESCRIPTION
See https://github.com/TokTok/c-toxcore/pull/295.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/qtox/7)
<!-- Reviewable:end -->
