### PR TITLE
chore: Only rebuild docker images if the build scripts changed.

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -1,13 +1,23 @@
 name: 'Build docker image'
+
 inputs:
   docker_image_name:
     description: "Name of docker image"
     required: True
+
 runs:
   using: 'composite'
   steps:
+    - uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          buildscripts:
+            - 'buildscripts/**'
     - uses: docker/setup-buildx-action@v3
+      if: steps.changes.outputs.buildscripts == 'true'
     - name: Setup buildx cache
+      if: steps.changes.outputs.buildscripts == 'true'
       uses: actions/cache@v4
       with:
         path: |
@@ -16,9 +26,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ inputs.docker_image_name }}-
     - name: Build docker image
+      if: steps.changes.outputs.buildscripts == 'true'
       shell: bash
-      run: docker buildx bake --set *.cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max --set *.cache-from=type=local,src=/tmp/.buildx-cache -f docker-compose.yml ${{ inputs.docker_image_name }}
+      run: docker buildx bake
+        --set *.cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max
+        --set *.cache-from=type=local,src=/tmp/.buildx-cache
+        -f docker-compose.yml
+        ${{ inputs.docker_image_name }}
     - name: Replace buildx cache
+      if: steps.changes.outputs.buildscripts == 'true'
       shell: bash
       run: |
         rm -fr /tmp/.buildx-cache

--- a/.github/actions/load-docker-image/action.yml
+++ b/.github/actions/load-docker-image/action.yml
@@ -1,8 +1,10 @@
 name: 'Load docker image'
+
 inputs:
   docker_image_name:
     description: "Name of docker image"
     required: True
+
 runs:
   using: 'composite'
   steps:
@@ -18,4 +20,8 @@ runs:
       run: sudo apt-get install -y docker-compose
     - name: Load cached docker images
       shell: bash
-      run: docker buildx bake --set *.cache-from=type=local,src=/tmp/.buildx-cache -f docker-compose.yml ${{ inputs.docker_image_name }} --load
+      run: docker buildx bake
+        --set *.cache-from=type=local,src=/tmp/.buildx-cache
+        -f docker-compose.yml
+        ${{ inputs.docker_image_name }}
+        --load


### PR DESCRIPTION
This is a bit of an overestimate. It'll run builds if *any* build script changed, even if it doesn't contribute to that particular docker image. This is fine, as we can still usually rely on github caching working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/66)
<!-- Reviewable:end -->
