### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,12 +43,14 @@ cc_library(
         ":res",
         ":translations",
     ],
+    tags = ["no-cross"],
     visibility = ["//qtox:__subpackages__"],
     alwayslink = True,
 )
 
 cc_binary(
     name = "qtox",
+    tags = ["no-cross"],
     visibility = ["//qtox:__subpackages__"],
     deps = ["//qtox/src:main"],
 )

--- a/audio/BUILD.bazel
+++ b/audio/BUILD.bazel
@@ -12,6 +12,7 @@ qt_moc(
     ],
     hdrs = glob(["**/*.h"]),
     mocopts = ["-Iqtox/audio/include"],
+    tags = ["no-cross"],
     deps = ["//qtox/util"],
 )
 
@@ -19,11 +20,13 @@ qt_rcc(
     name = "audio_res",
     srcs = ["resources/audio_res.qrc"],
     data = glob(["resources/*.pcm"]),
+    tags = ["no-cross"],
 )
 
 cc_library(
     name = "audio_res_lib",
     srcs = [":audio_res"],
+    tags = ["no-cross"],
     visibility = ["//qtox:__subpackages__"],
     alwayslink = True,
 )
@@ -52,6 +55,7 @@ cc_library(
         "UPDATE_CHECK_ENABLED",
     ],
     includes = ["include"],
+    tags = ["no-cross"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         ":audio_res_lib",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -117,6 +117,7 @@ qt_moc(
         "-Iqtox",
         "-Iqtox/util/include",
     ],
+    tags = ["no-cross"],
     deps = [
         "//qtox/util",
         "@qt//:qt_widgets",
@@ -126,6 +127,7 @@ qt_moc(
 qt_uic(
     name = "src_ui",
     srcs = glob(["**/*.ui"]),
+    tags = ["no-cross"],
 )
 
 objc_library(
@@ -220,6 +222,7 @@ cc_library(
         "//tools/config:osx": ["-framework IOKit"],
         "//tools/config:windows": [],
     }),
+    tags = ["no-cross"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         "//c-toxcore",
@@ -265,6 +268,7 @@ cc_library(
         "//tools/config:osx": [],
         "//tools/config:windows": [],
     }),
+    tags = ["no-cross"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         ":src",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -8,6 +8,7 @@ qt_moc(
         "-Iqtox",
         "-Iqtox/util/include",
     ],
+    tags = ["no-cross"],
     deps = [
         "//qtox/src",
         "//qtox/util",
@@ -25,6 +26,7 @@ cc_library(
         "//tools/config:windows": [],
     }),
     includes = ["mock/include"],
+    tags = ["no-cross"],
     deps = ["//qtox/src"],
 )
 

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -22,6 +22,7 @@ cc_library(
         "UPDATE_CHECK_ENABLED",
     ],
     includes = ["include"],
+    tags = ["no-cross"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         "//c-toxcore",


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/35)
<!-- Reviewable:end -->
