### PR TITLE
cleanup: Unify source to have prefix-`const` everywhere.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -77,4 +77,7 @@ AllowShortFunctionsOnASingleLine: Empty
 # Set pointer format
 DerivePointerAlignment: false
 PointerAlignment: Left
+
+# "const X" instead of "X const"
+QualifierAlignment: Left
 ...

--- a/audio/src/backend/openal.cpp
+++ b/audio/src/backend/openal.cpp
@@ -218,7 +218,7 @@ std::unique_ptr<IAudioSink> OpenAL::makeSink()
     ALuint sid;
     alGenSources(1, &sid);
 
-    auto const sink = new AlSink(*this, sid);
+    const auto sink = new AlSink(*this, sid);
     if (sink == nullptr) {
         return {};
     }
@@ -276,7 +276,7 @@ std::unique_ptr<IAudioSource> OpenAL::makeSource()
         return {};
     }
 
-    auto const source = new AlSource(*this);
+    const auto source = new AlSource(*this);
     if (source == nullptr) {
         return {};
     }

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -523,9 +523,9 @@ void ChatWidget::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
     QGraphicsScene::ItemIndexMethod oldIndexMeth = scene->itemIndexMethod();
     scene->setItemIndexMethod(QGraphicsScene::NoIndex);
 
-    for (auto const& chatLine : chatLines) {
+    for (const auto& chatLine : chatLines) {
         auto idx = chatLine.first;
-        auto const& l = chatLine.second;
+        const auto& l = chatLine.second;
 
         chatLineStorage->insertChatMessage(idx, chatLog.at(idx).getTimestamp(), l);
 

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -227,7 +227,7 @@ void FileTransferWidget::reloadTheme()
     updateBackgroundColor(lastStatus);
 }
 
-void FileTransferWidget::updateWidgetColor(ToxFile const& file)
+void FileTransferWidget::updateWidgetColor(const ToxFile& file)
 {
     if (lastStatus == file.status) {
         return;
@@ -236,7 +236,7 @@ void FileTransferWidget::updateWidgetColor(ToxFile const& file)
     updateBackgroundColor(file.status);
 }
 
-void FileTransferWidget::updateWidgetText(ToxFile const& file)
+void FileTransferWidget::updateWidgetText(const ToxFile& file)
 {
     if (lastStatus == file.status && file.status != ToxFile::PAUSED) {
         return;
@@ -273,7 +273,7 @@ void FileTransferWidget::updateWidgetText(ToxFile const& file)
     }
 }
 
-void FileTransferWidget::updatePreview(ToxFile const& file)
+void FileTransferWidget::updatePreview(const ToxFile& file)
 {
     if (lastStatus == file.status) {
         return;
@@ -298,7 +298,7 @@ void FileTransferWidget::updatePreview(ToxFile const& file)
     }
 }
 
-void FileTransferWidget::updateFileProgress(ToxFile const& file)
+void FileTransferWidget::updateFileProgress(const ToxFile& file)
 {
     switch (file.status) {
     case ToxFile::INITIALIZING:
@@ -338,7 +338,7 @@ void FileTransferWidget::updateFileProgress(ToxFile const& file)
     }
 }
 
-void FileTransferWidget::updateSignals(ToxFile const& file)
+void FileTransferWidget::updateSignals(const ToxFile& file)
 {
     if (lastStatus == file.status) {
         return;
@@ -361,7 +361,7 @@ void FileTransferWidget::updateSignals(ToxFile const& file)
     }
 }
 
-void FileTransferWidget::setupButtons(ToxFile const& file)
+void FileTransferWidget::setupButtons(const ToxFile& file)
 {
     if (lastStatus == file.status && file.status != ToxFile::PAUSED) {
         return;
@@ -497,7 +497,7 @@ void FileTransferWidget::onPreviewButtonClicked()
     handleButton(ui->previewButton);
 }
 
-void FileTransferWidget::updateWidget(ToxFile const& file)
+void FileTransferWidget::updateWidget(const ToxFile& file)
 {
     assert(file == fileInfo);
 

--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -35,12 +35,12 @@ public:
     void onFileTransferUpdate(ToxFile file);
 
 protected:
-    void updateWidgetColor(ToxFile const& file);
-    void updateWidgetText(ToxFile const& file);
-    void updateFileProgress(ToxFile const& file);
-    void updateSignals(ToxFile const& file);
-    void updatePreview(ToxFile const& file);
-    void setupButtons(ToxFile const& file);
+    void updateWidgetColor(const ToxFile& file);
+    void updateWidgetText(const ToxFile& file);
+    void updateFileProgress(const ToxFile& file);
+    void updateSignals(const ToxFile& file);
+    void updatePreview(const ToxFile& file);
+    void setupButtons(const ToxFile& file);
     void handleButton(QPushButton* btn);
     void showPreview(const QString& filename);
     void acceptTransfer(const QString& filepath);
@@ -62,7 +62,7 @@ private slots:
 private:
     static bool tryRemoveFile(const QString& filepath);
 
-    void updateWidget(ToxFile const& file);
+    void updateWidget(const ToxFile& file);
     void updateBackgroundColor(const ToxFile::FileStatus status);
 
 private:

--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -113,7 +113,7 @@ MatchingUri stripSurroundingChars(const QStringView wrappedUri, const int startO
     int curValidationEndPos = wrappedUri.length();
     do {
         matchFound = false;
-        for (auto const& surroundChars : URI_WRAPPING_CHARS) {
+        for (const auto& surroundChars : URI_WRAPPING_CHARS) {
             const int openingCharLength = surroundChars.first.length();
             const int closingCharLength = surroundChars.second.length();
             if (surroundChars.first == wrappedUri.mid(curValidationStartPos, openingCharLength)
@@ -125,7 +125,7 @@ MatchingUri stripSurroundingChars(const QStringView wrappedUri, const int startO
                 break;
             }
         }
-        for (QChar const endChar : URI_ENDING_CHARS) {
+        for (const QChar endChar : URI_ENDING_CHARS) {
             const int charLength = 1;
             if (endChar == wrappedUri.at(curValidationEndPos - charLength)) {
                 curValidationEndPos -= charLength;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -386,7 +386,7 @@ void Core::bootstrapDht()
     ASSERT_CORE_THREAD;
 
 
-    auto const shuffledBootstrapNodes =
+    const auto shuffledBootstrapNodes =
         shuffleBootstrapNodes(bootstrapListGenerator.getBootstrapNodes());
     if (shuffledBootstrapNodes.empty()) {
         qWarning() << "No bootstrap node list";

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -344,7 +344,7 @@ bool CoreAV::sendCallAudio(uint32_t callId, const int16_t* pcm, size_t samples, 
         return false;
     }
 
-    ToxFriendCall const& call = *it->second;
+    const ToxFriendCall& call = *it->second;
 
     if (call.getMuteMic() || !call.isActive()
         || !(call.getState() & TOXAV_FRIEND_CALL_STATE_ACCEPTING_A)) {

--- a/src/core/coreext.h
+++ b/src/core/coreext.h
@@ -43,9 +43,9 @@ public:
     static std::unique_ptr<CoreExt> makeCoreExt(Tox* core);
 
     // We do registration with our own pointer, need to ensure we're in a stable location
-    CoreExt(CoreExt const& other) = delete;
+    CoreExt(const CoreExt& other) = delete;
     CoreExt(CoreExt&& other) = delete;
-    CoreExt& operator=(CoreExt const& other) = delete;
+    CoreExt& operator=(const CoreExt& other) = delete;
     CoreExt& operator=(CoreExt&& other) = delete;
 
     /**
@@ -74,7 +74,7 @@ public:
                uint32_t friendId, std::mutex* toxext_mutex, PacketPassKey passKey);
 
         // Delete copy constructor, we shouldn't be able to copy
-        Packet(Packet const& other) = delete;
+        Packet(const Packet& other) = delete;
 
         Packet(Packet&& other)
         {

--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -168,7 +168,7 @@ const uint8_t* ToxId::getBytes() const
  */
 ToxPk ToxId::getPublicKey() const
 {
-    auto const pkBytes = toxId.left(ToxPk::size);
+    const auto pkBytes = toxId.left(ToxPk::size);
     if (pkBytes.isEmpty()) {
         return ToxPk{};
     } else {

--- a/src/model/conferencemessagedispatcher.cpp
+++ b/src/model/conferencemessagedispatcher.cpp
@@ -22,12 +22,12 @@ ConferenceMessageDispatcher::ConferenceMessageDispatcher(Conference& g_, Message
 }
 
 std::pair<DispatchedMessageId, DispatchedMessageId>
-ConferenceMessageDispatcher::sendMessage(bool isAction, QString const& content)
+ConferenceMessageDispatcher::sendMessage(bool isAction, const QString& content)
 {
     const auto firstMessageId = nextMessageId;
     auto lastMessageId = firstMessageId;
 
-    for (auto const& message : processor.processOutgoingMessage(isAction, content, ExtensionSet())) {
+    for (const auto& message : processor.processOutgoingMessage(isAction, content, ExtensionSet())) {
         auto messageId = nextMessageId++;
         lastMessageId = messageId;
         if (conference.getPeersCount() != 1) {
@@ -70,7 +70,7 @@ ConferenceMessageDispatcher::sendExtendedMessage(const QString& content, Extensi
  * @param[in] content Message content
  */
 void ConferenceMessageDispatcher::onMessageReceived(const ToxPk& sender, bool isAction,
-                                                    QString const& content)
+                                                    const QString& content)
 {
     bool isSelf = sender == idHandler.getSelfPublicKey();
 

--- a/src/model/conferencemessagedispatcher.h
+++ b/src/model/conferencemessagedispatcher.h
@@ -27,11 +27,11 @@ public:
                                 const IConferenceSettings& conferenceSettings);
 
     std::pair<DispatchedMessageId, DispatchedMessageId> sendMessage(bool isAction,
-                                                                    QString const& content) override;
+                                                                    const QString& content) override;
 
     std::pair<DispatchedMessageId, DispatchedMessageId>
     sendExtendedMessage(const QString& content, ExtensionSet extensions) override;
-    void onMessageReceived(ToxPk const& sender, bool isAction, QString const& content);
+    void onMessageReceived(const ToxPk& sender, bool isAction, const QString& content);
 
 private:
     Conference& conference;

--- a/src/model/friendmessagedispatcher.cpp
+++ b/src/model/friendmessagedispatcher.cpp
@@ -100,7 +100,7 @@ void FriendMessageDispatcher::onFriendOnlineOfflineChanged(const ToxPk& friendPk
     std::ignore = friendPk;
     if (isOnline) {
         auto messagesToResend = offlineMsgEngine.removeAllMessages();
-        for (auto const& message : messagesToResend) {
+        for (const auto& message : messagesToResend) {
             sendProcessedMessage(message.message, message.callback);
         }
     }
@@ -115,7 +115,7 @@ void FriendMessageDispatcher::clearOutgoingMessages()
 }
 
 
-void FriendMessageDispatcher::sendProcessedMessage(Message const& message,
+void FriendMessageDispatcher::sendProcessedMessage(const Message& message,
                                                    OfflineMsgEngine::CompletionFn onOfflineMsgComplete)
 {
     if (!Status::isOnline(f.getStatus())) {
@@ -132,7 +132,7 @@ void FriendMessageDispatcher::sendProcessedMessage(Message const& message,
 
 
 void FriendMessageDispatcher::sendExtendedProcessedMessage(
-    Message const& message, OfflineMsgEngine::CompletionFn onOfflineMsgComplete)
+    const Message& message, OfflineMsgEngine::CompletionFn onOfflineMsgComplete)
 {
     assert(!message.isAction); // Actions not supported with extensions
 
@@ -159,7 +159,7 @@ void FriendMessageDispatcher::sendExtendedProcessedMessage(
     }
 }
 
-void FriendMessageDispatcher::sendCoreProcessedMessage(Message const& message,
+void FriendMessageDispatcher::sendCoreProcessedMessage(const Message& message,
                                                        OfflineMsgEngine::CompletionFn onOfflineMsgComplete)
 {
     auto receipt = ReceiptNum();

--- a/src/model/friendmessagedispatcher.h
+++ b/src/model/friendmessagedispatcher.h
@@ -37,11 +37,11 @@ private slots:
     void onFriendOnlineOfflineChanged(const ToxPk& friendPk, bool isOnline);
 
 private:
-    void sendProcessedMessage(Message const& message,
+    void sendProcessedMessage(const Message& message,
                               OfflineMsgEngine::CompletionFn onOfflineMsgComplete);
-    void sendExtendedProcessedMessage(Message const& message,
+    void sendExtendedProcessedMessage(const Message& message,
                                       OfflineMsgEngine::CompletionFn onOfflineMsgComplete);
-    void sendCoreProcessedMessage(Message const& message,
+    void sendCoreProcessedMessage(const Message& message,
                                   OfflineMsgEngine::CompletionFn onOfflineMsgComplete);
     OfflineMsgEngine::CompletionFn getCompletionFn(DispatchedMessageId messageId);
 

--- a/src/model/message.cpp
+++ b/src/model/message.cpp
@@ -69,7 +69,7 @@ MessageProcessor::MessageProcessor(const MessageProcessor::SharedParams& sharedP
 /**
  * @brief Converts an outgoing message into one (or many) sanitized Message(s)
  */
-std::vector<Message> MessageProcessor::processOutgoingMessage(bool isAction, QString const& content,
+std::vector<Message> MessageProcessor::processOutgoingMessage(bool isAction, const QString& content,
                                                               ExtensionSet extensions)
 {
     std::vector<Message> ret;
@@ -102,7 +102,7 @@ std::vector<Message> MessageProcessor::processOutgoingMessage(bool isAction, QSt
 /**
  * @brief Converts an incoming message into a sanitized Message
  */
-Message MessageProcessor::processIncomingCoreMessage(bool isAction, QString const& message)
+Message MessageProcessor::processIncomingCoreMessage(bool isAction, const QString& message)
 {
     QDateTime timestamp = QDateTime::currentDateTime();
     auto ret = Message{};
@@ -115,7 +115,7 @@ Message MessageProcessor::processIncomingCoreMessage(bool isAction, QString cons
         auto sanitizedNameMention = sharedParams.getSanitizedNameMention();
         auto pubKeyMention = sharedParams.getPublicKeyMention();
 
-        for (auto const& mention : {nameMention, sanitizedNameMention, pubKeyMention}) {
+        for (const auto& mention : {nameMention, sanitizedNameMention, pubKeyMention}) {
             auto matchIt = mention.globalMatch(ret.content);
             if (!matchIt.hasNext()) {
                 continue;

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -124,7 +124,7 @@ QPixmap getSenderAvatar(Profile* profile, const ToxPk& sender)
 }
 } // namespace
 
-NotificationGenerator::NotificationGenerator(INotificationSettings const& notificationSettings_,
+NotificationGenerator::NotificationGenerator(const INotificationSettings& notificationSettings_,
                                              Profile* profile_)
     : notificationSettings(notificationSettings_)
     , profile(profile_)

--- a/src/model/notificationgenerator.h
+++ b/src/model/notificationgenerator.h
@@ -21,7 +21,7 @@ class NotificationGenerator : public QObject
     Q_OBJECT
 
 public:
-    NotificationGenerator(INotificationSettings const& notificationSettings_,
+    NotificationGenerator(const INotificationSettings& notificationSettings_,
                           // Optional profile input to lookup avatars. Avatar lookup is not
                           // currently mockable so we allow profile to be nullptr for unit
                           // testing
@@ -44,7 +44,7 @@ public slots:
     void onNotificationActivated();
 
 private:
-    INotificationSettings const& notificationSettings;
+    const INotificationSettings& notificationSettings;
     Profile* profile;
     QHash<const Friend*, size_t> friendNotifications;
     QHash<const Conference*, size_t> conferenceNotifications;

--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -86,7 +86,7 @@ std::map<ChatLogIdx, ChatLogItem>::const_iterator
 firstItemAfterDate(QDate date, const std::map<ChatLogIdx, ChatLogItem>& items)
 {
     return std::lower_bound(items.begin(), items.end(), date.startOfDay(),
-                            [](const MessageDateAdaptor& a, MessageDateAdaptor const& b) {
+                            [](const MessageDateAdaptor& a, const MessageDateAdaptor& b) {
                                 return a.timestamp.date() < b.timestamp.date();
                             });
 }

--- a/src/persistence/db/upgrades/dbupgrader.cpp
+++ b/src/persistence/db/upgrades/dbupgrader.cpp
@@ -247,7 +247,7 @@ bool DbUpgrader::dbSchemaUpgrade(std::shared_ptr<RawDatabase>& db, IMessageBoxMa
     assert(upgradeFns.size() == SCHEMA_VERSION);
 
     for (int64_t i = databaseSchemaVersion; i < static_cast<int>(upgradeFns.size()); ++i) {
-        auto const newDbVersion = i + 1;
+        const auto newDbVersion = i + 1;
         if (!upgradeFns[i](*db)) {
             qCritical() << "Failed to upgrade db to schema version " << newDbVersion << " aborting";
             return false;

--- a/src/persistence/globalsettingsupgrader.cpp
+++ b/src/persistence/globalsettingsupgrader.cpp
@@ -51,7 +51,7 @@ bool GlobalSettingsUpgrader::doUpgrade(Settings& settings, int fromVer, int toVe
     assert(toVer == static_cast<int>(upgradeFns.size()));
 
     for (int i = fromVer; i < static_cast<int>(upgradeFns.size()); ++i) {
-        auto const newSettingsVersion = i + 1;
+        const auto newSettingsVersion = i + 1;
         if (!upgradeFns[i](settings)) {
             qCritical() << "Failed to upgrade settings to version" << newSettingsVersion << "aborting";
             return false;

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -43,21 +43,21 @@ void addChatIdSubQuery(QString& queryString, QVector<QByteArray>& boundParams, c
     queryString += "(SELECT id FROM chats WHERE uuid = ?)";
 }
 
-RawDatabase::Query generateEnsurePkInChats(ChatId const& id)
+RawDatabase::Query generateEnsurePkInChats(const ChatId& id)
 {
     return RawDatabase::Query{QStringLiteral("INSERT OR IGNORE INTO chats (uuid) "
                                              "VALUES (?)"),
                               {id.getByteArray()}};
 }
 
-RawDatabase::Query generateEnsurePkInAuthors(ToxPk const& pk)
+RawDatabase::Query generateEnsurePkInAuthors(const ToxPk& pk)
 {
     return RawDatabase::Query{QStringLiteral("INSERT OR IGNORE INTO authors (public_key) "
                                              "VALUES (?)"),
                               {pk.getByteArray()}};
 }
 
-RawDatabase::Query generateUpdateAlias(ToxPk const& pk, QString const& dispName)
+RawDatabase::Query generateUpdateAlias(const ToxPk& pk, const QString& dispName)
 {
     QVector<QByteArray> boundParams;
     QString queryString =
@@ -418,7 +418,7 @@ RawDatabase::Query History::generateFileFinished(RowId id, bool success, const Q
 
 void History::addNewFileMessage(const ChatId& chatId, const QByteArray& fileId,
                                 const QString& fileName, const QString& filePath, int64_t size,
-                                const ToxPk& sender, const QDateTime& time, QString const& dispName)
+                                const ToxPk& sender, const QDateTime& time, const QString& dispName)
 {
     if (historyAccessBlocked()) {
         return;

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -221,7 +221,7 @@ public:
 
     void addNewFileMessage(const ChatId& chatId, const QByteArray& fileId, const QString& fileName,
                            const QString& filePath, int64_t size, const ToxPk& sender,
-                           const QDateTime& time, QString const& dispName);
+                           const QDateTime& time, const QString& dispName);
 
     void addNewSystemMessage(const ChatId& chatId, const SystemMessage& systemMessage);
 

--- a/src/persistence/iconferencesettings.h
+++ b/src/persistence/iconferencesettings.h
@@ -25,6 +25,6 @@ public:
     virtual bool getShowConferenceJoinLeaveMessages() const = 0;
     virtual void setShowConferenceJoinLeaveMessages(bool newValue) = 0;
 
-    DECLARE_SIGNAL(blackListChanged, QStringList const& blist);
+    DECLARE_SIGNAL(blackListChanged, const QStringList& blist);
     DECLARE_SIGNAL(showConferenceJoinLeaveMessagesChanged, bool show);
 };

--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -41,7 +41,7 @@ void OfflineMsgEngine::onExtendedReceiptReceived(ExtendedReceiptNum receipt)
  * @param[in] messageID   database RowId of the message, used to eventually mark messages as received in history
  * @param[in] msg         chat message line in the chatlog, used to eventually set the message's receieved timestamp
  */
-void OfflineMsgEngine::addUnsentMessage(Message const& message, CompletionFn completionCallback)
+void OfflineMsgEngine::addUnsentMessage(const Message& message, CompletionFn completionCallback)
 {
     QMutexLocker<QRecursiveMutex> ml(&mutex);
     unsentMessages.push_back(
@@ -58,7 +58,7 @@ void OfflineMsgEngine::addUnsentMessage(Message const& message, CompletionFn com
  * @param[in] messageID   database RowId of the message, used to eventually mark messages as received in history
  * @param[in] msg         chat message line in the chatlog, used to eventually set the message's receieved timestamp
  */
-void OfflineMsgEngine::addSentCoreMessage(ReceiptNum receipt, Message const& message,
+void OfflineMsgEngine::addSentCoreMessage(ReceiptNum receipt, const Message& message,
                                           CompletionFn completionCallback)
 {
     QMutexLocker<QRecursiveMutex> ml(&mutex);
@@ -66,7 +66,7 @@ void OfflineMsgEngine::addSentCoreMessage(ReceiptNum receipt, Message const& mes
                                                 completionCallback});
 }
 
-void OfflineMsgEngine::addSentExtendedMessage(ExtendedReceiptNum receipt, Message const& message,
+void OfflineMsgEngine::addSentExtendedMessage(ExtendedReceiptNum receipt, const Message& message,
                                               CompletionFn completionCallback)
 {
     QMutexLocker<QRecursiveMutex> ml(&mutex);

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -23,10 +23,10 @@ class OfflineMsgEngine : public QObject
 public:
     using CompletionFn = std::function<void(bool)>;
     OfflineMsgEngine() = default;
-    void addUnsentMessage(Message const& message, CompletionFn completionCallback);
-    void addSentCoreMessage(ReceiptNum receipt, Message const& message,
+    void addUnsentMessage(const Message& message, CompletionFn completionCallback);
+    void addSentCoreMessage(ReceiptNum receipt, const Message& message,
                             CompletionFn completionCallback);
-    void addSentExtendedMessage(ExtendedReceiptNum receipt, Message const& message,
+    void addSentExtendedMessage(ExtendedReceiptNum receipt, const Message& message,
                                 CompletionFn completionCallback);
 
     struct RemovedMessage
@@ -54,7 +54,7 @@ private:
     class ReceiptResolver
     {
     public:
-        void notifyMessageSent(ReceiptT receipt, OfflineMessage const& message)
+        void notifyMessageSent(ReceiptT receipt, const OfflineMessage& message)
         {
             auto receivedReceiptIt =
                 std::find(receivedReceipts.begin(), receivedReceipts.end(), receipt);

--- a/src/persistence/personalsettingsupgrader.cpp
+++ b/src/persistence/personalsettingsupgrader.cpp
@@ -51,7 +51,7 @@ bool PersonalSettingsUpgrader::doUpgrade(SettingsSerializer& settingsSerializer,
     assert(toVer == static_cast<int>(upgradeFns.size()));
 
     for (int i = fromVer; i < static_cast<int>(upgradeFns.size()); ++i) {
-        auto const newSettingsVersion = i + 1;
+        const auto newSettingsVersion = i + 1;
         if (!upgradeFns[i](settingsSerializer)) {
             qCritical() << "Failed to upgrade settings to version " << newSettingsVersion
                         << " aborting";

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -888,7 +888,7 @@ void Settings::setMakeToxPortable(bool newValue)
     bool changed = false;
     {
         QMutexLocker<QRecursiveMutex> locker{&bigLock};
-        auto const oldSettingsPath = paths.getSettingsDirPath() + globalSettingsFile;
+        const auto oldSettingsPath = paths.getSettingsDirPath() + globalSettingsFile;
         changed = paths.setPortable(newValue);
         if (changed) {
             QFile(oldSettingsPath).remove();

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -452,7 +452,7 @@ public:
 
     QStringList getBlackList() const override;
     void setBlackList(const QStringList& blist) override;
-    SIGNAL_IMPL(Settings, blackListChanged, QStringList const& blist)
+    SIGNAL_IMPL(Settings, blackListChanged, const QStringList& blist)
 
     bool getShowConferenceJoinLeaveMessages() const override;
     void setShowConferenceJoinLeaveMessages(bool newValue) override;

--- a/src/widget/form/conferenceform.cpp
+++ b/src/widget/form/conferenceform.cpp
@@ -125,7 +125,7 @@ ConferenceForm::ConferenceForm(Core& core_, Conference* chatConference, IChatLog
     connect(conference, &Conference::userLeft, this, &ConferenceForm::onUserLeft);
     connect(conference, &Conference::peerNameChanged, this, &ConferenceForm::onPeerNameChanged);
     connect(conference, &Conference::numPeersChanged, this, &ConferenceForm::updateUserCount);
-    settings.connectTo_blackListChanged(this, [this](QStringList const&) { updateUserNames(); });
+    settings.connectTo_blackListChanged(this, [this](const QStringList&) { updateUserNames(); });
 
     if (settings.getShowConferenceJoinLeaveMessages()) {
         addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::selfJoinedConference, {});

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1257,11 +1257,11 @@ void Widget::onCoreFriendStatusChanged(int friendId, Status::Status status)
         return;
     }
 
-    auto const oldStatus = f->getStatus();
+    const auto oldStatus = f->getStatus();
     f->setStatus(status);
-    auto const newStatus = f->getStatus();
+    const auto newStatus = f->getStatus();
 
-    auto const startedNegotiating =
+    const auto startedNegotiating =
         (newStatus == Status::Status::Negotiating && oldStatus != newStatus);
     if (startedNegotiating) {
         constexpr auto negotiationTimeoutMs = 1000;

--- a/test/dbutility/src/dbutility.cpp
+++ b/test/dbutility/src/dbutility.cpp
@@ -186,7 +186,7 @@ void DbUtility::createSchemaAtVersion(std::shared_ptr<RawDatabase> db,
                                       const std::vector<DbUtility::SqliteMasterEntry>& schema)
 {
     QVector<RawDatabase::Query> queries;
-    for (auto const& entry : schema) {
+    for (const auto& entry : schema) {
         queries += entry.sql;
     }
     QVERIFY(db->execNow(queries));

--- a/test/model/conferencemessagedispatcher_test.cpp
+++ b/test/model/conferencemessagedispatcher_test.cpp
@@ -12,8 +12,8 @@
 #include "src/persistence/settings.h"
 #include "util/interface.h"
 
-#include "mock/mockcoreidhandler.h"
 #include "mock/mockconferencequery.h"
+#include "mock/mockcoreidhandler.h"
 
 #include <QObject>
 #include <QtTest/QtTest>
@@ -55,7 +55,7 @@ class MockConferenceSettings : public QObject, public IConferenceSettings
 public:
     QStringList getBlackList() const override;
     void setBlackList(const QStringList& blist) override;
-    SIGNAL_IMPL(MockConferenceSettings, blackListChanged, QStringList const& blist)
+    SIGNAL_IMPL(MockConferenceSettings, blackListChanged, const QStringList& blist)
 
     bool getShowConferenceJoinLeaveMessages() const override
     {
@@ -144,15 +144,15 @@ void TestConferenceMessageDispatcher::init()
     conferenceSettings = std::unique_ptr<MockConferenceSettings>(new MockConferenceSettings());
     conferenceQuery = std::unique_ptr<MockConferenceQuery>(new MockConferenceQuery());
     coreIdHandler = std::unique_ptr<MockCoreIdHandler>(new MockCoreIdHandler());
-    g = std::unique_ptr<Conference>(new Conference(0, ConferenceId(), "TestConference", false, "me", *conferenceQuery,
-                                         *coreIdHandler, *friendList));
+    g = std::unique_ptr<Conference>(new Conference(0, ConferenceId(), "TestConference", false, "me",
+                                                   *conferenceQuery, *coreIdHandler, *friendList));
     messageSender = std::unique_ptr<MockConferenceMessageSender>(new MockConferenceMessageSender());
     sharedProcessorParams = std::unique_ptr<MessageProcessor::SharedParams>(
         new MessageProcessor::SharedParams(tox_max_message_length(), 10 * 1024 * 1024));
     messageProcessor = std::unique_ptr<MessageProcessor>(new MessageProcessor(*sharedProcessorParams));
     conferenceMessageDispatcher = std::unique_ptr<ConferenceMessageDispatcher>(
         new ConferenceMessageDispatcher(*g, *messageProcessor, *coreIdHandler, *messageSender,
-                                   *conferenceSettings));
+                                        *conferenceSettings));
 
     connect(conferenceMessageDispatcher.get(), &ConferenceMessageDispatcher::messageSent, this,
             &TestConferenceMessageDispatcher::onMessageSent);
@@ -205,8 +205,8 @@ void TestConferenceMessageDispatcher::testMessageSending()
 }
 
 /**
- * @brief Tests that if we are the only member in a conference we do _not_ send messages to core. Toxcore
- * isn't too happy if we send messages and we're the only one in the conference
+ * @brief Tests that if we are the only member in a conference we do _not_ send messages to core.
+ * Toxcore isn't too happy if we send messages and we're the only one in the conference
  */
 void TestConferenceMessageDispatcher::testEmptyConference()
 {

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -564,10 +564,16 @@ void TestFriendListManager::testSetConferencesOnTop()
     FriendItemsBuilder listBuilder;
     auto manager = createManagerWithItems(
         listBuilder.addOfflineFriends()->addOnlineFriends()->addConferences()->buildUnsorted());
-    auto sortedVecOnlineOnTop =
-        listBuilder.addOfflineFriends()->addOnlineFriends()->addConferences()->setConferencesOnTop(false)->buildSortedByName();
-    auto sortedVecConferencesOnTop =
-        listBuilder.addOfflineFriends()->addOnlineFriends()->addConferences()->setConferencesOnTop(true)->buildSortedByName();
+    auto sortedVecOnlineOnTop = listBuilder.addOfflineFriends()
+                                    ->addOnlineFriends()
+                                    ->addConferences()
+                                    ->setConferencesOnTop(false)
+                                    ->buildSortedByName();
+    auto sortedVecConferencesOnTop = listBuilder.addOfflineFriends()
+                                         ->addOnlineFriends()
+                                         ->addConferences()
+                                         ->setConferencesOnTop(true)
+                                         ->buildSortedByName();
 
     manager->setConferencesOnTop(false);
     manager->sortByName();

--- a/test/model/notificationgenerator_test.cpp
+++ b/test/model/notificationgenerator_test.cpp
@@ -6,8 +6,8 @@
 #include "src/friendlist.h"
 #include "src/model/notificationgenerator.h"
 
-#include "mock/mockcoreidhandler.h"
 #include "mock/mockconferencequery.h"
+#include "mock/mockcoreidhandler.h"
 
 #include <QObject>
 #include <QtTest/QtTest>
@@ -169,7 +169,8 @@ void TestNotificationGenerator::testNotificationClear()
 
 void TestNotificationGenerator::testConferenceMessage()
 {
-    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery, *coreIdHandler, *friendList);
+    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery,
+                 *coreIdHandler, *friendList);
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
     g.updateUsername(sender, "sender1");
 
@@ -180,7 +181,8 @@ void TestNotificationGenerator::testConferenceMessage()
 
 void TestNotificationGenerator::testMultipleConferenceMessages()
 {
-    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery, *coreIdHandler, *friendList);
+    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery,
+                 *coreIdHandler, *friendList);
 
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
     g.updateUsername(sender, "sender1");
@@ -212,10 +214,10 @@ void TestNotificationGenerator::testMultipleFriendSourceMessages()
 
 void TestNotificationGenerator::testMultipleConferenceSourceMessages()
 {
-    Conference g(0, ConferenceId(QByteArray(32, 0)), "conferenceName", false, "selfName", *conferenceQuery,
-            *coreIdHandler, *friendList);
-    Conference g2(1, ConferenceId(QByteArray(32, 1)), "conferenceName2", false, "selfName", *conferenceQuery,
-             *coreIdHandler, *friendList);
+    Conference g(0, ConferenceId(QByteArray(32, 0)), "conferenceName", false, "selfName",
+                 *conferenceQuery, *coreIdHandler, *friendList);
+    Conference g2(1, ConferenceId(QByteArray(32, 1)), "conferenceName2", false, "selfName",
+                  *conferenceQuery, *coreIdHandler, *friendList);
 
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
     g.updateUsername(sender, "sender1");
@@ -232,8 +234,8 @@ void TestNotificationGenerator::testMixedSourceMessages()
     Friend f(0, ToxPk());
     f.setName("friend");
 
-    Conference g(0, ConferenceId(QByteArray(32, 0)), "conference", false, "selfName", *conferenceQuery, *coreIdHandler,
-            *friendList);
+    Conference g(0, ConferenceId(QByteArray(32, 0)), "conference", false, "selfName",
+                 *conferenceQuery, *coreIdHandler, *friendList);
 
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
     g.updateUsername(sender, "sender1");
@@ -350,7 +352,8 @@ void TestNotificationGenerator::testSimpleFileTransfer()
 
 void TestNotificationGenerator::testSimpleConferenceMessage()
 {
-    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery, *coreIdHandler, *friendList);
+    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery,
+                 *coreIdHandler, *friendList);
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
     g.updateUsername(sender, "sender1");
 

--- a/test/model/sessionchatlog_test.cpp
+++ b/test/model/sessionchatlog_test.cpp
@@ -69,7 +69,8 @@ void TestSessionChatLog::init()
 {
     friendList = std::unique_ptr<FriendList>(new FriendList());
     conferenceList = std::unique_ptr<ConferenceList>(new ConferenceList());
-    chatLog = std::unique_ptr<SessionChatLog>(new SessionChatLog(idHandler, *friendList, *conferenceList));
+    chatLog =
+        std::unique_ptr<SessionChatLog>(new SessionChatLog(idHandler, *friendList, *conferenceList));
 }
 
 /**

--- a/test/persistence/offlinemsgengine_test.cpp
+++ b/test/persistence/offlinemsgengine_test.cpp
@@ -36,11 +36,11 @@ void TestOfflineMsgEngine::testReceiptBeforeMessage()
 
     Message msg{false, QString(), QDateTime(), {}, {}};
 
-    auto const receipt = ReceiptNum(0);
+    const auto receipt = ReceiptNum(0);
     offlineMsgEngine.onReceiptReceived(receipt);
     offlineMsgEngine.addSentCoreMessage(receipt, Message(), completionFn);
 
-    auto const removedMessages = offlineMsgEngine.removeAllMessages();
+    const auto removedMessages = offlineMsgEngine.removeAllMessages();
 
     QVERIFY(removedMessages.empty());
 }
@@ -49,11 +49,11 @@ void TestOfflineMsgEngine::testReceiptAfterMessage()
 {
     OfflineMsgEngine offlineMsgEngine;
 
-    auto const receipt = ReceiptNum(0);
+    const auto receipt = ReceiptNum(0);
     offlineMsgEngine.addSentCoreMessage(receipt, Message(), completionFn);
     offlineMsgEngine.onReceiptReceived(receipt);
 
-    auto const removedMessages = offlineMsgEngine.removeAllMessages();
+    const auto removedMessages = offlineMsgEngine.removeAllMessages();
 
     QVERIFY(removedMessages.empty());
 }
@@ -62,7 +62,7 @@ void TestOfflineMsgEngine::testResendWorkflow()
 {
     OfflineMsgEngine offlineMsgEngine;
 
-    auto const receipt = ReceiptNum(0);
+    const auto receipt = ReceiptNum(0);
     offlineMsgEngine.addSentCoreMessage(receipt, Message(), completionFn);
     auto messagesToResend = offlineMsgEngine.removeAllMessages();
 
@@ -74,7 +74,7 @@ void TestOfflineMsgEngine::testResendWorkflow()
     messagesToResend = offlineMsgEngine.removeAllMessages();
     QVERIFY(messagesToResend.size() == 0);
 
-    auto const nullMsg = Message();
+    const auto nullMsg = Message();
     auto msg2 = Message();
     auto msg3 = Message();
     msg2.content = "msg2";

--- a/util/include/util/strongtype.h
+++ b/util/include/util/strongtype.h
@@ -10,32 +10,32 @@
 template <typename T>
 struct Addable
 {
-    T operator+(T const& other) const
+    T operator+(const T& other) const
     {
-        return static_cast<T const&>(*this).get() + other.get();
+        return static_cast<const T&>(*this).get() + other.get();
     };
 };
 
 template <typename T, typename Underlying>
 struct UnderlyingAddable
 {
-    T operator+(Underlying const& other) const
+    T operator+(const Underlying& other) const
     {
-        return T(static_cast<T const&>(*this).get() + other);
+        return T(static_cast<const T&>(*this).get() + other);
     };
 };
 
 template <typename T, typename Underlying>
 struct UnitlessDifferencable
 {
-    T operator-(Underlying const& other) const
+    T operator-(const Underlying& other) const
     {
-        return T(static_cast<T const&>(*this).get() - other);
+        return T(static_cast<const T&>(*this).get() - other);
     };
 
-    Underlying operator-(T const& other) const
+    Underlying operator-(const T& other) const
     {
-        return static_cast<T const&>(*this).get() - other.get();
+        return static_cast<const T&>(*this).get() - other.get();
     }
 };
 
@@ -51,7 +51,7 @@ struct Incrementable
 
     T operator++(int)
     {
-        auto ret = T(static_cast<T const&>(*this));
+        auto ret = T(static_cast<const T&>(*this));
         ++(*this);
         return ret;
     }
@@ -63,11 +63,11 @@ struct EqualityComparible
 {
     bool operator==(const T& other) const
     {
-        return static_cast<T const&>(*this).get() == other.get();
+        return static_cast<const T&>(*this).get() == other.get();
     };
     bool operator!=(const T& other) const
     {
-        return static_cast<T const&>(*this).get() != other.get();
+        return static_cast<const T&>(*this).get() != other.get();
     };
 };
 
@@ -76,7 +76,7 @@ struct Hashable
 {
     friend uint qHash(const Hashable<T, Underlying>& key, uint seed = 0)
     {
-        return qHash(static_cast<T const&>(*key).get(), seed);
+        return qHash(static_cast<const T&>(*key).get(), seed);
     }
 };
 
@@ -85,19 +85,19 @@ struct Orderable : EqualityComparible<T, Underlying>
 {
     bool operator<(const T& rhs) const
     {
-        return static_cast<T const&>(*this).get() < rhs.get();
+        return static_cast<const T&>(*this).get() < rhs.get();
     }
     bool operator>(const T& rhs) const
     {
-        return static_cast<T const&>(*this).get() > rhs.get();
+        return static_cast<const T&>(*this).get() > rhs.get();
     }
     bool operator>=(const T& rhs) const
     {
-        return static_cast<T const&>(*this).get() >= rhs.get();
+        return static_cast<const T&>(*this).get() >= rhs.get();
     }
     bool operator<=(const T& rhs) const
     {
-        return static_cast<T const&>(*this).get() <= rhs.get();
+        return static_cast<const T&>(*this).get() <= rhs.get();
     }
 };
 
@@ -119,7 +119,7 @@ public:
     using UnderlyingType = T;
 
     NamedType() {}
-    explicit NamedType(T const& value)
+    explicit NamedType(const T& value)
         : value_(value)
     {
     }
@@ -127,7 +127,7 @@ public:
     {
         return value_;
     }
-    T const& get() const
+    const T& get() const
     {
         return value_;
     }


### PR DESCRIPTION
2300+ places use `const T`, only about 130 use `T const`. I prefer the latter, but the former is less disruptive to the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/73)
<!-- Reviewable:end -->
