### PR TITLE
chore: Cancel old release-check runs when pushing new commits.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
     branches: [master]
     types: [opened, reopened, synchronize]
 
+# Cancel old PR builds when pushing new commits.
+concurrency:
+  group: release-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     uses: TokTok/ci-tools/.github/workflows/release-drafter.yml@master


### PR DESCRIPTION
Requires https://github.com/TokTok/toktok-stack/pull/865

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/47)
<!-- Reviewable:end -->
