### PR TITLE
cleanup: Add `const` to local variables where possible.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: "-*
 , google-explicit-constructor
+, misc-const-correctness
 , modernize-avoid-bind
 , modernize-deprecated-headers
 , modernize-loop-convert

--- a/audio/src/backend/alsink.cpp
+++ b/audio/src/backend/alsink.cpp
@@ -16,7 +16,7 @@
 
 AlSink::~AlSink()
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
 
     // unsubscribe only if not already killed
     if (!killed) {
@@ -27,7 +27,7 @@ AlSink::~AlSink()
 
 void AlSink::playAudioBuffer(const int16_t* data, int samples, unsigned channels, int sampleRate) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to play audio on an invalid sink";
@@ -38,7 +38,7 @@ void AlSink::playAudioBuffer(const int16_t* data, int samples, unsigned channels
 
 void AlSink::playMono16Sound(const IAudioSink::Sound& sound)
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to play sound on an invalid sink";
@@ -49,7 +49,7 @@ void AlSink::playMono16Sound(const IAudioSink::Sound& sound)
 
 void AlSink::startLoop()
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to start loop on an invalid sink";
@@ -60,7 +60,7 @@ void AlSink::startLoop()
 
 void AlSink::stopLoop()
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to stop loop on an invalid sink";
@@ -71,7 +71,7 @@ void AlSink::stopLoop()
 
 uint AlSink::getSourceId() const
 {
-    uint tmp = sourceId;
+    const uint tmp = sourceId;
     return tmp;
 }
 
@@ -92,7 +92,7 @@ AlSink::AlSink(OpenAL& al, uint sourceId_)
 
 AlSink::operator bool() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
 
     return !killed;
 }

--- a/audio/src/backend/alsource.cpp
+++ b/audio/src/backend/alsource.cpp
@@ -21,7 +21,7 @@ AlSource::AlSource(OpenAL& al)
 
 AlSource::~AlSource()
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
 
     // unsubscribe only if not already killed
     if (!killed) {
@@ -32,7 +32,7 @@ AlSource::~AlSource()
 
 AlSource::operator bool() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&killLock};
+    const QMutexLocker<QRecursiveMutex> locker{&killLock};
     return !killed;
 }
 

--- a/audio/src/backend/openal.cpp
+++ b/audio/src/backend/openal.cpp
@@ -160,7 +160,7 @@ void OpenAL::checkAlcError(ALCdevice* device) noexcept
  */
 void OpenAL::setOutputVolume(qreal volume)
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     alListenerf(AL_GAIN, static_cast<ALfloat>(std::max(0.0, std::min(volume, 1.0))));
     checkAlError();
@@ -173,7 +173,7 @@ void OpenAL::setOutputVolume(qreal volume)
  */
 qreal OpenAL::minInputGain() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
     return minInGain;
 }
 
@@ -184,7 +184,7 @@ qreal OpenAL::minInputGain() const
  */
 qreal OpenAL::maxInputGain() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
     return maxInGain;
 }
 
@@ -195,7 +195,7 @@ qreal OpenAL::maxInputGain() const
  */
 qreal OpenAL::minInputThreshold() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
     return minInThreshold;
 }
 
@@ -206,7 +206,7 @@ qreal OpenAL::minInputThreshold() const
  */
 qreal OpenAL::maxInputThreshold() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
     return maxInThreshold;
 }
 
@@ -255,7 +255,7 @@ bool OpenAL::reinitOutput(const QString& outDevDesc)
  */
 std::unique_ptr<IAudioSink> OpenAL::makeSink()
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     if (!autoInitOutput()) {
         qWarning("Failed to subscribe to audio output device.");
@@ -283,7 +283,7 @@ std::unique_ptr<IAudioSink> OpenAL::makeSink()
  */
 void OpenAL::destroySink(AlSink& sink)
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     const auto sinksErased = sinks.erase(&sink);
     const auto soundSinksErased = soundSinks.erase(&sink);
@@ -316,7 +316,7 @@ void OpenAL::destroySink(AlSink& sink)
  */
 std::unique_ptr<IAudioSource> OpenAL::makeSource()
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     if (!autoInitInput()) {
         qWarning("Failed to subscribe to audio input device.");
@@ -339,7 +339,7 @@ std::unique_ptr<IAudioSource> OpenAL::makeSource()
  */
 void OpenAL::destroySource(AlSource& source)
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     const auto s = sources.find(&source);
     if (s == sources.end()) {
@@ -393,7 +393,7 @@ bool OpenAL::initInput(const QString& deviceName, uint32_t channels)
 
     // TODO: Try to actually detect if our audio source is stereo
     inputChannels = channels;
-    int stereoFlag = inputChannels == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
+    const int stereoFlag = inputChannels == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
     const int bytesPerSample = 2;
     const int safetyFactor = 2; // internal OpenAL ring buffer. must be larger than our inputBuffer
                                 // to avoid the ring from overwriting itself between captures.
@@ -480,7 +480,7 @@ void OpenAL::playMono16Sound(AlSink& sink, const IAudioSink::Sound& sound)
         return;
     }
 
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     // interrupt possibly playing sound, we don't buffer here
     alSourceStop(sourceId);
@@ -508,12 +508,12 @@ void OpenAL::playMono16Sound(AlSink& sink, const IAudioSink::Sound& sound)
 
 void OpenAL::cleanupSound()
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     auto sinkIt = soundSinks.begin();
     while (sinkIt != soundSinks.end()) {
         auto sink = *sinkIt;
-        ALuint sourceId = sink->getSourceId();
+        const ALuint sourceId = sink->getSourceId();
         ALint state = 0;
 
         alGetSourcei(sourceId, AL_SOURCE_STATE, &state);
@@ -530,7 +530,7 @@ void OpenAL::playAudioBuffer(uint sourceId, const int16_t* data, int samples, un
                              int sampleRate)
 {
     assert(channels == 1 || channels == 2);
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
 
     if (!(alOutDev && outputInitialized))
         return;
@@ -688,7 +688,7 @@ void OpenAL::doOutput()
  */
 void OpenAL::doAudio()
 {
-    QMutexLocker<QRecursiveMutex> lock(&audioLock);
+    const QMutexLocker<QRecursiveMutex> lock(&audioLock);
 
     // Output section does nothing
 
@@ -708,7 +708,7 @@ void OpenAL::captureSamples(ALCdevice* device, int16_t* buffer, ALCsizei samples
  */
 bool OpenAL::isOutputReady() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
     return alOutDev && outputInitialized;
 }
 
@@ -767,13 +767,13 @@ void OpenAL::cleanupBuffers(uint sourceId)
 
 void OpenAL::startLoop(uint sourceId)
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
     alSourcei(sourceId, AL_LOOPING, AL_TRUE);
 }
 
 void OpenAL::stopLoop(uint sourceId)
 {
-    QMutexLocker<QRecursiveMutex> locker(&audioLock);
+    const QMutexLocker<QRecursiveMutex> locker(&audioLock);
     alSourcei(sourceId, AL_LOOPING, AL_FALSE);
     alSourceStop(sourceId);
     cleanupBuffers(sourceId);

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -112,7 +112,7 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
     }
 
     // Time should be in UTC to save user privacy on log sharing
-    QTime time = QDateTime::currentDateTime().toUTC().time();
+    const QTime time = QDateTime::currentDateTime().toUTC().time();
     QString logPrefix =
         QStringLiteral("[%1 UTC] (%2) %3:%4 : ")
             .arg(time.toString("HH:mm:ss.zzz"), category, file, QString::number(ctxt.line));
@@ -156,8 +156,9 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
         logBufferMutex->lock();
         if (logBuffer) {
             // empty logBuffer to file
-            foreach (QByteArray bufferedMsg, *logBuffer)
+            for (const QByteArray& bufferedMsg : *logBuffer) {
                 fwrite(bufferedMsg.constData(), 1, bufferedMsg.size(), logFilePtr);
+            }
 
             delete logBuffer; // no longer needed
             logBuffer = nullptr;
@@ -209,10 +210,10 @@ int AppManager::startGui(QCommandLineParser& parser)
     }
 
 #ifdef LOG_TO_FILE
-    QString logFileDir = settings->getPaths().getAppCacheDirPath();
+    const QString logFileDir = settings->getPaths().getAppCacheDirPath();
     QDir(logFileDir).mkpath(".");
 
-    QString logfile = logFileDir + "qtox.log";
+    const QString logfile = logFileDir + "qtox.log";
     FILE* mainLogFilePtr = fopen(logfile.toLocal8Bit().constData(), "a");
 
     // Trim log file if over 1MB
@@ -295,7 +296,7 @@ int AppManager::startGui(QCommandLineParser& parser)
     }
 
     if (doIpc && !ipc->isCurrentOwner()) {
-        time_t event = ipc->postEvent(eventType, firstParam.toUtf8(), ipcDest);
+        const time_t event = ipc->postEvent(eventType, firstParam.toUtf8(), ipcDest);
         // If someone else processed it, we're done here, no need to actually start qTox
         if (ipc->waitUntilAccepted(event, 2)) {
             if (eventType == "activate") {
@@ -335,7 +336,7 @@ int AppManager::startGui(QCommandLineParser& parser)
         nexus->bootstrapWithProfile(profile);
     } else {
         nexus->setParser(&parser);
-        int returnval = nexus->showLogin(profileName);
+        const int returnval = nexus->showLogin(profileName);
         if (returnval == QDialog::Rejected) {
             return -1;
         }
@@ -394,7 +395,7 @@ int AppManager::run()
         qWarning() << "Couldn't load font";
     }
 
-    QString locale = settings->getTranslation();
+    const QString locale = settings->getTranslation();
     // We need to init the resources in the translations_library explicitly.
     // See https://doc.qt.io/qt-5/resources.html#using-resources-in-a-library
     Q_INIT_RESOURCE(translations);

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -166,7 +166,7 @@ void ChatLine::layout(qreal w, QPointF scenePos)
     if (varWidth == 0.0)
         varWidth = 1.0;
 
-    qreal leftover = qMax(0.0, width - fixedWidth);
+    const qreal leftover = qMax(0.0, width - fixedWidth);
 
     qreal maxVOffset = 0.0;
     qreal xOffset = 0.0;
@@ -207,7 +207,7 @@ void ChatLine::layout(qreal w, QPointF scenePos)
     for (int i = 0; i < content.size(); ++i) {
         // calculate vertical alignment
         // vertical alignment may depend on width, so we do it in a second pass
-        qreal yOffset = maxVOffset - content[i]->getAscent();
+        const qreal yOffset = maxVOffset - content[i]->getAscent();
 
         // reposition
         content[i]->setPos(xPos[i], scenePos.y() + yOffset);

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -58,7 +58,7 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QSt
     text = TextFormatter::highlightURI(text);
 
     // text styling
-    Settings::StyleType styleType = settings.getStylePreference();
+    const Settings::StyleType styleType = settings.getStylePreference();
     if (styleType != Settings::StyleType::NONE) {
         text = TextFormatter::applyMarkdown(text, styleType == Settings::StyleType::WITH_CHARS);
     }
@@ -80,14 +80,14 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QSt
     }
 
     // Note: Eliding cannot be enabled for RichText items. (QTBUG-17207)
-    QFont baseFont = settings.getChatMessageFont();
+    const QFont baseFont = settings.getChatMessageFont();
     QFont authorFont = baseFont;
     if (isMe)
         authorFont.setBold(true);
 
     QColor color = style.getColor(Style::ColorPalette::MainText);
     if (colorizeName) {
-        QByteArray hash = QCryptographicHash::hash((sender.toUtf8()), QCryptographicHash::Sha256);
+        const QByteArray hash = QCryptographicHash::hash(sender.toUtf8(), QCryptographicHash::Sha256);
         auto lightness = color.lightnessF();
         // Adapt as good as possible to Light/Dark themes
         lightness = lightness * 0.5f + 0.3f;
@@ -134,7 +134,7 @@ ChatMessage::Ptr ChatMessage::createChatInfoMessage(const QString& rawMessage,
                                                     Settings& settings, Style& style)
 {
     ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
-    QString text = rawMessage.toHtmlEscaped();
+    const QString text = rawMessage.toHtmlEscaped();
 
     QString img;
     switch (type) {
@@ -149,7 +149,7 @@ ChatMessage::Ptr ChatMessage::createChatInfoMessage(const QString& rawMessage,
         break;
     }
 
-    QFont baseFont = settings.getChatMessageFont();
+    const QFont baseFont = settings.getChatMessageFont();
 
     msg->addColumn(new Image(QSize(18, 18), img),
                    ColumnFormat(NAME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
@@ -170,7 +170,7 @@ ChatMessage::Ptr ChatMessage::createFileTransferMessage(const QString& sender, C
 {
     ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
 
-    QFont baseFont = settings.getChatMessageFont();
+    const QFont baseFont = settings.getChatMessageFont();
     QFont authorFont = baseFont;
     if (isMe) {
         authorFont.setBold(true);
@@ -194,7 +194,7 @@ ChatMessage::Ptr ChatMessage::createTypingNotification(DocumentCache& documentCa
 {
     ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
 
-    QFont baseFont = settings.getChatMessageFont();
+    const QFont baseFont = settings.getChatMessageFont();
 
     // Note: "[user]..." is just a placeholder. The actual text is set in
     // ChatForm::setFriendTyping()
@@ -238,7 +238,7 @@ ChatMessage::Ptr ChatMessage::createBusyNotification(DocumentCache& documentCach
 
 void ChatMessage::markAsDelivered(const QDateTime& time)
 {
-    QFont baseFont = settings.getChatMessageFont();
+    const QFont baseFont = settings.getChatMessageFont();
 
     // remove the spinner and replace it by $time
     replaceContent(2, new Timestamp(time, settings.getTimestampFormat(), baseFont, documentCache,

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -292,7 +292,7 @@ ChatWidget::~ChatWidget()
     Translator::unregister(this);
 
     // Remove chatlines from scene
-    for (ChatLine::Ptr l : *chatLineStorage)
+    for (const ChatLine::Ptr& l : *chatLineStorage)
         l->removeFromScene();
 
     if (busyNotification)
@@ -389,7 +389,7 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
 {
     QGraphicsView::mouseMoveEvent(ev);
 
-    QPointF scenePos = mapToScene(ev->pos());
+    const QPointF scenePos = mapToScene(ev->pos());
 
     if (ev->buttons() & Qt::LeftButton) {
         // autoscroll
@@ -403,8 +403,8 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
         // select
         if (selectionMode == SelectionMode::None
             && (clickPos - ev->pos()).manhattanLength() > QApplication::startDragDistance()) {
-            QPointF sceneClickPos = mapToScene(clickPos.toPoint());
-            ChatLine::Ptr line = findLineByPosY(scenePos.y());
+            const QPointF sceneClickPos = mapToScene(clickPos.toPoint());
+            const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
             ChatLineContent* content = getContentFromPos(sceneClickPos);
             if (content) {
@@ -431,10 +431,10 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
 
         if (selectionMode != SelectionMode::None) {
             ChatLineContent* content = getContentFromPos(scenePos);
-            ChatLine::Ptr line = findLineByPosY(scenePos.y());
+            const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
             if (content) {
-                int col = content->getColumn();
+                const int col = content->getColumn();
 
                 if (line == selClickedRow && col == selClickedCol) {
                     selectionMode = SelectionMode::Precise;
@@ -511,11 +511,11 @@ void ChatWidget::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
     if (chatLines.empty())
         return;
 
-    bool allLinesAtEnd = !chatLineStorage->hasIndexedMessage()
-                         || chatLines.begin()->first > chatLineStorage->lastIdx();
+    const bool allLinesAtEnd = !chatLineStorage->hasIndexedMessage()
+                               || chatLines.begin()->first > chatLineStorage->lastIdx();
     auto startLineSize = chatLineStorage->size();
 
-    QGraphicsScene::ItemIndexMethod oldIndexMeth = scene->itemIndexMethod();
+    const QGraphicsScene::ItemIndexMethod oldIndexMeth = scene->itemIndexMethod();
     scene->setItemIndexMethod(QGraphicsScene::NoIndex);
 
     for (const auto& chatLine : chatLines) {
@@ -553,7 +553,7 @@ void ChatWidget::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
     // have to rely on the onRenderFinished callback to continue doing any work,
     // even if all rendering is done synchronously
     if (allLinesAtEnd) {
-        bool stickToBtm = stickToBottom();
+        const bool stickToBtm = stickToBottom();
 
         // partial refresh
         layout(startLineSize, chatLineStorage->size(), useableWidth());
@@ -600,7 +600,7 @@ void ChatWidget::startResizeWorker()
     // switch to busy scene displaying the busy notification if there is a lot
     // of text to be resized
     int txt = 0;
-    for (ChatLine::Ptr line : *chatLineStorage) {
+    for (const ChatLine::Ptr& line : *chatLineStorage) {
         if (txt > 500000)
             break;
         for (ChatLineContent* content : line->content)
@@ -617,9 +617,9 @@ void ChatWidget::startResizeWorker()
 
 void ChatWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 {
-    QPointF scenePos = mapToScene(ev->pos());
+    const QPointF scenePos = mapToScene(ev->pos());
     ChatLineContent* content = getContentFromPos(scenePos);
-    ChatLine::Ptr line = findLineByPosY(scenePos.y());
+    const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
     if (content) {
         content->selectionDoubleClick(scenePos);
@@ -658,10 +658,10 @@ QString ChatWidget::getSelectedText() const
             if (line->content[1]->getText().isEmpty())
                 return;
 
-            QString timestamp =
+            const QString timestamp =
                 line->content[2]->getText().isEmpty() ? tr("pending") : line->content[2]->getText();
-            QString author = line->content[0]->getText();
-            QString msg = line->content[1]->getText();
+            const QString author = line->content[0]->getText();
+            const QString msg = line->content[1]->getText();
 
             out += QString(out.isEmpty() ? QStringLiteral("[%2] %1: %3")
                                          : QStringLiteral("\n[%2] %1: %3"))
@@ -698,7 +698,7 @@ void ChatWidget::clear()
 {
     clearSelection();
 
-    QVector<ChatLine::Ptr> savedLines;
+    const QVector<ChatLine::Ptr> savedLines;
 
     for (auto it = chatLineStorage->begin(); it != chatLineStorage->end();) {
         if (!isActiveFileTransfer(*it)) {
@@ -717,7 +717,7 @@ void ChatWidget::clear()
 
 void ChatWidget::copySelectedText(bool toSelectionBuffer) const
 {
-    QString text = getSelectedText();
+    const QString text = getSelectedText();
     QClipboard* clipboard = QApplication::clipboard();
 
     if (clipboard && !text.isNull())
@@ -739,7 +739,7 @@ void ChatWidget::setTypingNotificationName(const QString& displayName)
     }
 
     Text* text = static_cast<Text*>(typingNotification->getContent(1));
-    QString typingDiv = "<div class=typing>%1</div>";
+    const QString typingDiv = "<div class=typing>%1</div>";
     text->setText(typingDiv.arg(tr("%1 is typing").arg(displayName)));
 
     updateTypingNotification();
@@ -771,7 +771,7 @@ void ChatWidget::selectAll()
 
 void ChatWidget::fontChanged(const QFont& font)
 {
-    for (ChatLine::Ptr l : *chatLineStorage) {
+    for (const ChatLine::Ptr& l : *chatLineStorage) {
         l->fontChanged(font);
     }
 }
@@ -785,7 +785,7 @@ void ChatWidget::reloadTheme()
     selGraphItem->setPen(QPen(selectionRectColor.darker(120)));
     setTypingNotification();
 
-    for (ChatLine::Ptr l : *chatLineStorage) {
+    for (const ChatLine::Ptr& l : *chatLineStorage) {
         l->reloadTheme();
     }
 }
@@ -908,7 +908,7 @@ void ChatWidget::checkVisibility()
     }
 
     // these lines are no longer visible
-    for (ChatLine::Ptr line : visibleLines)
+    for (const ChatLine::Ptr& line : visibleLines)
         line->visibilityChanged(false);
 
     visibleLines = newVisibleLines;
@@ -1107,8 +1107,8 @@ void ChatWidget::renderMessages(ChatLogIdx begin, ChatLogIdx end)
     auto linesToRender = std::map<ChatLogIdx, ChatLine::Ptr>();
 
     for (auto i = begin; i < end; ++i) {
-        bool alreadyRendered = chatLineStorage->contains(i);
-        bool prevIdxRendered = i != begin || chatLineStorage->contains(i - 1);
+        const bool alreadyRendered = chatLineStorage->contains(i);
+        const bool prevIdxRendered = i != begin || chatLineStorage->contains(i - 1);
 
         auto chatMessage = alreadyRendered ? (*chatLineStorage)[i] : ChatLine::Ptr();
         renderItem(chatLog.at(i), needsToHideName(i, prevIdxRendered), colorizeNames, chatMessage);
@@ -1263,9 +1263,9 @@ void ChatWidget::handleMultiClickEvent()
 
     switch (clickCount) {
     case 3:
-        QPointF scenePos = mapToScene(lastClickPos);
+        const QPointF scenePos = mapToScene(lastClickPos);
         ChatLineContent* content = getContentFromPos(scenePos);
-        ChatLine::Ptr line = findLineByPosY(scenePos.y());
+        const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
         if (content) {
             content->selectionTripleClick(scenePos);
@@ -1359,7 +1359,7 @@ void ChatWidget::retranslateUi()
 
 bool ChatWidget::isActiveFileTransfer(ChatLine::Ptr l)
 {
-    int count = l->getColumnCount();
+    const int count = l->getColumnCount();
     for (int i = 0; i < count; ++i) {
         ChatLineContent* content = l->getContent(i);
         ChatLineContentProxy* proxy = qobject_cast<ChatLineContentProxy*>(content);
@@ -1390,7 +1390,7 @@ void ChatWidget::renderItem(const ChatLogItem& item, bool hideName, bool coloriz
 {
     const auto& sender = item.getSender();
 
-    bool isSelf = sender == core.getSelfPublicKey();
+    const bool isSelf = sender == core.getSelfPublicKey();
 
     switch (item.getContentType()) {
     case ChatLogItem::ContentType::message: {
@@ -1467,7 +1467,7 @@ bool ChatWidget::needsToHideName(ChatLogIdx idx, bool prevIdxRendered) const
         return false;
     }
 
-    qint64 messagesTimeDiff = prevItem.getTimestamp().secsTo(currentItem.getTimestamp());
+    const qint64 messagesTimeDiff = prevItem.getTimestamp().secsTo(currentItem.getTimestamp());
     return currentItem.getSender() == prevItem.getSender() && messagesTimeDiff < repNameAfter;
 }
 

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -110,7 +110,7 @@ FileTransferWidget::~FileTransferWidget()
 bool FileTransferWidget::tryRemoveFile(const QString& filepath)
 {
     QFile tmp(filepath);
-    bool writable = tmp.open(QIODevice::WriteOnly);
+    const bool writable = tmp.open(QIODevice::WriteOnly);
     tmp.remove();
     return writable;
 }
@@ -184,7 +184,8 @@ void FileTransferWidget::paintEvent(QPaintEvent* event)
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
 
-    qreal ratio = static_cast<qreal>(geometry().height()) / static_cast<qreal>(geometry().width());
+    const qreal ratio =
+        static_cast<qreal>(geometry().height()) / static_cast<qreal>(geometry().width());
     const int r = 24;
     const int buttonFieldWidth = 32;
     const int lineWidth = 1;
@@ -320,8 +321,9 @@ void FileTransferWidget::updateFileProgress(const ToxFile& file)
         // update UI
         if (speed > 0) {
             // ETA
-            QTime toGo = QTime(0, 0).addSecs(remainingTime);
-            QString format = toGo.hour() > 0 ? QStringLiteral("hh:mm:ss") : QStringLiteral("mm:ss");
+            const QTime toGo = QTime(0, 0).addSecs(remainingTime);
+            const QString format =
+                toGo.hour() > 0 ? QStringLiteral("hh:mm:ss") : QStringLiteral("mm:ss");
             ui->etaLabel->setText(toGo.toString(format));
         } else {
             ui->etaLabel->setText("");
@@ -465,7 +467,7 @@ void FileTransferWidget::handleButton(QPushButton* btn)
         } else if (btn->objectName() == "resume") {
             coreFile.pauseResumeFile(fileInfo.friendId, fileInfo.fileNum);
         } else if (btn->objectName() == "accept") {
-            QString path =
+            const QString path =
                 QFileDialog::getSaveFileName(Q_NULLPTR,
                                              tr("Save a file", "Title of the file saving dialog"),
                                              settings.getGlobalAutoAcceptDir() + "/"
@@ -477,7 +479,7 @@ void FileTransferWidget::handleButton(QPushButton* btn)
     if (btn->objectName() == "ok" || btn->objectName() == "previewButton") {
         messageBoxManager.confirmExecutableOpen(QFileInfo(fileInfo.filePath));
     } else if (btn->objectName() == "dir") {
-        QString dirPath = QFileInfo(fileInfo.filePath).dir().path();
+        const QString dirPath = QFileInfo(fileInfo.filePath).dir().path();
         QDesktopServices::openUrl(QUrl::fromLocalFile(dirPath));
     }
 }
@@ -513,7 +515,7 @@ void FileTransferWidget::updateWidget(const ToxFile& file)
 
     fileInfo = file;
 
-    bool shouldUpdateFileProgress =
+    const bool shouldUpdateFileProgress =
         file.status != ToxFile::TRANSMITTING || lastTransmissionUpdate == QTime()
         || lastTransmissionUpdate.msecsTo(file.progress.lastSampleTime()) > 1000;
 

--- a/src/chatlog/content/spinner.cpp
+++ b/src/chatlog/content/spinner.cpp
@@ -46,7 +46,7 @@ void Spinner::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, Q
 {
     painter->setClipRect(boundingRect());
 
-    QTransform trans =
+    const QTransform trans =
         QTransform().rotate(static_cast<qreal>(curRot)).translate(-size.width() / 2.0, -size.height() / 2.0);
     painter->setOpacity(alpha);
     painter->setTransform(trans, true);
@@ -74,7 +74,7 @@ qreal Spinner::getAscent() const
 void Spinner::timeout()
 {
     // Use global time, so the animations are synced
-    float angle = QTime::currentTime().msecsSinceStartOfDay() / 1000.0f * rotSpeed;
+    const float angle = QTime::currentTime().msecsSinceStartOfDay() / 1000.0f * rotSpeed;
     // limit to the range [0.0 - 360.0]
     curRot = remainderf(angle, 360.0f);
 

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -102,7 +102,7 @@ void Text::selectionMouseMove(QPointF scenePos)
     if (!doc)
         return;
 
-    int cur = cursorFromPos(scenePos);
+    const int cur = cursorFromPos(scenePos);
     if (cur >= 0) {
         selectionEnd = cur;
         selectedText = extractSanitizedText(getSelectionStart(), getSelectionEnd());
@@ -113,7 +113,7 @@ void Text::selectionMouseMove(QPointF scenePos)
 
 void Text::selectionStarted(QPointF scenePos)
 {
-    int cur = cursorFromPos(scenePos);
+    const int cur = cursorFromPos(scenePos);
     if (cur >= 0) {
         selectionEnd = cur;
         selectionAnchor = cur;
@@ -136,7 +136,7 @@ void Text::selectionDoubleClick(QPointF scenePos)
     if (!doc)
         return;
 
-    int cur = cursorFromPos(scenePos);
+    const int cur = cursorFromPos(scenePos);
 
     if (cur >= 0) {
         QTextCursor cursor(doc);
@@ -157,7 +157,7 @@ void Text::selectionTripleClick(QPointF scenePos)
     if (!doc)
         return;
 
-    int cur = cursorFromPos(scenePos);
+    const int cur = cursorFromPos(scenePos);
 
     if (cur >= 0) {
         QTextCursor cursor(doc);
@@ -184,7 +184,7 @@ void Text::selectionFocusChanged(bool focusIn)
 
 bool Text::isOverSelection(QPointF scenePos) const
 {
-    int cur = cursorFromPos(scenePos);
+    const int cur = cursorFromPos(scenePos);
     if (getSelectionStart() < cur && getSelectionEnd() >= cur)
         return true;
 
@@ -270,7 +270,7 @@ void Text::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
     if (!doc)
         return;
 
-    QString anchor = doc->documentLayout()->anchorAt(event->pos());
+    const QString anchor = doc->documentLayout()->anchorAt(event->pos());
 
     // open anchor in browser
     if (!anchor.isEmpty())
@@ -282,7 +282,7 @@ void Text::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
     if (!doc)
         return;
 
-    QString anchor = doc->documentLayout()->anchorAt(event->pos());
+    const QString anchor = doc->documentLayout()->anchorAt(event->pos());
 
     if (anchor.isEmpty())
         setCursor(Qt::IBeamCursor);
@@ -321,8 +321,8 @@ void Text::regenerate()
         doc->setDefaultFont(defFont);
 
         if (elide) {
-            QFontMetrics metrics = QFontMetrics(defFont);
-            QString elidedText = metrics.elidedText(text, Qt::ElideRight, qRound(width));
+            const QFontMetrics metrics = QFontMetrics(defFont);
+            const QString elidedText = metrics.elidedText(text, Qt::ElideRight, qRound(width));
 
             doc->setPlainText(elidedText);
         } else {
@@ -403,24 +403,24 @@ QString Text::extractSanitizedText(int from, int to) const
 
     QString txt;
 
-    QTextBlock begin = doc->findBlock(from);
-    QTextBlock end = doc->findBlock(to);
+    const QTextBlock begin = doc->findBlock(from);
+    const QTextBlock end = doc->findBlock(to);
     for (QTextBlock block = begin; block != end.next() && block.isValid(); block = block.next()) {
         for (QTextBlock::Iterator itr = block.begin(); itr != block.end(); ++itr) {
             int pos = itr.fragment().position(); // fragment position -> position of the first
                                                  // character in the fragment
 
             if (itr.fragment().charFormat().isImageFormat()) {
-                QTextImageFormat imgFmt = itr.fragment().charFormat().toImageFormat();
-                QString key = imgFmt.name(); // img key (eg. key::D for :D)
-                QString rune = key.mid(4);
+                const QTextImageFormat imgFmt = itr.fragment().charFormat().toImageFormat();
+                const QString key = imgFmt.name(); // img key (eg. key::D for :D)
+                const QString rune = key.mid(4);
 
                 if (pos >= from && pos < to) {
                     txt += rune;
                     ++pos;
                 }
             } else {
-                for (QChar c : itr.fragment().text()) {
+                for (const QChar c : itr.fragment().text()) {
                     if (pos >= from && pos < to)
                         txt += c;
 
@@ -441,7 +441,7 @@ QString Text::extractImgTooltip(int pos) const
 {
     for (QTextBlock::Iterator itr = doc->firstBlock().begin(); itr != doc->firstBlock().end(); ++itr) {
         if (itr.fragment().contains(pos) && itr.fragment().charFormat().isImageFormat()) {
-            QTextImageFormat imgFmt = itr.fragment().charFormat().toImageFormat();
+            const QTextImageFormat imgFmt = itr.fragment().charFormat().toImageFormat();
             return imgFmt.toolTip();
         }
     }

--- a/src/chatlog/customtextdocument.cpp
+++ b/src/chatlog/customtextdocument.cpp
@@ -24,10 +24,10 @@ CustomTextDocument::CustomTextDocument(SmileyPack& smileyPack_, Settings& settin
 QVariant CustomTextDocument::loadResource(int type, const QUrl& name)
 {
     if (type == QTextDocument::ImageResource && name.scheme() == "key") {
-        QSize size = QSize(settings.getEmojiFontPointSize(), settings.getEmojiFontPointSize());
-        QString fileName = QUrl::fromPercentEncoding(name.toEncoded()).mid(4).toHtmlEscaped();
+        const QSize size = QSize(settings.getEmojiFontPointSize(), settings.getEmojiFontPointSize());
+        const QString fileName = QUrl::fromPercentEncoding(name.toEncoded()).mid(4).toHtmlEscaped();
 
-        std::shared_ptr<QIcon> icon = smileyPack.getAsIcon(fileName);
+        const std::shared_ptr<QIcon> icon = smileyPack.getAsIcon(fileName);
         emoticonIcons.append(icon);
         return icon->pixmap(size);
     }

--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -164,9 +164,10 @@ QString highlight(const QString& message, const QVector<QRegularExpression>& pat
             const QRegularExpressionMatch match = iter.next();
             const int uriWithWrapMatch{0};
             const int uriWithoutWrapMatch{1};
-            MatchingUri matchUri = stripSurroundingChars(match.capturedView(uriWithWrapMatch),
-                                                         match.capturedStart(uriWithoutWrapMatch)
-                                                             - match.capturedStart(uriWithWrapMatch));
+            const MatchingUri matchUri =
+                stripSurroundingChars(match.capturedView(uriWithWrapMatch),
+                                      match.capturedStart(uriWithoutWrapMatch)
+                                          - match.capturedStart(uriWithWrapMatch));
             if (!matchUri.valid) {
                 continue;
             }
@@ -227,7 +228,7 @@ QString TextFormatter::applyMarkdown(const QString& message, bool showFormatting
         int offset = 0;
         while (iter.hasNext()) {
             const QRegularExpressionMatch match = iter.next();
-            QString captured = match.captured(!showFormattingSymbols);
+            const QString captured = match.captured(!showFormattingSymbols);
             if (isTagIntersection(captured)) {
                 continue;
             }

--- a/src/core/toxencrypt.cpp
+++ b/src/core/toxencrypt.cpp
@@ -167,7 +167,7 @@ QByteArray ToxEncrypt::encryptPass(const QString& password, const QByteArray& pl
         qWarning() << "Empty password supplied, probably not what you intended.";
     }
 
-    QByteArray pass = password.toUtf8();
+    const QByteArray pass = password.toUtf8();
     QByteArray ciphertext(plaintext.length() + TOX_PASS_ENCRYPTION_EXTRA_LENGTH, 0x00);
     Tox_Err_Encryption error;
     tox_pass_encrypt(reinterpret_cast<const uint8_t*>(plaintext.constData()),
@@ -202,7 +202,7 @@ QByteArray ToxEncrypt::decryptPass(const QString& password, const QByteArray& ci
         qDebug() << "Empty password supplied, probably not what you intended.";
     }
 
-    QByteArray pass = password.toUtf8();
+    const QByteArray pass = password.toUtf8();
     QByteArray plaintext(ciphertext.length() - TOX_PASS_ENCRYPTION_EXTRA_LENGTH, 0x00);
     Tox_Err_Decryption error;
     tox_pass_decrypt(reinterpret_cast<const uint8_t*>(ciphertext.constData()),
@@ -269,7 +269,7 @@ std::unique_ptr<ToxEncrypt> ToxEncrypt::makeToxEncrypt(const QString& password, 
         return std::unique_ptr<ToxEncrypt>{};
     }
 
-    QByteArray pass = password.toUtf8();
+    const QByteArray pass = password.toUtf8();
     Tox_Err_Key_Derivation keyError;
     Tox_Pass_Key* const passKey =
         tox_pass_key_derive_with_salt(reinterpret_cast<const uint8_t*>(pass.constData()),

--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -99,7 +99,7 @@ ToxId::ToxId(const QByteArray& rawId)
  */
 ToxId::ToxId(const uint8_t* rawId, int len)
 {
-    QByteArray tmpId(reinterpret_cast<const char*>(rawId), len);
+    const QByteArray tmpId(reinterpret_cast<const char*>(rawId), len);
     constructToxId(tmpId);
 }
 
@@ -226,7 +226,7 @@ bool ToxId::isValid() const
     const int pkAndChecksum = ToxPk::size + ToxId::nospamSize;
 
     QByteArray data = toxId.left(pkAndChecksum);
-    QByteArray checksum = toxId.right(ToxId::checksumSize);
+    const QByteArray checksum = toxId.right(ToxId::checksumSize);
     QByteArray calculated(ToxId::checksumSize, 0x00);
 
     for (int i = 0; i < pkAndChecksum; i++) {

--- a/src/core/toxoptions.cpp
+++ b/src/core/toxoptions.cpp
@@ -85,8 +85,8 @@ std::unique_ptr<ToxOptions> ToxOptions::makeToxOptions(const QByteArray& savedat
     bool forceTCP = s.getForceTCP();
     // LAN requiring UDP is a toxcore limitation, ideally wouldn't be related
     const bool enableLanDiscovery = s.getEnableLanDiscovery() && !forceTCP;
-    ICoreSettings::ProxyType proxyType = s.getProxyType();
-    quint16 proxyPort = s.getProxyPort();
+    const ICoreSettings::ProxyType proxyType = s.getProxyType();
+    const quint16 proxyPort = s.getProxyPort();
 
     if (!enableLanDiscovery) {
         qWarning() << "Core starting without LAN discovery. Peers can only be found through DHT.";

--- a/src/friendlist.cpp
+++ b/src/friendlist.cpp
@@ -19,7 +19,7 @@ Friend* FriendList::addFriend(uint32_t friendId, const ToxPk& friendPk, Settings
         qWarning() << "addFriend: friendPk already taken";
     }
 
-    QString alias = settings.getFriendAlias(friendPk);
+    const QString alias = settings.getFriendAlias(friendPk);
     Friend* newFriend = new Friend(friendId, friendPk, alias);
     friendList[friendPk] = newFriend;
     id2key[friendId] = friendPk;

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -129,7 +129,7 @@ IPC::~IPC()
  */
 time_t IPC::postEvent(const QString& name, const QByteArray& data, uint32_t dest)
 {
-    QByteArray binName = name.toUtf8();
+    const QByteArray binName = name.toUtf8();
     if (binName.length() > static_cast<int32_t>(sizeof(IPCEvent::name))) {
         return 0;
     }
@@ -233,7 +233,7 @@ bool IPC::isEventAccepted(time_t time)
 bool IPC::waitUntilAccepted(time_t postTime, int32_t timeout /*=-1*/)
 {
     bool result = false;
-    time_t start = time(nullptr);
+    const time_t start = time(nullptr);
     forever
     {
         result = isEventAccepted(postTime);
@@ -334,7 +334,7 @@ void IPC::processEvents()
 
     const std::lock_guard<std::mutex> lock(eventHandlersMutex);
     while (IPCEvent* evt = fetchEvent()) {
-        QString name = QString::fromUtf8(evt->name);
+        const QString name = QString::fromUtf8(evt->name);
         auto it = eventHandlers.find(name);
         if (it != eventHandlers.end()) {
             evt->accepted = runEventHandler(it.value().handler, evt->data, it.value().userData);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char* argv[])
     Q_INIT_RESOURCE(trigrams);
 #endif
     AppManager appManager(argc, argv);
-    int errorcode = appManager.run();
+    const int errorcode = appManager.run();
 
     qDebug() << "Exit with status" << errorcode;
     return errorcode;

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -209,8 +209,8 @@ void ChatHistory::onFileUpdated(const ToxPk& sender, const ToxFile& file)
         switch (file.status) {
         case ToxFile::INITIALIZING: {
             auto selfPk = coreIdHandler.getSelfPublicKey();
-            QString username(selfPk == sender ? coreIdHandler.getUsername()
-                                              : chat.getDisplayedName(sender));
+            const QString username(selfPk == sender ? coreIdHandler.getUsername()
+                                                    : chat.getDisplayedName(sender));
 
             // Note: There is some implicit coupling between history and the current
             // chat log. Both rely on generating a new id based on the state of

--- a/src/model/conferencemessagedispatcher.cpp
+++ b/src/model/conferencemessagedispatcher.cpp
@@ -60,7 +60,7 @@ ConferenceMessageDispatcher::sendMessage(bool isAction, const QString& content)
 void ConferenceMessageDispatcher::onMessageReceived(const ToxPk& sender, bool isAction,
                                                     const QString& content)
 {
-    bool isSelf = sender == idHandler.getSelfPublicKey();
+    const bool isSelf = sender == idHandler.getSelfPublicKey();
 
     if (isSelf) {
         return;

--- a/src/model/friendlist/friendlistmanager.cpp
+++ b/src/model/friendlist/friendlistmanager.cpp
@@ -91,13 +91,13 @@ void FriendListManager::setFilter(const QString& searchString, bool hideOnline, 
 
 void FriendListManager::applyFilter()
 {
-    QString searchString = filterParams.searchString;
+    const QString searchString = filterParams.searchString;
 
-    for (IFriendListItemPtr itemTmp : items) {
+    for (const IFriendListItemPtr& itemTmp : items) {
         if (searchString.isEmpty()) {
             itemTmp->setWidgetVisible(true);
         } else {
-            QString tmp_name = itemTmp->getNameItem();
+            const QString tmp_name = itemTmp->getNameItem();
             itemTmp->setWidgetVisible(tmp_name.contains(searchString, Qt::CaseInsensitive));
         }
 
@@ -216,8 +216,8 @@ bool FriendListManager::cmpByActivity(const IFriendListItemPtr& a, const IFriend
         return a->getNameItem().toUpper() < b->getNameItem().toUpper();
     }
 
-    QDateTime dateA = a->getLastActivity();
-    QDateTime dateB = b->getLastActivity();
+    const QDateTime dateA = a->getLastActivity();
+    const QDateTime dateB = b->getLastActivity();
     if (dateA.date() == dateB.date()) {
         if (a->isOnline() && !b->isOnline()) {
             return true;

--- a/src/model/friendmessagedispatcher.cpp
+++ b/src/model/friendmessagedispatcher.cpp
@@ -97,7 +97,7 @@ void FriendMessageDispatcher::sendCoreProcessedMessage(const Message& message,
 {
     auto receipt = ReceiptNum();
 
-    uint32_t friendId = f.getId();
+    const uint32_t friendId = f.getId();
 
     auto sendFn = message.isAction ? std::mem_fn(&ICoreFriendMessageSender::sendAction)
                                    : std::mem_fn(&ICoreFriendMessageSender::sendMessage);

--- a/src/model/message.cpp
+++ b/src/model/message.cpp
@@ -97,7 +97,7 @@ std::vector<Message> MessageProcessor::processOutgoingMessage(bool isAction, con
  */
 Message MessageProcessor::processIncomingCoreMessage(bool isAction, const QString& message)
 {
-    QDateTime timestamp = QDateTime::currentDateTime();
+    const QDateTime timestamp = QDateTime::currentDateTime();
     auto ret = Message{};
     ret.isAction = isAction;
     ret.content = message;

--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -40,8 +40,8 @@ QString sanitize(const QString& src)
 {
     QString name = src;
     // these are pretty much Windows banned filename characters
-    QList<QChar> banned{'/', '\\', ':', '<', '>', '"', '|', '?', '*'};
-    for (QChar c : banned) {
+    const QList<QChar> banned{'/', '\\', ':', '<', '>', '"', '|', '?', '*'};
+    for (const QChar c : banned) {
         name.replace(c, '_');
     }
 
@@ -66,7 +66,7 @@ QString sanitize(const QString& src)
 bool tryRemoveFile(const QString& filepath)
 {
     QFile tmp(filepath);
-    bool writable = tmp.open(QIODevice::WriteOnly);
+    const bool writable = tmp.open(QIODevice::WriteOnly);
     tmp.remove();
     return writable;
 }
@@ -103,7 +103,7 @@ ProfileInfo::ProfileInfo(Core* core_, Profile* profile_, Settings& settings_, Ne
  */
 bool ProfileInfo::setPassword(const QString& password)
 {
-    QString errorMsg = profile->setPassword(password);
+    const QString errorMsg = profile->setPassword(password);
     return errorMsg.isEmpty();
 }
 
@@ -113,7 +113,7 @@ bool ProfileInfo::setPassword(const QString& password)
  */
 bool ProfileInfo::deletePassword()
 {
-    QString errorMsg = profile->setPassword("");
+    const QString errorMsg = profile->setPassword("");
     return errorMsg.isEmpty();
 }
 
@@ -131,8 +131,8 @@ bool ProfileInfo::isEncrypted() const
  */
 void ProfileInfo::copyId() const
 {
-    ToxId selfId = core->getSelfId();
-    QString txt = selfId.toString();
+    const ToxId selfId = core->getSelfId();
+    const QString txt = selfId.toString();
     QClipboard* clip = QApplication::clipboard();
     clip->setText(txt, QClipboard::Clipboard);
     if (clip->supportsSelection()) {
@@ -174,12 +174,12 @@ QString ProfileInfo::getProfileName() const
  */
 IProfileInfo::RenameResult ProfileInfo::renameProfile(const QString& name)
 {
-    QString cur = profile->getName();
+    const QString cur = profile->getName();
     if (name.isEmpty()) {
         return RenameResult::EmptyName;
     }
 
-    QString newName = sanitize(name);
+    const QString newName = sanitize(name);
 
     if (Profile::exists(newName, settings.getPaths())) {
         return RenameResult::ProfileAlreadyExists;
@@ -199,7 +199,7 @@ IProfileInfo::RenameResult ProfileInfo::renameProfile(const QString& name)
  */
 IProfileInfo::SaveResult ProfileInfo::exportProfile(const QString& path) const
 {
-    QString current = profile->getName() + Core::TOX_EXT;
+    const QString current = profile->getName() + Core::TOX_EXT;
     if (path.isEmpty()) {
         return SaveResult::EmptyPath;
     }
@@ -253,7 +253,7 @@ void ProfileInfo::copyQr(const QImage& image) const
  */
 IProfileInfo::SaveResult ProfileInfo::saveQr(const QImage& image, const QString& path) const
 {
-    QString current = profile->getName() + ".png";
+    const QString current = profile->getName() + ".png";
     if (path.isEmpty()) {
         return SaveResult::EmptyPath;
     }
@@ -303,7 +303,7 @@ IProfileInfo::SetAvatarResult ProfileInfo::setAvatar(const QString& path)
  */
 IProfileInfo::SetAvatarResult ProfileInfo::createAvatarFromFile(QFile& file, QByteArray& avatar)
 {
-    QByteArray fileContents{file.readAll()};
+    const QByteArray fileContents{file.readAll()};
     auto err = byteArrayToPng(fileContents, avatar);
     if (err != SetAvatarResult::OK) {
         return err;

--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -120,8 +120,8 @@ SessionChatLog::~SessionChatLog() = default;
 
 QString SessionChatLog::resolveSenderNameFromSender(const ToxPk& sender)
 {
-    bool isSelf = sender == coreIdHandler.getSelfPublicKey();
-    QString myNickName =
+    const bool isSelf = sender == coreIdHandler.getSelfPublicKey();
+    const QString myNickName =
         coreIdHandler.getUsername().isEmpty() ? sender.toString() : coreIdHandler.getUsername();
 
     return isSelf ? myNickName : resolveToxPk(friendList, conferenceList, sender);

--- a/src/net/avatarbroadcaster.cpp
+++ b/src/net/avatarbroadcaster.cpp
@@ -37,8 +37,8 @@ void AvatarBroadcaster::setAvatar(QByteArray data)
     avatarData = data;
     friendsSentTo.clear();
 
-    QVector<uint32_t> friends = core.getFriendList();
-    for (uint32_t friendId : friends) {
+    const QVector<uint32_t> friends = core.getFriendList();
+    for (const uint32_t friendId : friends) {
         sendAvatarTo(friendId);
     }
 }

--- a/src/net/bootstrapnodeupdater.cpp
+++ b/src/net/bootstrapnodeupdater.cpp
@@ -131,8 +131,8 @@ QList<DhtServer> jsonToNodeList(const QJsonDocument& nodeList)
         qWarning() << "Bootstrap JSON is missing nodes array";
         return result;
     }
-    QJsonArray nodes = rootObj[jsonNodeArrayName].toArray();
-    for (const QJsonValueRef node : nodes) {
+    const QJsonArray nodes = rootObj[jsonNodeArrayName].toArray();
+    for (const auto node : nodes) {
         if (node.isObject()) {
             jsonNodeToDhtServer(node.toObject(), result);
         }
@@ -149,7 +149,7 @@ QList<DhtServer> loadNodesFile(QString file)
         return {};
     }
 
-    QString nodesJson = QString::fromUtf8(nodesFile.readAll());
+    const QString nodesJson = QString::fromUtf8(nodesFile.readAll());
     nodesFile.close();
 
     auto jsonDoc = QJsonDocument::fromJson(nodesJson.toUtf8());
@@ -175,7 +175,7 @@ QByteArray serialize(QList<DhtServer> nodes)
         nodeJson.insert(NodeFields::maintainer, node.maintainer);
 
         QJsonArray tcp_ports;
-        for (unsigned short tcpPort : node.tcpPorts) {
+        for (const unsigned short tcpPort : node.tcpPorts) {
             tcp_ports.push_back(tcpPort);
         }
         nodeJson.insert(NodeFields::tcp_ports, tcp_ports);
@@ -184,7 +184,7 @@ QByteArray serialize(QList<DhtServer> nodes)
     QJsonObject rootObj;
     rootObj.insert("nodes", jsonNodes);
 
-    QJsonDocument doc{rootObj};
+    const QJsonDocument doc{rootObj};
     return doc.toJson(QJsonDocument::Indented);
 }
 
@@ -252,13 +252,13 @@ void BootstrapNodeUpdater::onRequestComplete(QNetworkReply* reply)
     }
 
     // parse the reply JSON
-    QJsonDocument jsonDocument = QJsonDocument::fromJson(reply->readAll());
+    const QJsonDocument jsonDocument = QJsonDocument::fromJson(reply->readAll());
     if (jsonDocument.isNull()) {
         emit availableBootstrapNodes({});
         return;
     }
 
-    QList<DhtServer> result = jsonToNodeList(jsonDocument);
+    const QList<DhtServer> result = jsonToNodeList(jsonDocument);
 
     emit availableBootstrapNodes(result);
 }

--- a/src/net/toxuri.cpp
+++ b/src/net/toxuri.cpp
@@ -29,7 +29,7 @@ bool ToxURIDialog::handleToxURI(const QString& toxURI)
 {
     const QString toxAddress = toxURI.mid(4);
 
-    ToxId toxId(toxAddress);
+    const ToxId toxId(toxAddress);
     QString error = QString();
     if (!toxId.isValid()) {
         error = QMessageBox::tr("%1 is not a valid Tox address.").arg(toxAddress);
@@ -45,7 +45,7 @@ bool ToxURIDialog::handleToxURI(const QString& toxURI)
 
     setUserId(toxURI);
 
-    int result = exec();
+    const int result = exec();
     if (result == QDialog::Accepted) {
         core.requestFriendship(toxId, getRequestMessage());
     }

--- a/src/persistence/db/upgrades/dbto11.cpp
+++ b/src/persistence/db/upgrades/dbto11.cpp
@@ -25,7 +25,7 @@ bool DbTo11::dbSchema10to11(RawDatabase& db)
         return false;
     }
     upgradeQueries.emplace_back(QStringLiteral("PRAGMA user_version = 11;"));
-    bool transactionPass = db.execNow(std::move(upgradeQueries));
+    const bool transactionPass = db.execNow(std::move(upgradeQueries));
     if (transactionPass) {
         return db.execNow("VACUUM");
     }

--- a/src/persistence/db/upgrades/dbupgrader.cpp
+++ b/src/persistence/db/upgrades/dbupgrader.cpp
@@ -48,7 +48,7 @@ RowId getValidPeerRow(RawDatabase& db, const ChatId& chatId)
 
     db.execNow(RawDatabase::Query(("SELECT id FROM peers ORDER BY id DESC LIMIT 1;"),
                                   [&](const QVector<QVariant>& row) {
-                                      int64_t maxPeerId = row[0].toInt();
+                                      const int64_t maxPeerId = row[0].toInt();
                                       validPeerRow = RowId{maxPeerId + 1};
                                   }));
     db.execNow(
@@ -376,7 +376,7 @@ bool DbUpgrader::dbSchema1to2(RawDatabase& db)
     // faux_offline_pending to broken_messages
 
     // the last non-pending message in each chat
-    QString lastDeliveredQuery =
+    const QString lastDeliveredQuery =
         QString("SELECT chat_id, MAX(history.id) FROM "
                 "history JOIN peers chat ON chat_id = chat.id "
                 "LEFT JOIN faux_offline_pending ON history.id = faux_offline_pending.id "
@@ -611,7 +611,7 @@ bool DbUpgrader::dbSchema9to10(RawDatabase& db)
     // entries. The resume file ID isn't actually used for loaded files at this time, so we can heal
     // it to an arbitrary value of full length.
     constexpr int resumeFileIdLengthNow = 32;
-    QByteArray dummyResumeId(resumeFileIdLengthNow, 0);
+    const QByteArray dummyResumeId(resumeFileIdLengthNow, 0);
     std::vector<RawDatabase::Query> upgradeQueries;
     upgradeQueries.emplace_back(
         QStringLiteral(

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -171,7 +171,7 @@ std::vector<RawDatabase::Query> generateNewSystemMessageQueries(const ChatId& ch
 
 FileDbInsertionData::FileDbInsertionData()
 {
-    static int id = qRegisterMetaType<FileDbInsertionData>();
+    static const int id = qRegisterMetaType<FileDbInsertionData>();
     (void)id;
 }
 
@@ -376,7 +376,7 @@ History::generateNewFileTransferQueries(const ChatId& chatId, const ToxPk& sende
     queries.emplace_back(generateUpdateAlias(sender, dispName));
     queries.emplace_back(generateHistoryTableInsertion('F', time, chatId));
 
-    std::weak_ptr<History> weakThis = shared_from_this();
+    const std::weak_ptr<History> weakThis = shared_from_this();
     auto fileId = insertionData.fileId;
 
     QString queryString;
@@ -466,7 +466,7 @@ void History::addNewFileMessage(const ChatId& chatId, const QByteArray& fileId,
         direction = ToxFile::SENDING;
     }
 
-    std::weak_ptr<History> weakThis = shared_from_this();
+    const std::weak_ptr<History> weakThis = shared_from_this();
     FileDbInsertionData insertionData;
     insertionData.fileId = fileId;
     insertionData.fileName = fileName;
@@ -705,7 +705,7 @@ QList<History::HistMessage> History::getUndeliveredMessagesForChat(const ChatId&
         auto senderKey = ToxPk{(*it++).toByteArray()};
         auto displayName = QString::fromUtf8((*it++).toByteArray().replace('\0', ""));
 
-        MessageState messageState = getMessageState(isPending, isBroken);
+        const MessageState messageState = getMessageState(isPending, isBroken);
 
         ret +=
             {id, messageState, timestamp, chatId.clone(), displayName, senderKey, messageContent};

--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -22,7 +22,7 @@
  */
 void OfflineMsgEngine::onReceiptReceived(ReceiptNum receipt)
 {
-    QMutexLocker<QRecursiveMutex> ml(&mutex);
+    const QMutexLocker<QRecursiveMutex> ml(&mutex);
     receiptResolver.notifyReceiptReceived(receipt);
 }
 
@@ -37,7 +37,7 @@ void OfflineMsgEngine::onReceiptReceived(ReceiptNum receipt)
  */
 void OfflineMsgEngine::addUnsentMessage(const Message& message, CompletionFn completionCallback)
 {
-    QMutexLocker<QRecursiveMutex> ml(&mutex);
+    const QMutexLocker<QRecursiveMutex> ml(&mutex);
     unsentMessages.push_back(
         OfflineMessage{message, std::chrono::steady_clock::now(), completionCallback});
 }
@@ -55,7 +55,7 @@ void OfflineMsgEngine::addUnsentMessage(const Message& message, CompletionFn com
 void OfflineMsgEngine::addSentCoreMessage(ReceiptNum receipt, const Message& message,
                                           CompletionFn completionCallback)
 {
-    QMutexLocker<QRecursiveMutex> ml(&mutex);
+    const QMutexLocker<QRecursiveMutex> ml(&mutex);
     receiptResolver.notifyMessageSent(receipt, {message, std::chrono::steady_clock::now(),
                                                 completionCallback});
 }
@@ -65,7 +65,7 @@ void OfflineMsgEngine::addSentCoreMessage(ReceiptNum receipt, const Message& mes
  */
 std::vector<OfflineMsgEngine::RemovedMessage> OfflineMsgEngine::removeAllMessages()
 {
-    QMutexLocker<QRecursiveMutex> ml(&mutex);
+    const QMutexLocker<QRecursiveMutex> ml(&mutex);
     auto messages = receiptResolver.clear();
 
     messages.insert(messages.end(), std::make_move_iterator(unsentMessages.begin()),

--- a/src/persistence/paths.cpp
+++ b/src/persistence/paths.cpp
@@ -369,21 +369,21 @@ QString Paths::getAppCacheDirPath() const
 
 QString Paths::getExampleNodesFilePath() const
 {
-    QDir dir(getSettingsDirPath());
+    const QDir dir(getSettingsDirPath());
     constexpr static char nodesFileName[] = "bootstrapNodes.example.json";
     return dir.filePath(nodesFileName);
 }
 
 QString Paths::getUserNodesFilePath() const
 {
-    QDir dir(getSettingsDirPath());
+    const QDir dir(getSettingsDirPath());
     constexpr static char nodesFileName[] = "bootstrapNodes.json";
     return dir.filePath(nodesFileName);
 }
 
 QString Paths::getBackupUserNodesFilePath() const
 {
-    QDir dir(getSettingsDirPath());
+    const QDir dir(getSettingsDirPath());
     constexpr static char nodesFileName[] = "bootstrapNodes.backup.json";
     return dir.filePath(nodesFileName);
 }

--- a/src/persistence/personalsettingsupgrader.cpp
+++ b/src/persistence/personalsettingsupgrader.cpp
@@ -16,7 +16,7 @@ bool version0to1(SettingsSerializer& ps)
 {
     ps.beginGroup("Friends");
     {
-        int size = ps.beginReadArray("Friend");
+        const int size = ps.beginReadArray("Friend");
         for (int i = 0; i < size; i++) {
             ps.setArrayIndex(i);
             const auto oldFriendAddr = ps.value("addr").toString();

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -314,7 +314,7 @@ Profile* Profile::loadProfile(const QString& name, const QString& password, Sett
 
     LoadToxDataError error;
     QByteArray toxSave = QByteArray();
-    QString path = paths.getSettingsDirPath() + name + ".tox";
+    const QString path = paths.getSettingsDirPath() + name + ".tox";
     std::unique_ptr<ToxEncrypt> tmpKey = loadToxData(password, path, toxSave, error);
     if (logLoadToxDataError(error, path)) {
         ProfileLocker::unlock();
@@ -347,7 +347,7 @@ Profile* Profile::createProfile(const QString& name, const QString& password, Se
 {
     CreateToxDataError error;
     Paths& paths = settings.getPaths();
-    QString path = paths.getSettingsDirPath() + name + ".tox";
+    const QString path = paths.getSettingsDirPath() + name + ".tox";
     std::unique_ptr<ToxEncrypt> tmpKey = createToxData(name, password, path, error, paths);
 
     if (logCreateToxDataError(error, name)) {
@@ -392,9 +392,9 @@ QStringList Profile::getFilesByExt(QString extension, Paths& paths)
     QStringList out;
     dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
     dir.setNameFilters(QStringList("*." + extension));
-    QFileInfoList list = dir.entryInfoList();
+    const QFileInfoList list = dir.entryInfoList();
     out.reserve(list.size());
-    for (QFileInfo file : list) {
+    for (const QFileInfo& file : list) {
         out += file.completeBaseName();
     }
 
@@ -459,7 +459,7 @@ void Profile::startCore()
  */
 void Profile::onSaveToxSave()
 {
-    QByteArray data = core->getToxSaveData();
+    const QByteArray data = core->getToxSaveData();
     assert(data.size());
     saveToxSave(data);
 }
@@ -485,7 +485,7 @@ bool Profile::saveToxSave(QByteArray data)
     ProfileLocker::assertLock(paths);
     assert(ProfileLocker::getCurLockName() == name);
 
-    QString path = paths.getSettingsDirPath() + name + ".tox";
+    const QString path = paths.getSettingsDirPath() + name + ".tox";
     qDebug() << "Saving tox save to" << path;
     QSaveFile saveFile(path);
     if (!saveFile.open(QIODevice::WriteOnly)) {
@@ -617,7 +617,7 @@ void Profile::loadDatabase(QString password, IMessageBoxManager& messageBoxManag
         return;
     }
 
-    QByteArray salt = core->getSelfPublicKey().getByteArray();
+    const QByteArray salt = core->getSelfPublicKey().getByteArray();
     if (salt.size() != TOX_PASS_SALT_LENGTH) {
         qWarning() << "Couldn't compute salt from public key" << name;
         messageBoxManager
@@ -721,7 +721,7 @@ void Profile::saveAvatar(const ToxPk& owner, const QByteArray& avatar)
     const bool needEncrypt = encrypted && !avatar.isEmpty();
     const QByteArray& pic = needEncrypt ? passkey->encrypt(avatar) : avatar;
 
-    QString path = avatarPath(owner);
+    const QString path = avatarPath(owner);
     QDir(paths.getSettingsDirPath()).mkdir("avatars");
     if (pic.isEmpty()) {
         QFile::remove(path);
@@ -801,7 +801,7 @@ void Profile::removeAvatar(const ToxPk& owner)
 
 bool Profile::exists(QString name, Paths& paths)
 {
-    QString path = paths.getSettingsDirPath() + name;
+    const QString path = paths.getSettingsDirPath() + name;
     return QFile::exists(path + ".tox");
 }
 
@@ -823,7 +823,7 @@ bool Profile::isEncrypted() const
 bool Profile::isEncrypted(QString name, Paths& paths)
 {
     uint8_t data[TOX_PASS_ENCRYPTION_EXTRA_LENGTH] = {0};
-    QString path = paths.getSettingsDirPath() + name + ".tox";
+    const QString path = paths.getSettingsDirPath() + name + ".tox";
     QFile saveFile(path);
     if (!saveFile.open(QIODevice::ReadOnly)) {
         qWarning() << "Couldn't open tox save" << path;
@@ -856,7 +856,7 @@ QStringList Profile::remove()
             i--;
         }
     }
-    QString path = paths.getSettingsDirPath() + name;
+    const QString path = paths.getSettingsDirPath() + name;
     ProfileLocker::unlock();
 
     QFile profileMain{path + ".tox"};
@@ -873,7 +873,7 @@ QStringList Profile::remove()
         qWarning() << "Could not remove file" << profileConfig.fileName();
     }
 
-    QString dbPath = getDbPath(name, settings.getPaths());
+    const QString dbPath = getDbPath(name, settings.getPaths());
     if (database && database->isOpen() && !database->remove() && QFile::exists(dbPath)) {
         ret.push_back(dbPath);
         qWarning() << "Could not remove file" << dbPath;
@@ -904,7 +904,7 @@ bool Profile::rename(QString newName)
         database->rename(newName);
     }
 
-    bool resetAutorun = settings.getAutorun();
+    const bool resetAutorun = settings.getAutorun();
     settings.setAutorun(false);
     settings.setCurrentProfile(newName);
     if (resetAutorun) {
@@ -961,10 +961,10 @@ QString Profile::setPassword(const QString& newPassword)
                    "password.");
     }
 
-    QByteArray avatar = loadAvatarData(core->getSelfPublicKey());
+    const QByteArray avatar = loadAvatarData(core->getSelfPublicKey());
     saveAvatar(core->getSelfPublicKey(), avatar);
 
-    QVector<uint32_t> friendList = core->getFriendList();
+    const QVector<uint32_t> friendList = core->getFriendList();
     QVectorIterator<uint32_t> i(friendList);
     while (i.hasNext()) {
         const ToxPk friendPublicKey = core->getFriendPublicKey(i.next());

--- a/src/persistence/profilelocker.cpp
+++ b/src/persistence/profilelocker.cpp
@@ -96,7 +96,7 @@ void ProfileLocker::assertLock(Paths& paths)
     }
 
     if (!QFile(lockPathFromName(curLockName, paths)).exists()) {
-        QString tmp = curLockName;
+        const QString tmp = curLockName;
         unlock();
         if (lock(tmp, paths)) {
             qCritical() << "assertLock: Lock file was lost, but could be restored";

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -98,14 +98,14 @@ Settings::~Settings()
 
 void Settings::loadGlobal()
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     if (loaded)
         return;
 
     createSettingsDir();
 
-    QDir dir(paths.getSettingsDirPath());
+    const QDir dir(paths.getSettingsDirPath());
     QString filePath = dir.filePath(globalSettingsFile);
 
     // If no settings file exist -- use the default one
@@ -176,7 +176,7 @@ void Settings::loadGlobal()
     });
 
     inGroup(s, "Widgets", [this, &s] {
-        QList<QString> objectNames = s.childKeys();
+        const QList<QString> objectNames = s.childKeys();
         for (const QString& name : objectNames)
             widgetSettings[name] = s.value(name).toByteArray();
     });
@@ -271,7 +271,7 @@ void Settings::loadGlobal()
 
 void Settings::updateProfileData(Profile* profile, const QCommandLineParser* parser, bool newProfile)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     if (profile == nullptr) {
         qWarning() << QString("Could not load new settings (profile change to nullptr)");
@@ -293,10 +293,10 @@ void Settings::updateProfileData(Profile* profile, const QCommandLineParser* par
  */
 bool Settings::verifyProxySettings(const QCommandLineParser& parser)
 {
-    QString IPv6SettingString = parser.value("I").toLower();
-    QString LANSettingString = parser.value("L").toLower();
-    QString UDPSettingString = parser.value("U").toLower();
-    QString proxySettingString = parser.value("proxy").toLower();
+    const QString IPv6SettingString = parser.value("I").toLower();
+    const QString LANSettingString = parser.value("L").toLower();
+    const QString UDPSettingString = parser.value("U").toLower();
+    const QString proxySettingString = parser.value("proxy").toLower();
     QStringList proxySettingStrings = proxySettingString.split(":");
 
     const QString SOCKS5 = QStringLiteral("socks5");
@@ -390,10 +390,10 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
         return false;
     }
 
-    QString IPv6Setting = parser.value("I").toUpper();
-    QString LANSetting = parser.value("L").toUpper();
-    QString UDPSetting = parser.value("U").toUpper();
-    QString proxySettingString = parser.value("proxy").toUpper();
+    const QString IPv6Setting = parser.value("I").toUpper();
+    const QString LANSetting = parser.value("L").toUpper();
+    const QString UDPSetting = parser.value("U").toUpper();
+    const QString proxySettingString = parser.value("proxy").toUpper();
     QStringList proxySettings = proxySettingString.split(":");
 
     const QString SOCKS5 = QStringLiteral("SOCKS5");
@@ -441,7 +441,7 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
     }
 
     if (parser.isSet("U")) {
-        bool shouldForceTCP = UDPSetting == OFF;
+        const bool shouldForceTCP = UDPSetting == OFF;
         if (!shouldForceTCP && proxyType != ICoreSettings::ProxyType::ptNone) {
             qDebug() << "Cannot use UDP with proxy; disable proxy explicitly with '-P none'.";
         } else {
@@ -457,7 +457,7 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
     }
 
     if (parser.isSet("L")) {
-        bool shouldEnableLAN = LANSetting == ON;
+        const bool shouldEnableLAN = LANSetting == ON;
 
         if (shouldEnableLAN && proxyType != ICoreSettings::ProxyType::ptNone) {
             qDebug()
@@ -474,14 +474,14 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
 
 void Settings::loadPersonal(const Profile& profile, bool newProfile)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     loadedProfile = &profile;
-    QDir dir(paths.getSettingsDirPath());
+    const QDir dir(paths.getSettingsDirPath());
     QString filePath = dir.filePath(globalSettingsFile);
 
     // load from a profile specific friend data list if possible
-    QString tmp = dir.filePath(profile.getName() + ".ini");
+    const QString tmp = dir.filePath(profile.getName() + ".ini");
     if (QFile(tmp).exists()) { // otherwise, filePath remains the global file
         filePath = tmp;
     }
@@ -589,8 +589,8 @@ void Settings::resetToDefault()
     loaded = false;
 
     // Remove file with profile settings
-    QDir dir(paths.getSettingsDirPath());
-    QString localPath = dir.filePath(loadedProfile->getName() + ".ini");
+    const QDir dir(paths.getSettingsDirPath());
+    const QString localPath = dir.filePath(loadedProfile->getName() + ".ini");
     QFile local(localPath);
     if (local.exists())
         local.remove();
@@ -604,11 +604,11 @@ void Settings::saveGlobal()
     if (QThread::currentThread() != settingsThread)
         return (void)QMetaObject::invokeMethod(this, "saveGlobal");
 
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     if (!loaded)
         return;
 
-    QString path = paths.getSettingsDirPath() + globalSettingsFile;
+    const QString path = paths.getSettingsDirPath() + globalSettingsFile;
     qDebug() << "Saving global settings at" << path;
 
     QSettings s(path, QSettings::IniFormat);
@@ -734,11 +734,11 @@ void Settings::savePersonal()
 
 void Settings::savePersonal(QString profileName, const ToxEncrypt* passkey)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     if (!loaded)
         return;
 
-    QString path = paths.getSettingsDirPath() + profileName + ".ini";
+    const QString path = paths.getSettingsDirPath() + profileName + ".ini";
 
     qDebug() << "Saving personal settings at" << path;
 
@@ -815,7 +815,7 @@ void Settings::savePersonal(QString profileName, const ToxEncrypt* passkey)
 
 uint32_t Settings::makeProfileId(const QString& profile)
 {
-    QByteArray data = QCryptographicHash::hash(profile.toUtf8(), QCryptographicHash::Md5);
+    const QByteArray data = QCryptographicHash::hash(profile.toUtf8(), QCryptographicHash::Md5);
     const uint32_t* dwords = reinterpret_cast<const uint32_t*>(data.constData());
     return dwords[0] ^ dwords[1] ^ dwords[2] ^ dwords[3];
 }
@@ -827,7 +827,7 @@ Paths& Settings::getPaths()
 
 bool Settings::getEnableTestSound() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return enableTestSound;
 }
 
@@ -840,7 +840,7 @@ void Settings::setEnableTestSound(bool newValue)
 
 bool Settings::getEnableIPv6() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return enableIPv6;
 }
 
@@ -853,7 +853,7 @@ void Settings::setEnableIPv6(bool enabled)
 
 bool Settings::getMakeToxPortable() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return paths.isPortable();
 }
 
@@ -861,7 +861,7 @@ void Settings::setMakeToxPortable(bool newValue)
 {
     bool changed = false;
     {
-        QMutexLocker<QRecursiveMutex> locker{&bigLock};
+        const QMutexLocker<QRecursiveMutex> locker{&bigLock};
         const auto oldSettingsPath = paths.getSettingsDirPath() + globalSettingsFile;
         changed = paths.setPortable(newValue);
         if (changed) {
@@ -874,7 +874,7 @@ void Settings::setMakeToxPortable(bool newValue)
 
 bool Settings::getAutorun() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
 #ifdef QTOX_PLATFORM_EXT
     return Platform::getAutorun(*this);
@@ -886,7 +886,7 @@ bool Settings::getAutorun() const
 void Settings::setAutorun(bool newValue)
 {
 #ifdef QTOX_PLATFORM_EXT
-    bool autorun = Platform::getAutorun(*this);
+    const bool autorun = Platform::getAutorun(*this);
 
     if (newValue != autorun) {
         Platform::setAutorun(*this, newValue);
@@ -899,13 +899,13 @@ void Settings::setAutorun(bool newValue)
 
 bool Settings::getAutostartInTray() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return autostartInTray;
 }
 
 QString Settings::getStyle() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return style;
 }
 
@@ -918,7 +918,7 @@ void Settings::setStyle(const QString& newStyle)
 
 bool Settings::getShowSystemTray() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return showSystemTray;
 }
 
@@ -938,7 +938,7 @@ void Settings::setUseEmoticons(bool newValue)
 
 bool Settings::getUseEmoticons() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return useEmoticons;
 }
 
@@ -951,7 +951,7 @@ void Settings::setAutoSaveEnabled(bool newValue)
 
 bool Settings::getAutoSaveEnabled() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return autoSaveEnabled;
 }
 
@@ -964,7 +964,7 @@ void Settings::setEnableDebug(bool newValue)
 
 bool Settings::getEnableDebug() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return enableDebug;
 }
 
@@ -977,7 +977,7 @@ void Settings::setAutostartInTray(bool newValue)
 
 bool Settings::getCloseToTray() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return closeToTray;
 }
 
@@ -990,7 +990,7 @@ void Settings::setCloseToTray(bool newValue)
 
 bool Settings::getMinimizeToTray() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return minimizeToTray;
 }
 
@@ -1003,7 +1003,7 @@ void Settings::setMinimizeToTray(bool newValue)
 
 bool Settings::getLightTrayIcon() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return lightTrayIcon;
 }
 
@@ -1016,7 +1016,7 @@ void Settings::setLightTrayIcon(bool newValue)
 
 bool Settings::getStatusChangeNotificationEnabled() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return statusChangeNotificationEnabled;
 }
 
@@ -1029,7 +1029,7 @@ void Settings::setStatusChangeNotificationEnabled(bool newValue)
 
 bool Settings::getShowConferenceJoinLeaveMessages() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return showConferenceJoinLeaveMessages;
 }
 
@@ -1055,7 +1055,7 @@ void Settings::setSpellCheckingEnabled(bool newValue)
 
 bool Settings::getNotifySound() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return notifySound;
 }
 
@@ -1068,7 +1068,7 @@ void Settings::setNotifySound(bool newValue)
 
 bool Settings::getNotifyHide() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return notifyHide;
 }
 
@@ -1081,7 +1081,7 @@ void Settings::setNotifyHide(bool newValue)
 
 bool Settings::getBusySound() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return busySound;
 }
 
@@ -1094,7 +1094,7 @@ void Settings::setBusySound(bool newValue)
 
 bool Settings::getConferenceAlwaysNotify() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return conferenceAlwaysNotify;
 }
 
@@ -1107,7 +1107,7 @@ void Settings::setConferenceAlwaysNotify(bool newValue)
 
 QString Settings::getTranslation() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return translation;
 }
 
@@ -1120,7 +1120,7 @@ void Settings::setTranslation(const QString& newValue)
 
 bool Settings::getForceTCP() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return forceTCP;
 }
 
@@ -1133,7 +1133,7 @@ void Settings::setForceTCP(bool enabled)
 
 bool Settings::getEnableLanDiscovery() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return enableLanDiscovery;
 }
 
@@ -1146,7 +1146,7 @@ void Settings::setEnableLanDiscovery(bool enabled)
 
 QNetworkProxy Settings::getProxy() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     QNetworkProxy proxy;
     switch (Settings::getProxyType()) {
@@ -1172,7 +1172,7 @@ QNetworkProxy Settings::getProxy() const
 
 Settings::ProxyType Settings::getProxyType() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return proxyType;
 }
 
@@ -1185,7 +1185,7 @@ void Settings::setProxyType(ProxyType newValue)
 
 QString Settings::getProxyAddr() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return proxyAddr;
 }
 
@@ -1198,7 +1198,7 @@ void Settings::setProxyAddr(const QString& address)
 
 quint16 Settings::getProxyPort() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return proxyPort;
 }
 
@@ -1211,13 +1211,13 @@ void Settings::setProxyPort(quint16 port)
 
 QString Settings::getCurrentProfile() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return currentProfile;
 }
 
 uint32_t Settings::getCurrentProfileId() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return currentProfileId;
 }
 
@@ -1226,7 +1226,7 @@ void Settings::setCurrentProfile(const QString& profile)
     bool updated = false;
     uint32_t newProfileId = 0;
     {
-        QMutexLocker<QRecursiveMutex> locker{&bigLock};
+        const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
         if (profile != currentProfile) {
             currentProfile = profile;
@@ -1242,7 +1242,7 @@ void Settings::setCurrentProfile(const QString& profile)
 
 bool Settings::getEnableLogging() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return enableLogging;
 }
 
@@ -1255,7 +1255,7 @@ void Settings::setEnableLogging(bool newValue)
 
 int Settings::getAutoAwayTime() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return autoAwayTime;
 }
 
@@ -1277,7 +1277,7 @@ void Settings::setAutoAwayTime(int newValue)
 
 QString Settings::getAutoAcceptDir(const ToxPk& id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     auto it = friendLst.find(id.getByteArray());
     if (it != friendLst.end())
@@ -1290,7 +1290,7 @@ void Settings::setAutoAcceptDir(const ToxPk& id, const QString& dir)
 {
     bool updated = false;
     {
-        QMutexLocker<QRecursiveMutex> locker{&bigLock};
+        const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
         auto& frnd = getOrInsertFriendPropRef(id);
 
@@ -1306,7 +1306,7 @@ void Settings::setAutoAcceptDir(const ToxPk& id, const QString& dir)
 
 Settings::AutoAcceptCallFlags Settings::getAutoAcceptCall(const ToxPk& id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     auto it = friendLst.find(id.getByteArray());
     if (it != friendLst.end())
@@ -1319,7 +1319,7 @@ void Settings::setAutoAcceptCall(const ToxPk& id, AutoAcceptCallFlags accept)
 {
     bool updated = false;
     {
-        QMutexLocker<QRecursiveMutex> locker{&bigLock};
+        const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
         auto& frnd = getOrInsertFriendPropRef(id);
 
@@ -1335,7 +1335,7 @@ void Settings::setAutoAcceptCall(const ToxPk& id, AutoAcceptCallFlags accept)
 
 bool Settings::getAutoConferenceInvite(const ToxPk& id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     auto it = friendLst.find(id.getByteArray());
     if (it != friendLst.end()) {
@@ -1349,7 +1349,7 @@ void Settings::setAutoConferenceInvite(const ToxPk& id, bool accept)
 {
     bool updated = false;
     {
-        QMutexLocker<QRecursiveMutex> locker{&bigLock};
+        const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
         auto& frnd = getOrInsertFriendPropRef(id);
 
@@ -1366,7 +1366,7 @@ void Settings::setAutoConferenceInvite(const ToxPk& id, bool accept)
 
 QString Settings::getContactNote(const ToxPk& id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     auto it = friendLst.find(id.getByteArray());
     if (it != friendLst.end())
@@ -1379,7 +1379,7 @@ void Settings::setContactNote(const ToxPk& id, const QString& note)
 {
     bool updated = false;
     {
-        QMutexLocker<QRecursiveMutex> locker{&bigLock};
+        const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
         auto& frnd = getOrInsertFriendPropRef(id);
 
@@ -1395,7 +1395,7 @@ void Settings::setContactNote(const ToxPk& id, const QString& note)
 
 QString Settings::getGlobalAutoAcceptDir() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return globalAutoAcceptDir;
 }
 
@@ -1408,7 +1408,7 @@ void Settings::setGlobalAutoAcceptDir(const QString& newValue)
 
 size_t Settings::getMaxAutoAcceptSize() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return autoAcceptMaxSize;
 }
 
@@ -1421,7 +1421,7 @@ void Settings::setMaxAutoAcceptSize(size_t size)
 
 const QFont& Settings::getChatMessageFont() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&bigLock);
+    const QMutexLocker<QRecursiveMutex> locker(&bigLock);
     return chatMessageFont;
 }
 
@@ -1436,7 +1436,7 @@ void Settings::setWidgetData(const QString& uniqueName, const QByteArray& data)
 {
     bool updated = false;
     {
-        QMutexLocker<QRecursiveMutex> locker{&bigLock};
+        const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
         if (!widgetSettings.contains(uniqueName) || widgetSettings[uniqueName] != data) {
             widgetSettings[uniqueName] = data;
@@ -1450,13 +1450,13 @@ void Settings::setWidgetData(const QString& uniqueName, const QByteArray& data)
 
 QByteArray Settings::getWidgetData(const QString& uniqueName) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return widgetSettings.value(uniqueName);
 }
 
 QString Settings::getSmileyPack() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return smileyPack;
 }
 
@@ -1469,7 +1469,7 @@ void Settings::setSmileyPack(const QString& value)
 
 int Settings::getEmojiFontPointSize() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return emojiFontPointSize;
 }
 
@@ -1482,7 +1482,7 @@ void Settings::setEmojiFontPointSize(int value)
 
 const QString& Settings::getTimestampFormat() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return timestampFormat;
 }
 
@@ -1495,7 +1495,7 @@ void Settings::setTimestampFormat(const QString& format)
 
 const QString& Settings::getDateFormat() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return dateFormat;
 }
 
@@ -1508,7 +1508,7 @@ void Settings::setDateFormat(const QString& format)
 
 Settings::StyleType Settings::getStylePreference() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return stylePreference;
 }
 
@@ -1521,7 +1521,7 @@ void Settings::setStylePreference(StyleType newValue)
 
 QByteArray Settings::getWindowGeometry() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return windowGeometry;
 }
 
@@ -1534,7 +1534,7 @@ void Settings::setWindowGeometry(const QByteArray& value)
 
 QByteArray Settings::getWindowState() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return windowState;
 }
 
@@ -1547,7 +1547,7 @@ void Settings::setWindowState(const QByteArray& value)
 
 bool Settings::getCheckUpdates() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return checkUpdates;
 }
 
@@ -1560,7 +1560,7 @@ void Settings::setCheckUpdates(bool newValue)
 
 bool Settings::getNotify() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return notify;
 }
 
@@ -1573,7 +1573,7 @@ void Settings::setNotify(bool newValue)
 
 bool Settings::getShowWindow() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return showWindow;
 }
 
@@ -1586,7 +1586,7 @@ void Settings::setShowWindow(bool newValue)
 
 bool Settings::getDesktopNotify() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return desktopNotify;
 }
 
@@ -1599,7 +1599,7 @@ void Settings::setDesktopNotify(bool newValue)
 
 bool Settings::getNotifySystemBackend() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return notifySystemBackend;
 }
 
@@ -1612,7 +1612,7 @@ void Settings::setNotifySystemBackend(bool newValue)
 
 QByteArray Settings::getSplitterState() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return splitterState;
 }
 
@@ -1625,7 +1625,7 @@ void Settings::setSplitterState(const QByteArray& value)
 
 QByteArray Settings::getDialogGeometry() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return dialogGeometry;
 }
 
@@ -1638,7 +1638,7 @@ void Settings::setDialogGeometry(const QByteArray& value)
 
 QByteArray Settings::getDialogSplitterState() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return dialogSplitterState;
 }
 
@@ -1651,7 +1651,7 @@ void Settings::setDialogSplitterState(const QByteArray& value)
 
 QByteArray Settings::getDialogSettingsGeometry() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return dialogSettingsGeometry;
 }
 
@@ -1664,7 +1664,7 @@ void Settings::setDialogSettingsGeometry(const QByteArray& value)
 
 bool Settings::getMinimizeOnClose() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return minimizeOnClose;
 }
 
@@ -1677,7 +1677,7 @@ void Settings::setMinimizeOnClose(bool newValue)
 
 bool Settings::getTypingNotification() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return typingNotification;
 }
 
@@ -1690,7 +1690,7 @@ void Settings::setTypingNotification(bool enabled)
 
 QStringList Settings::getBlockList() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return blockList;
 }
 
@@ -1703,7 +1703,7 @@ void Settings::setBlockList(const QStringList& blist)
 
 QString Settings::getInDev() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return inDev;
 }
 
@@ -1716,7 +1716,7 @@ void Settings::setInDev(const QString& deviceSpecifier)
 
 bool Settings::getAudioInDevEnabled() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&bigLock);
+    const QMutexLocker<QRecursiveMutex> locker(&bigLock);
     return audioInDevEnabled;
 }
 
@@ -1729,7 +1729,7 @@ void Settings::setAudioInDevEnabled(bool enabled)
 
 qreal Settings::getAudioInGainDecibel() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return audioInGainDecibel;
 }
 
@@ -1742,7 +1742,7 @@ void Settings::setAudioInGainDecibel(qreal dB)
 
 qreal Settings::getAudioThreshold() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return audioThreshold;
 }
 
@@ -1755,7 +1755,7 @@ void Settings::setAudioThreshold(qreal percent)
 
 QString Settings::getVideoDev() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return videoDev;
 }
 
@@ -1768,7 +1768,7 @@ void Settings::setVideoDev(const QString& deviceSpecifier)
 
 QString Settings::getOutDev() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return outDev;
 }
 
@@ -1781,7 +1781,7 @@ void Settings::setOutDev(const QString& deviceSpecifier)
 
 bool Settings::getAudioOutDevEnabled() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&bigLock);
+    const QMutexLocker<QRecursiveMutex> locker(&bigLock);
     return audioOutDevEnabled;
 }
 
@@ -1794,7 +1794,7 @@ void Settings::setAudioOutDevEnabled(bool enabled)
 
 int Settings::getOutVolume() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return outVolume;
 }
 
@@ -1820,7 +1820,7 @@ void Settings::setAudioBitrate(int bitrate)
 
 QRect Settings::getScreenRegion() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&bigLock);
+    const QMutexLocker<QRecursiveMutex> locker(&bigLock);
     return screenRegion;
 }
 
@@ -1833,7 +1833,7 @@ void Settings::setScreenRegion(const QRect& value)
 
 bool Settings::getScreenGrabbed() const
 {
-    QMutexLocker<QRecursiveMutex> locker(&bigLock);
+    const QMutexLocker<QRecursiveMutex> locker(&bigLock);
     return screenGrabbed;
 }
 
@@ -1846,7 +1846,7 @@ void Settings::setScreenGrabbed(bool value)
 
 QRect Settings::getCamVideoRes() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return camVideoRes;
 }
 
@@ -1859,7 +1859,7 @@ void Settings::setCamVideoRes(QRect newValue)
 
 float Settings::getCamVideoFPS() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return camVideoFPS;
 }
 
@@ -1872,7 +1872,7 @@ void Settings::setCamVideoFPS(float newValue)
 
 void Settings::updateFriendAddress(const QString& newAddr)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     auto key = ToxPk(newAddr);
     auto& frnd = getOrInsertFriendPropRef(key);
     frnd.addr = newAddr;
@@ -1880,7 +1880,7 @@ void Settings::updateFriendAddress(const QString& newAddr)
 
 QString Settings::getFriendAlias(const ToxPk& id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     auto it = friendLst.find(id.getByteArray());
     if (it != friendLst.end())
         return it->alias;
@@ -1890,14 +1890,14 @@ QString Settings::getFriendAlias(const ToxPk& id) const
 
 void Settings::setFriendAlias(const ToxPk& id, const QString& alias)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     auto& frnd = getOrInsertFriendPropRef(id);
     frnd.alias = alias;
 }
 
 int Settings::getFriendCircleID(const ToxPk& id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     auto it = friendLst.find(id.getByteArray());
     if (it != friendLst.end())
         return it->circleID;
@@ -1907,14 +1907,14 @@ int Settings::getFriendCircleID(const ToxPk& id) const
 
 void Settings::setFriendCircleID(const ToxPk& id, int circleID)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     auto& frnd = getOrInsertFriendPropRef(id);
     frnd.circleID = circleID;
 }
 
 QDateTime Settings::getFriendActivity(const ToxPk& id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     auto it = friendLst.find(id.getByteArray());
     if (it != friendLst.end())
         return it->activity;
@@ -1924,7 +1924,7 @@ QDateTime Settings::getFriendActivity(const ToxPk& id) const
 
 void Settings::setFriendActivity(const ToxPk& id, const QDateTime& activity)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     auto& frnd = getOrInsertFriendPropRef(id);
     frnd.activity = activity;
 }
@@ -1937,13 +1937,13 @@ void Settings::saveFriendSettings(const ToxPk& id)
 
 void Settings::removeFriendSettings(const ToxPk& id)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     friendLst.remove(id.getByteArray());
 }
 
 bool Settings::getCompactLayout() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return compactLayout;
 }
 
@@ -1956,7 +1956,7 @@ void Settings::setCompactLayout(bool value)
 
 Settings::FriendListSortingMode Settings::getFriendSortingMode() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return sortingMode;
 }
 
@@ -1969,7 +1969,7 @@ void Settings::setFriendSortingMode(FriendListSortingMode mode)
 
 bool Settings::getSeparateWindow() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return separateWindow;
 }
 
@@ -1982,7 +1982,7 @@ void Settings::setSeparateWindow(bool value)
 
 bool Settings::getDontGroupWindows() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return dontGroupWindows;
 }
 
@@ -1995,7 +1995,7 @@ void Settings::setDontGroupWindows(bool value)
 
 bool Settings::getConferencePosition() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return conferencePosition;
 }
 
@@ -2021,7 +2021,7 @@ void Settings::setShowIdenticons(bool value)
 
 bool Settings::getImagePreview() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return imagePreview;
 }
 
@@ -2034,26 +2034,26 @@ void Settings::setImagePreview(bool newValue)
 
 int Settings::getCircleCount() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return circleLst.size();
 }
 
 QString Settings::getCircleName(int id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return circleLst[id].name;
 }
 
 void Settings::setCircleName(int id, const QString& name)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     circleLst[id].name = name;
     savePersonal();
 }
 
 int Settings::addCircle(const QString& name)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     circleProp cp;
     cp.expanded = false;
@@ -2070,19 +2070,19 @@ int Settings::addCircle(const QString& name)
 
 bool Settings::getCircleExpanded(int id) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return circleLst[id].expanded;
 }
 
 void Settings::setCircleExpanded(int id, bool expanded)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     circleLst[id].expanded = expanded;
 }
 
 bool Settings::addFriendRequest(const QString& friendAddress, const QString& message)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     for (auto queued : friendRequests) {
         if (queued.address == friendAddress) {
@@ -2103,7 +2103,7 @@ bool Settings::addFriendRequest(const QString& friendAddress, const QString& mes
 
 unsigned int Settings::getUnreadFriendRequests() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     unsigned int unreadFriendRequests = 0;
     for (auto request : friendRequests)
         if (!request.read)
@@ -2114,19 +2114,19 @@ unsigned int Settings::getUnreadFriendRequests() const
 
 Settings::Request Settings::getFriendRequest(int index) const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return friendRequests.at(index);
 }
 
 int Settings::getFriendRequestSize() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return friendRequests.size();
 }
 
 void Settings::clearUnreadFriendRequests()
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
     for (auto& request : friendRequests)
         request.read = true;
@@ -2134,13 +2134,13 @@ void Settings::clearUnreadFriendRequests()
 
 void Settings::removeFriendRequest(int index)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     friendRequests.removeAt(index);
 }
 
 void Settings::readFriendRequest(int index)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     friendRequests[index].read = true;
 }
 
@@ -2156,7 +2156,7 @@ int Settings::removeCircle(int id)
 
 int Settings::getThemeColor() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return themeColor;
 }
 
@@ -2169,7 +2169,7 @@ void Settings::setThemeColor(int value)
 
 bool Settings::getAutoLogin() const
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     return autoLogin;
 }
 
@@ -2200,9 +2200,9 @@ bool Settings::getEnableConferencesColor() const
  */
 void Settings::createPersonal(const Paths& paths, const QString& basename)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
-    QString path = paths.getSettingsDirPath() + QDir::separator() + basename + ".ini";
+    const QString path = paths.getSettingsDirPath() + QDir::separator() + basename + ".ini";
     qDebug() << "Creating new profile settings in" << path;
 
     QSettings ps(path, QSettings::IniFormat);
@@ -2218,10 +2218,10 @@ void Settings::createPersonal(const Paths& paths, const QString& basename)
  */
 void Settings::createSettingsDir()
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
 
-    QString dir = paths.getSettingsDirPath();
-    QDir directory(dir);
+    const QString dir = paths.getSettingsDirPath();
+    const QDir directory(dir);
     if (!directory.exists() && !directory.mkpath(directory.absolutePath()))
         qCritical() << "Error while creating directory" << dir;
 }
@@ -2236,7 +2236,7 @@ void Settings::sync()
         return;
     }
 
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     qApp->processEvents();
 }
 
@@ -2269,7 +2269,7 @@ ICoreSettings::ProxyType Settings::fixInvalidProxyType(ICoreSettings::ProxyType 
 template <typename T>
 bool Settings::setVal(T& savedVal, T newVal)
 {
-    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
     if (savedVal != newVal) {
         savedVal = newVal;
         return true;

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -97,7 +97,7 @@ void SettingsSerializer::beginGroup(const QString& prefix)
 {
     if (prefix.isEmpty())
         endGroup();
-    int index = groups.indexOf(prefix);
+    const int index = groups.indexOf(prefix);
     if (index >= 0) {
         group = index;
     } else {
@@ -162,7 +162,7 @@ void SettingsSerializer::setValue(const QString& key, const QVariant& value)
     if (v) {
         v->value = value;
     } else {
-        Value nv{group, array, arrayIndex, key, value};
+        const Value nv{group, array, arrayIndex, key, value};
         if (array >= 0)
             arrays[array].values.append(values.size());
         values.append(nv);
@@ -184,7 +184,7 @@ const SettingsSerializer::Value* SettingsSerializer::findValue(const QString& ke
             if (a.group != group)
                 continue;
 
-            for (int vi : a.values) {
+            for (const int vi : a.values) {
                 const Value& v = values[vi];
                 if (v.arrayIndex == arrayIndex && v.key == key)
                     return &v;
@@ -246,7 +246,7 @@ void SettingsSerializer::save()
     stream.setVersion(QDataStream::Qt_5_0);
 
     // prevent signed overflow and the associated warning
-    int numGroups = std::max(QStringList::size_type(0), groups.size());
+    const int numGroups = std::max(QStringList::size_type(0), groups.size());
     for (int g = -1; g < numGroups; ++g) {
         // Save the group name, if any
         if (g != -1) {
@@ -264,7 +264,7 @@ void SettingsSerializer::save()
             writeStream(stream, a.name.toUtf8());
             writeStream(stream, vintToData(a.size));
 
-            for (int vi : a.values) {
+            for (const int vi : a.values) {
                 const Value& v = values[vi];
                 writeStream(stream, RecordTag::ArrayValue);
                 writeStream(stream, vintToData(values[vi].arrayIndex));
@@ -359,7 +359,7 @@ void SettingsSerializer::readSerialized()
                 qWarning("The personal save file is corrupted!");
                 return;
             }
-            int size = dataToVInt(sizeData);
+            const int size = dataToVInt(sizeData);
             arrays[array].size = qMax(size, arrays[array].size);
         } else if (tag == RecordTag::ArrayValue) {
             QByteArray indexData;
@@ -393,18 +393,18 @@ void SettingsSerializer::readIni()
         if (!s.group().isEmpty())
             beginGroup(s.group());
 
-        for (QString k : s.childKeys()) {
+        for (const QString& k : s.childKeys()) {
             setValue(k, s.value(k));
         }
 
         // Add all groups
         gstack.push_back(QString());
-        for (QString g : s.childGroups())
+        for (const QString& g : s.childGroups())
             gstack.push_back(g);
 
         // Visit the next group, if any
         while (!gstack.isEmpty()) {
-            QString g = gstack.takeLast();
+            const QString g = gstack.takeLast();
             if (g.isEmpty()) {
                 if (gstack.isEmpty())
                     break;
@@ -421,7 +421,7 @@ void SettingsSerializer::readIni()
     // and its elements are all groups matching the pattern "[<group>/]<arrayName>/<arrayIndex>"
 
     // Find groups that only have 1 key
-    std::unique_ptr<int[]> groupSizes{new int[groups.size()]};
+    const std::unique_ptr<int[]> groupSizes{new int[groups.size()]};
     memset(groupSizes.get(), 0, static_cast<size_t>(groups.size()) * sizeof(int));
     for (const Value& v : values) {
         if (v.group < 0 || v.group > groups.size())
@@ -444,7 +444,7 @@ void SettingsSerializer::readIni()
 
         Array a;
         a.size = v.value.toInt();
-        int slashIndex = groups[static_cast<int>(v.group)].lastIndexOf('/');
+        const int slashIndex = groups[static_cast<int>(v.group)].lastIndexOf('/');
         if (slashIndex == -1) {
             a.group = -1;
             a.name = groups[static_cast<int>(v.group)];
@@ -475,7 +475,7 @@ void SettingsSerializer::readIni()
             if (!groups[g].startsWith(arrayPrefix))
                 continue;
             bool ok;
-            int groupArrayIndex = groups[g].mid(arrayPrefix.size()).toInt(&ok);
+            const int groupArrayIndex = groups[g].mid(arrayPrefix.size()).toInt(&ok);
             if (!ok)
                 continue;
             groupsToKill.append(g);
@@ -500,7 +500,7 @@ void SettingsSerializer::readIni()
     // Clean up spurious array element groups
     std::sort(std::begin(groupsToKill), std::end(groupsToKill), std::greater_equal<int>());
 
-    for (int g : groupsToKill) {
+    for (const int g : groupsToKill) {
         if (groupSizes[static_cast<size_t>(g)])
             continue;
 
@@ -534,7 +534,7 @@ void SettingsSerializer::removeGroup(int group_)
 void SettingsSerializer::writePackedVariant(QDataStream& stream, const QVariant& v)
 {
     assert(v.canConvert(QMetaType(QMetaType::QString)));
-    QString str = v.toString();
+    const QString str = v.toString();
     if (str == "true")
         writeStream(stream, QString("1"));
     else if (str == "false")

--- a/src/persistence/smileypack.cpp
+++ b/src/persistence/smileypack.cpp
@@ -129,9 +129,9 @@ QString SmileyPack::getAsRichText(const QString& key)
 
 void SmileyPack::cleanupIconsCache()
 {
-    QMutexLocker<QMutex> locker(&loadingMutex);
+    const QMutexLocker<QMutex> locker(&loadingMutex);
     for (auto it = cachedIcon.begin(); it != cachedIcon.end();) {
-        std::shared_ptr<QIcon>& icon = it->second;
+        const std::shared_ptr<QIcon>& icon = it->second;
         if (icon.use_count() == 1) {
             it = cachedIcon.erase(it);
         } else {
@@ -170,8 +170,8 @@ QList<QPair<QString, QString>> SmileyPack::listSmileyPacks(const QStringList& pa
         for (const QString& subdirectory : dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot)) {
             dir.cd(subdirectory);
             if (dir.exists(EMOTICONS_FILE_NAME)) {
-                QString absPath = dir.absolutePath() + QDir::separator() + EMOTICONS_FILE_NAME;
-                QPair<QString, QString> p{dir.dirName(), absPath};
+                const QString absPath = dir.absolutePath() + QDir::separator() + EMOTICONS_FILE_NAME;
+                const QPair<QString, QString> p{dir.dirName(), absPath};
                 if (!smileyPacks.contains(p)) {
                     smileyPacks.append(p);
                 }
@@ -191,7 +191,7 @@ QList<QPair<QString, QString>> SmileyPack::listSmileyPacks(const QStringList& pa
  */
 void SmileyPack::load(const QString& filename)
 {
-    QMutexLocker<QMutex> locker(&loadingMutex);
+    const QMutexLocker<QMutex> locker(&loadingMutex);
 
     QFile xmlFile(filename);
     if (!xmlFile.exists() || !xmlFile.open(QIODevice::ReadOnly)) {
@@ -219,7 +219,7 @@ void SmileyPack::load(const QString& filename)
      */
 
     path = QFileInfo(filename).absolutePath();
-    QDomNodeList emoticonElements = doc.elementsByTagName("emoticon");
+    const QDomNodeList emoticonElements = doc.elementsByTagName("emoticon");
     const QString itemName = QStringLiteral("file");
     const QString childName = QStringLiteral("string");
     const int iconsCount = emoticonElements.size();
@@ -228,13 +228,13 @@ void SmileyPack::load(const QString& filename)
     cachedIcon.clear();
 
     for (int i = 0; i < iconsCount; ++i) {
-        QDomNode node = emoticonElements.at(i);
-        QString iconName = node.attributes().namedItem(itemName).nodeValue();
-        QString iconPath = QDir{path}.filePath(iconName);
+        const QDomNode node = emoticonElements.at(i);
+        const QString iconName = node.attributes().namedItem(itemName).nodeValue();
+        const QString iconPath = QDir{path}.filePath(iconName);
         QDomElement stringElement = node.firstChildElement(childName);
         QStringList emoticonList;
         while (!stringElement.isNull()) {
-            QString emoticon = singleCharAsciiEmoticon(
+            const QString emoticon = singleCharAsciiEmoticon(
                 stringElement.text().replace("<", "&lt;").replace(">", "&gt;"));
             emoticonToPath.insert(emoticon, iconPath);
             emoticonList.append(emoticon);
@@ -291,14 +291,14 @@ void SmileyPack::constructRegex()
  */
 QString SmileyPack::smileyfied(const QString& msg)
 {
-    QMutexLocker<QMutex> locker(&loadingMutex);
+    const QMutexLocker<QMutex> locker(&loadingMutex);
     QString result(msg);
 
     int replaceDiff = 0;
     for (const auto& match : smilify.globalMatch(result)) {
-        int startPos = match.capturedStart();
-        int keyLength = match.capturedLength();
-        QString imgRichText = SmileyPack::getAsRichText(match.captured());
+        const int startPos = match.capturedStart();
+        const int keyLength = match.capturedLength();
+        const QString imgRichText = SmileyPack::getAsRichText(match.captured());
         result.replace(startPos + replaceDiff, keyLength, imgRichText);
         replaceDiff += imgRichText.length() - keyLength;
     }
@@ -311,7 +311,7 @@ QString SmileyPack::smileyfied(const QString& msg)
  */
 QList<QStringList> SmileyPack::getEmoticons() const
 {
-    QMutexLocker<QMutex> locker(&loadingMutex);
+    const QMutexLocker<QMutex> locker(&loadingMutex);
     return emoticons;
 }
 
@@ -322,7 +322,7 @@ QList<QStringList> SmileyPack::getEmoticons() const
  */
 std::shared_ptr<QIcon> SmileyPack::getAsIcon(const QString& emoticon) const
 {
-    QMutexLocker<QMutex> locker(&loadingMutex);
+    const QMutexLocker<QMutex> locker(&loadingMutex);
     if (cachedIcon.contains(emoticon)) {
         return cachedIcon[emoticon];
     }

--- a/src/platform/autorun_xdg.cpp
+++ b/src/platform/autorun_xdg.cpp
@@ -17,7 +17,7 @@
 namespace {
 QString getAutostartDirPath()
 {
-    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    const QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     QString config = env.value("XDG_CONFIG_HOME");
     if (config.isEmpty())
         config = QDir::homePath() + "/" + ".config";
@@ -48,7 +48,7 @@ inline QString profileRunCommand(const Settings& settings)
 
 bool Platform::setAutorun(const Settings& settings, bool on)
 {
-    QString dirPath = getAutostartDirPath();
+    const QString dirPath = getAutostartDirPath();
     QFile desktop(getAutostartFilePath(settings, dirPath));
     if (on) {
         if (!QDir().mkpath(dirPath) || !desktop.open(QFile::WriteOnly | QFile::Truncate))

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -115,7 +115,7 @@ QVector<VideoMode> v4l2::getDeviceModes(QString devName)
     QVector<VideoMode> modes;
 
     int error = 0;
-    int fd = deviceOpen(devName, &error);
+    const int fd = deviceOpen(devName, &error);
     if (fd < 0 || error != 0) {
         return modes;
     }
@@ -155,7 +155,7 @@ QVector<VideoMode> v4l2::getDeviceModes(QString devName)
                 rates.append(0.0f);
             }
 
-            for (float rate : rates) {
+            for (const float rate : rates) {
                 mode.fps = rate;
                 if (!modes.contains(mode)) {
                     modes.append(mode);
@@ -184,9 +184,9 @@ QVector<QPair<QString, QString>> v4l2::getDeviceList()
             deviceFiles += QString("/dev/") + QString::fromUtf8(e->d_name);
     closedir(dir);
 
-    for (QString file : deviceFiles) {
+    for (const QString& file : deviceFiles) {
         const std::string filePath = file.toStdString();
-        int fd = open(filePath.c_str(), O_RDWR);
+        const int fd = open(filePath.c_str(), O_RDWR);
         if (fd < 0) {
             continue;
         }

--- a/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
+++ b/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
@@ -218,7 +218,7 @@ QString imageDataFieldName(const NotificationSpecVersion& specVersion)
 const QFile* getIconFile(const QImage& image, QMutex& iconMutex,
                          std::unique_ptr<QTemporaryFile>& iconFile)
 {
-    QMutexLocker<QMutex> lock(&iconMutex);
+    const QMutexLocker<QMutex> lock(&iconMutex);
     const qint64 iconKey = image.cacheKey();
     iconFile = std::make_unique<QTemporaryFile>(
         QStringList{QDir::tempPath(),

--- a/src/platform/timer_x11.cpp
+++ b/src/platform/timer_x11.cpp
@@ -25,7 +25,7 @@ uint32_t Platform::getIdleTime()
     }
 
     int32_t x11event = 0, x11error = 0;
-    static int32_t hasExtension = XScreenSaverQueryExtension(display, &x11event, &x11error);
+    static const int32_t hasExtension = XScreenSaverQueryExtension(display, &x11event, &x11error);
     if (hasExtension) {
         XScreenSaverInfo* info = XScreenSaverAllocInfo();
         if (info) {

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -114,7 +114,7 @@ CameraDevice::CameraDevice(QString devName_, AVFormatContext* context_)
 
 CameraDevice* CameraDevice::open(QString devName, AVDictionary** options)
 {
-    QMutexLocker<QMutex> lock(&openDeviceLock);
+    const QMutexLocker<QMutex> lock(&openDeviceLock);
     CameraDevice* dev = openDevices.value(devName);
     if (dev) {
         return dev;
@@ -208,7 +208,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
             screen.setHeight(mode.height);
         } else {
             QScreen* defaultScreen = QApplication::primaryScreen();
-            qreal pixRatio = defaultScreen->devicePixelRatio();
+            const qreal pixRatio = defaultScreen->devicePixelRatio();
 
             screen = defaultScreen->size();
             // Workaround https://trac.ffmpeg.org/ticket/4574 by choping 1 px bottom and right
@@ -397,7 +397,7 @@ QVector<QPair<QString, QString>> CameraDevice::getDeviceList()
     if (idesktopFormat) {
         if (QString::fromUtf8(idesktopFormat->name) == QStringLiteral("x11grab")) {
             QString dev = "x11grab#";
-            QByteArray display = qgetenv("DISPLAY");
+            const QByteArray display = qgetenv("DISPLAY");
 
             if (display.isNull())
                 dev += ":0";
@@ -459,12 +459,12 @@ QVector<VideoMode> CameraDevice::getScreenModes()
     QVector<VideoMode> result;
 
     std::for_each(screens.begin(), screens.end(), [&result](QScreen* s) {
-        QRect rect = s->geometry();
-        QPoint p = rect.topLeft();
-        qreal pixRatio = s->devicePixelRatio();
+        const QRect rect = s->geometry();
+        const QPoint p = rect.topLeft();
+        const qreal pixRatio = s->devicePixelRatio();
 
-        VideoMode mode(rect.width() * pixRatio, rect.height() * pixRatio, p.x() * pixRatio,
-                       p.y() * pixRatio);
+        const VideoMode mode(rect.width() * pixRatio, rect.height() * pixRatio, p.x() * pixRatio,
+                             p.y() * pixRatio);
         result.push_back(mode);
     });
 
@@ -541,7 +541,7 @@ bool CameraDevice::betterPixelFormat(uint32_t a, uint32_t b)
  */
 bool CameraDevice::getDefaultInputFormat()
 {
-    QMutexLocker<QMutex> locker(&iformatLock);
+    const QMutexLocker<QMutex> locker(&iformatLock);
     if (iformat) {
         return true;
     }

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -234,8 +234,8 @@ CameraSource::CameraSource(Settings& settings_)
  */
 void CameraSource::setupDefault()
 {
-    QString deviceName_ = CameraDevice::getDefaultDeviceName(settings);
-    bool isScreen = CameraDevice::isScreen(deviceName_);
+    const QString deviceName_ = CameraDevice::getDefaultDeviceName(settings);
+    const bool isScreen = CameraDevice::isScreen(deviceName_);
     VideoMode mode_ = VideoMode(settings.getScreenRegion());
     if (!isScreen) {
         mode_ = VideoMode(settings.getCamVideoRes());
@@ -257,7 +257,7 @@ void CameraSource::setupDevice(const QString& deviceName_, const VideoMode& mode
         return;
     }
 
-    QWriteLocker locker{&deviceMutex};
+    const QWriteLocker locker{&deviceMutex};
 
     if (deviceName_ == deviceName && mode_ == mode) {
         return;
@@ -265,7 +265,7 @@ void CameraSource::setupDevice(const QString& deviceName_, const VideoMode& mode
 
     if (subscriptions != 0) {
         // To force close, ignoring optimization
-        int subs = subscriptions;
+        const int subs = subscriptions;
         subscriptions = 0;
         closeDevice();
         subscriptions = subs;
@@ -288,7 +288,7 @@ bool CameraSource::isNone() const
 CameraSource::~CameraSource()
 {
     QWriteLocker locker{&streamMutex};
-    QWriteLocker locker2{&deviceMutex};
+    const QWriteLocker locker2{&deviceMutex};
 
     // Stop the device thread
     deviceThread->exit(0);
@@ -327,7 +327,7 @@ CameraSource::~CameraSource()
 
 void CameraSource::subscribe()
 {
-    QWriteLocker locker{&deviceMutex};
+    const QWriteLocker locker{&deviceMutex};
 
     ++subscriptions;
     openDevice();
@@ -335,7 +335,7 @@ void CameraSource::subscribe()
 
 void CameraSource::unsubscribe()
 {
-    QWriteLocker locker{&deviceMutex};
+    const QWriteLocker locker{&deviceMutex};
 
     --subscriptions;
     if (subscriptions == 0) {
@@ -354,7 +354,7 @@ void CameraSource::openDevice()
         return;
     }
 
-    QWriteLocker locker{&streamMutex};
+    const QWriteLocker locker{&streamMutex};
     if (subscriptions == 0) {
         return;
     }
@@ -472,7 +472,7 @@ void CameraSource::closeDevice()
         return;
     }
 
-    QWriteLocker locker{&streamMutex};
+    const QWriteLocker locker{&streamMutex};
     if (subscriptions != 0) {
         return;
     }
@@ -526,8 +526,8 @@ void CameraSource::stream()
 #else
 
         // Forward packets to the decoder and grab the decoded frame
-        bool isVideo = packet.stream_index == videoStreamIndex;
-        bool readyToReceive = isVideo && !avcodec_send_packet(cctx, &packet);
+        const bool isVideo = packet.stream_index == videoStreamIndex;
+        const bool readyToReceive = isVideo && !avcodec_send_packet(cctx, &packet);
 
         if (readyToReceive) {
             AVFrame* frame = av_frame_alloc();
@@ -544,7 +544,7 @@ void CameraSource::stream()
 
     forever
     {
-        QReadLocker locker{&streamMutex};
+        const QReadLocker locker{&streamMutex};
 
         // Exit if device is no longer valid
         if (!device) {

--- a/src/video/corevideosource.cpp
+++ b/src/video/corevideosource.cpp
@@ -49,11 +49,11 @@ void CoreVideoSource::pushFrame(const vpx_image_t* vpxFrame)
     if (stopped)
         return;
 
-    QMutexLocker<QMutex> locker(&biglock);
+    const QMutexLocker<QMutex> locker(&biglock);
 
-    std::shared_ptr<VideoFrame> vframe;
-    int width = vpxFrame->d_w;
-    int height = vpxFrame->d_h;
+    const std::shared_ptr<VideoFrame> vframe;
+    const int width = vpxFrame->d_w;
+    const int height = vpxFrame->d_h;
 
     if (subscribers <= 0)
         return;
@@ -66,7 +66,7 @@ void CoreVideoSource::pushFrame(const vpx_image_t* vpxFrame)
     avFrame->height = height;
     avFrame->format = AV_PIX_FMT_YUV420P;
 
-    int bufSize =
+    const int bufSize =
         av_image_alloc(avFrame->data, avFrame->linesize, width, height,
                        static_cast<AVPixelFormat>(AV_PIX_FMT_YUV420P), VideoFrame::dataAlignment);
 
@@ -76,10 +76,10 @@ void CoreVideoSource::pushFrame(const vpx_image_t* vpxFrame)
     }
 
     for (int i = 0; i < 3; ++i) {
-        int dstStride = avFrame->linesize[i];
-        int srcStride = vpxFrame->stride[i];
-        int minStride = std::min(dstStride, srcStride);
-        int size = (i == 0) ? height : height / 2;
+        const int dstStride = avFrame->linesize[i];
+        const int srcStride = vpxFrame->stride[i];
+        const int minStride = std::min(dstStride, srcStride);
+        const int size = (i == 0) ? height : height / 2;
 
         for (int j = 0; j < size; ++j) {
             uint8_t* dst = avFrame->data[i] + dstStride * j;
@@ -93,7 +93,7 @@ void CoreVideoSource::pushFrame(const vpx_image_t* vpxFrame)
 
 void CoreVideoSource::subscribe()
 {
-    QMutexLocker<QMutex> locker(&biglock);
+    const QMutexLocker<QMutex> locker(&biglock);
     ++subscribers;
 }
 
@@ -117,7 +117,7 @@ void CoreVideoSource::unsubscribe()
  */
 void CoreVideoSource::setDeleteOnClose(bool newstate)
 {
-    QMutexLocker<QMutex> locker(&biglock);
+    const QMutexLocker<QMutex> locker(&biglock);
     deleteOnClose = newstate;
 }
 
@@ -129,13 +129,13 @@ void CoreVideoSource::setDeleteOnClose(bool newstate)
  */
 void CoreVideoSource::stopSource()
 {
-    QMutexLocker<QMutex> locker(&biglock);
+    const QMutexLocker<QMutex> locker(&biglock);
     stopped = true;
     emit sourceStopped();
 }
 
 void CoreVideoSource::restartSource()
 {
-    QMutexLocker<QMutex> locker(&biglock);
+    const QMutexLocker<QMutex> locker(&biglock);
     stopped = false;
 }

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -122,14 +122,14 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, Settings& s
         connect(selfVideoSurface, &VideoSurface::ratioChanged, this, &NetCamView::updateRatio);
 
     connections += connect(videoSurface, &VideoSurface::boundaryChanged, this, [this]() {
-        QRect boundingRect = videoSurface->getBoundingRect();
+        const QRect boundingRect = videoSurface->getBoundingRect();
         updateFrameSize(boundingRect.size());
         selfFrame->setBoundary(boundingRect);
     });
 
     connections += connect(videoSurface, &VideoSurface::ratioChanged, this, [this]() {
         selfFrame->setMinimumWidth(selfFrame->minimumHeight() * selfVideoSurface->getRatio());
-        QRect boundingRect = videoSurface->getBoundingRect();
+        const QRect boundingRect = videoSurface->getBoundingRect();
         updateFrameSize(boundingRect.size());
         selfFrame->resetBoundary(boundingRect);
     });
@@ -143,13 +143,13 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, Settings& s
                                    videoSurface->setAvatar(pixmap);
                            });
 
-    QRect videoSize = settings.getCamVideoRes();
+    const QRect videoSize = settings.getCamVideoRes();
     qDebug() << "SIZER" << videoSize;
 }
 
 NetCamView::~NetCamView()
 {
-    for (QMetaObject::Connection conn : connections)
+    for (const QMetaObject::Connection& conn : connections)
         disconnect(conn);
 }
 
@@ -209,9 +209,9 @@ void NetCamView::updateFrameSize(QSize size)
 
 QSize NetCamView::getSurfaceMinSize()
 {
-    QSize surfaceSize = videoSurface->minimumSize();
-    QSize buttonSize = toggleMessagesButton->size();
-    QSize panelSize(0, 45);
+    const QSize surfaceSize = videoSurface->minimumSize();
+    const QSize buttonSize = toggleMessagesButton->size();
+    const QSize panelSize(0, 45);
 
     return surfaceSize + buttonSize + panelSize;
 }
@@ -325,7 +325,7 @@ void NetCamView::updateButtonState(QPushButton* btn, bool active)
 
 void NetCamView::keyPressEvent(QKeyEvent* event)
 {
-    int key = event->key();
+    const int key = event->key();
     if (key == Qt::Key_Escape && isFullScreen()) {
         exitFullScreen();
     }

--- a/src/video/videosurface.cpp
+++ b/src/video/videosurface.cpp
@@ -136,7 +136,7 @@ void VideoSurface::onNewFrameAvailable(const std::shared_ptr<VideoFrame>& newFra
     newSize = lastFrame->getSourceDimensions().size();
     unlock();
 
-    float newRatio = getSizeRatio(newSize);
+    const float newRatio = getSizeRatio(newSize);
 
     if (!qFuzzyCompare(newRatio, ratio) && isVisible()) {
         ratio = newRatio;
@@ -163,7 +163,7 @@ void VideoSurface::paintEvent(QPaintEvent* event)
     QPainter painter(this);
     painter.fillRect(painter.viewport(), Qt::black);
     if (lastFrame) {
-        QImage frame = lastFrame->toQImage(rect().size());
+        const QImage frame = lastFrame->toQImage(rect().size());
         if (frame.isNull())
             lastFrame.reset();
         painter.drawImage(boundingRect, frame, frame.rect(), Qt::NoFormatConversion);
@@ -201,8 +201,8 @@ void VideoSurface::recalculateBounds()
     } else {
         QPoint pos;
         QSize size;
-        QSize usableSize = contentsRect().size();
-        int possibleWidth = usableSize.height() * ratio;
+        const QSize usableSize = contentsRect().size();
+        const int possibleWidth = usableSize.height() * ratio;
 
         if (possibleWidth > usableSize.width())
             size = (QSize(usableSize.width(), usableSize.width() / ratio));

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -131,9 +131,9 @@ void CategoryWidget::removeFriendWidget(FriendWidget* w, Status::Status s)
 
 void CategoryWidget::updateStatus()
 {
-    QString online = QString::number(listLayout->friendOnlineCount());
-    QString offline = QString::number(listLayout->friendTotalCount());
-    QString text = online + QStringLiteral(" / ") + offline;
+    const QString online = QString::number(listLayout->friendOnlineCount());
+    const QString offline = QString::number(listLayout->friendTotalCount());
+    const QString text = online + QStringLiteral(" / ") + offline;
     statusLabel->setText(text);
 }
 
@@ -148,7 +148,7 @@ void CategoryWidget::search(const QString& searchString, bool updateAll, bool hi
     if (updateAll) {
         listLayout->searchChatRooms(searchString, hideOnline, hideOffline);
     }
-    bool inCategory = searchString.isEmpty() && !(hideOnline && hideOffline);
+    const bool inCategory = searchString.isEmpty() && !(hideOnline && hideOffline);
     setVisible(inCategory || listLayout->hasChatRooms());
 }
 

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -98,7 +98,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
             friendListWidget->removeCircleWidget(this);
 
-            int replacedCircle = settings.removeCircle(id);
+            const int replacedCircle = settings.removeCircle(id);
 
             auto circleReplace = circleList.find(replacedCircle);
             if (circleReplace != circleList.end())
@@ -141,7 +141,7 @@ void CircleWidget::dragEnterEvent(QDragEnterEvent* event)
     if (!event->mimeData()->hasFormat("toxPk")) {
         return;
     }
-    ToxPk toxPk(event->mimeData()->data("toxPk"));
+    const ToxPk toxPk(event->mimeData()->data("toxPk"));
     Friend* f = friendList.findFriend(toxPk);
     if (f != nullptr)
         event->acceptProposedAction();
@@ -169,13 +169,13 @@ void CircleWidget::dropEvent(QDropEvent* event)
         return;
     }
     // Check, that the user has a friend with the same ToxId
-    ToxPk toxPk{event->mimeData()->data("toxPk")};
+    const ToxPk toxPk{event->mimeData()->data("toxPk")};
     Friend* f = friendList.findFriend(toxPk);
     if (!f)
         return;
 
     // Save CircleWidget before changing the Id
-    int circleId = settings.getFriendCircleID(toxPk);
+    const int circleId = settings.getFriendCircleID(toxPk);
     CircleWidget* circleWidget = getFromID(circleId);
 
     addFriendWidget(widget, f->getStatus());
@@ -202,7 +202,7 @@ void CircleWidget::onExpand()
 void CircleWidget::onAddFriendWidget(FriendWidget* w)
 {
     const Friend* f = w->getFriend();
-    ToxPk toxId = f->getPublicKey();
+    const ToxPk toxId = f->getPublicKey();
     settings.setFriendCircleID(toxId, id);
 }
 

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -101,7 +101,7 @@ ContentDialog::ContentDialog(const Core& core, Settings& settings_, Style& style
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("detached");
 
-    QByteArray geometry = settings.getDialogGeometry();
+    const QByteArray geometry = settings.getDialogGeometry();
 
     if (!geometry.isNull()) {
         restoreGeometry(geometry);
@@ -303,16 +303,17 @@ void ContentDialog::cycleChats(bool forward, bool inverse)
     }
 
     if (!inverse && index == currentLayout->count() - 1) {
-        bool conferencesOnTop = settings.getConferencePosition();
-        bool offlineEmpty = friendLayout->getLayoutOffline()->isEmpty();
-        bool onlineEmpty = friendLayout->getLayoutOnline()->isEmpty();
-        bool conferencesEmpty = conferenceLayout.getLayout()->isEmpty();
-        bool isCurOffline = currentLayout == friendLayout->getLayoutOffline();
-        bool isCurOnline = currentLayout == friendLayout->getLayoutOnline();
-        bool isCurConference = currentLayout == conferenceLayout.getLayout();
-        bool nextIsEmpty = (isCurOnline && offlineEmpty && (conferencesEmpty || conferencesOnTop))
-                           || (isCurConference && offlineEmpty && (onlineEmpty || !conferencesOnTop))
-                           || (isCurOffline);
+        const bool conferencesOnTop = settings.getConferencePosition();
+        const bool offlineEmpty = friendLayout->getLayoutOffline()->isEmpty();
+        const bool onlineEmpty = friendLayout->getLayoutOnline()->isEmpty();
+        const bool conferencesEmpty = conferenceLayout.getLayout()->isEmpty();
+        const bool isCurOffline = currentLayout == friendLayout->getLayoutOffline();
+        const bool isCurOnline = currentLayout == friendLayout->getLayoutOnline();
+        const bool isCurConference = currentLayout == conferenceLayout.getLayout();
+        const bool nextIsEmpty =
+            (isCurOnline && offlineEmpty && (conferencesEmpty || conferencesOnTop))
+            || (isCurConference && offlineEmpty && (onlineEmpty || !conferencesOnTop))
+            || (isCurOffline);
 
         if (nextIsEmpty) {
             forward = !forward;
@@ -323,12 +324,12 @@ void ContentDialog::cycleChats(bool forward, bool inverse)
     // If goes out of the layout, then go to the next and skip empty. This loop goes more
     // then 1 time, because for empty layout index will be out of interval (0 < 0 || 0 >= 0)
     while (index < 0 || index >= currentLayout->count()) {
-        int oldCount = currentLayout->count();
+        const int oldCount = currentLayout->count();
         currentLayout = nextLayout(currentLayout, forward);
         if (currentLayout == nullptr) {
             qFatal("Layouts changed during iteration");
         }
-        int newCount = currentLayout->count();
+        const int newCount = currentLayout->count();
         if (index < 0) {
             index = newCount - 1;
         } else if (index >= oldCount) {
@@ -352,7 +353,7 @@ void ContentDialog::onVideoShow(QSize size)
     }
 
     videoSurfaceSize = size;
-    QSize minSize_ = minimumSize();
+    const QSize minSize_ = minimumSize();
     setMinimumSize(minSize_ + videoSurfaceSize);
 }
 
@@ -363,7 +364,7 @@ void ContentDialog::onVideoHide()
         return;
     }
 
-    QSize minSize_ = minimumSize();
+    const QSize minSize_ = minimumSize();
     setMinimumSize(minSize_ - videoSurfaceSize);
     videoSurfaceSize = QSize();
 }
@@ -381,13 +382,13 @@ void ContentDialog::updateTitleAndStatusIcon()
 
     setWindowTitle(username + QStringLiteral(" - ") + activeChatroomWidget->getTitle());
 
-    bool isConference = activeChatroomWidget->getConference() != nullptr;
+    const bool isConference = activeChatroomWidget->getConference() != nullptr;
     if (isConference) {
         setWindowIcon(QIcon(":/img/conference.svg"));
         return;
     }
 
-    Status::Status currentStatus = activeChatroomWidget->getFriend()->getStatus();
+    const Status::Status currentStatus = activeChatroomWidget->getFriend()->getStatus();
     setWindowIcon(QIcon{Status::getIconPath(currentStatus)});
 }
 
@@ -397,7 +398,7 @@ void ContentDialog::updateTitleAndStatusIcon()
  */
 void ContentDialog::reorderLayouts(bool newConferenceOnTop)
 {
-    bool oldConferenceOnTop = layouts.first() == conferenceLayout.getLayout();
+    const bool oldConferenceOnTop = layouts.first() == conferenceLayout.getLayout();
     if (newConferenceOnTop != oldConferenceOnTop) {
         layouts.swapItemsAt(0, 1);
     }
@@ -467,13 +468,13 @@ void ContentDialog::dragEnterEvent(QDragEnterEvent* event)
     ConferenceWidget* conference = qobject_cast<ConferenceWidget*>(o);
     if (frnd) {
         assert(event->mimeData()->hasFormat("toxPk"));
-        ToxPk toxPk{event->mimeData()->data("toxPk")};
+        const ToxPk toxPk{event->mimeData()->data("toxPk")};
         Friend* contact = friendList.findFriend(toxPk);
         if (!contact) {
             return;
         }
 
-        ToxPk friendId = contact->getPublicKey();
+        const ToxPk friendId = contact->getPublicKey();
 
         // If friend is already in a dialog then you can't drop friend where it already is.
         if (!hasChat(friendId)) {
@@ -481,7 +482,7 @@ void ContentDialog::dragEnterEvent(QDragEnterEvent* event)
         }
     } else if (conference) {
         assert(event->mimeData()->hasFormat("conferenceId"));
-        ConferenceId conferenceId = ConferenceId{event->mimeData()->data("conferenceId")};
+        const ConferenceId conferenceId = ConferenceId{event->mimeData()->data("conferenceId")};
         Conference* contact = conferenceList.findConference(conferenceId);
         if (!contact) {
             return;
@@ -638,7 +639,7 @@ void ContentDialog::updateFriendWidget(const ToxPk& friendPk, QString alias)
     Friend* f = friendList.findFriend(friendPk);
     FriendWidget* friendWidget = qobject_cast<FriendWidget*>(chatWidgets[friendPk]);
 
-    Status::Status status = f->getStatus();
+    const Status::Status status = f->getStatus();
     friendLayout->addFriendWidget(friendWidget, status);
 }
 
@@ -691,13 +692,13 @@ bool ContentDialog::hasChat(const ChatId& chatId) const
  */
 QLayout* ContentDialog::nextLayout(QLayout* layout, bool forward) const
 {
-    int index = layouts.indexOf(layout);
+    const int index = layouts.indexOf(layout);
     if (index == -1) {
         return nullptr;
     }
 
     int next = forward ? index + 1 : index - 1;
-    size_t size = layouts.size();
+    const size_t size = layouts.size();
     next = (next + size) % size;
 
     return layouts[next];

--- a/src/widget/emoticonswidget.cpp
+++ b/src/widget/emoticonswidget.cpp
@@ -36,8 +36,8 @@ EmoticonsWidget::EmoticonsWidget(SmileyPack& smileyPack, Settings& settings, Sty
     const int itemsPerPage = maxRows * maxCols;
 
     const QList<QStringList>& emoticons = smileyPack.getEmoticons();
-    int itemCount = emoticons.size();
-    int pageCount = std::ceil(float(itemCount) / float(itemsPerPage));
+    const int itemCount = emoticons.size();
+    const int pageCount = std::ceil(float(itemCount) / float(itemsPerPage));
     int currPage = 0;
     int currItem = 0;
     int row = 0;
@@ -75,7 +75,7 @@ EmoticonsWidget::EmoticonsWidget(SmileyPack& smileyPack, Settings& settings, Sty
 
     for (const QStringList& set : emoticons) {
         QPushButton* button = new QPushButton;
-        std::shared_ptr<QIcon> icon = smileyPack.getAsIcon(set[0]);
+        const std::shared_ptr<QIcon> icon = smileyPack.getAsIcon(set[0]);
         emoticonsIcons.append(icon);
         button->setIcon(icon->pixmap(size));
         button->setToolTip(set.join(" "));
@@ -115,7 +115,7 @@ void EmoticonsWidget::onSmileyClicked()
     // emit insert emoticon
     QWidget* sender = qobject_cast<QWidget*>(QObject::sender());
     if (sender) {
-        QString sequence =
+        const QString sequence =
             sender->property("sequence").toString().replace("&lt;", "<").replace("&gt;", ">");
         emit insertEmoticon(sequence);
     }
@@ -125,7 +125,7 @@ void EmoticonsWidget::onPageButtonClicked()
 {
     QWidget* sender = qobject_cast<QRadioButton*>(QObject::sender());
     if (sender) {
-        int page = sender->property("pageIndex").toInt();
+        const int page = sender->property("pageIndex").toInt();
         stack.setCurrentIndex(page);
     }
 }
@@ -163,7 +163,7 @@ void EmoticonsWidget::wheelEvent(QWheelEvent* e)
 
 void EmoticonsWidget::PageButtonsUpdate()
 {
-    QList<QRadioButton*> pageButtons = findChildren<QRadioButton*>(QString());
+    const QList<QRadioButton*> pageButtons = findChildren<QRadioButton*>(QString());
     foreach (QRadioButton* t_pageButton, pageButtons) {
         if (t_pageButton->property("pageIndex").toInt() == stack.currentIndex())
             t_pageButton->setChecked(true);

--- a/src/widget/flowlayout.cpp
+++ b/src/widget/flowlayout.cpp
@@ -89,7 +89,7 @@ bool FlowLayout::hasHeightForWidth() const
 
 int FlowLayout::heightForWidth(int width) const
 {
-    int height = doLayout(QRect(0, 0, width, 0), true);
+    const int height = doLayout(QRect(0, 0, width, 0), true);
     return height;
 }
 //! [7]
@@ -123,7 +123,7 @@ int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
 {
     int left, top, right, bottom;
     getContentsMargins(&left, &top, &right, &bottom);
-    QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
+    const QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
     int x = effectiveRect.x();
     int y = effectiveRect.y();
     int lineHeight = 0;

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -113,7 +113,7 @@ AddFriendForm::AddFriendForm(ToxId ownId_, Settings& settings_, Style& style_,
 
     const int size = settings.getFriendRequestSize();
     for (int i = 0; i < size; ++i) {
-        Settings::Request request = settings.getFriendRequest(i);
+        const Settings::Request request = settings.getFriendRequest(i);
         addFriendRequestWidget(request.address, request.message);
     }
 }
@@ -188,7 +188,7 @@ void AddFriendForm::onUsernameSet(const QString& username)
 
 void AddFriendForm::addFriend(const QString& idText)
 {
-    ToxId friendId(idText);
+    const ToxId friendId(idText);
 
     if (!friendId.isValid()) {
         messageBoxManager.showWarning(tr("Couldn't add friend"),
@@ -302,7 +302,7 @@ void AddFriendForm::deleteFriendRequest(const ToxId& toxId_)
 {
     const int size = settings.getFriendRequestSize();
     for (int i = 0; i < size; ++i) {
-        Settings::Request request = settings.getFriendRequest(i);
+        const Settings::Request request = settings.getFriendRequest(i);
         if (toxId_.getPublicKey() == ToxPk(request.address)) {
             settings.removeFriendRequest(i);
             return;
@@ -416,7 +416,7 @@ void AddFriendForm::addFriendRequestWidget(const QString& friendAddress_, const 
 
 void AddFriendForm::removeFriendRequestWidget(QWidget* friendWidget)
 {
-    int index = requestsLayout->indexOf(friendWidget);
+    const int index = requestsLayout->indexOf(friendWidget);
     requestsLayout->removeWidget(friendWidget);
     acceptButtons.removeAt(index);
     rejectButtons.removeAt(index);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -67,14 +67,14 @@ const QString ChatForm::ACTION_PREFIX = QStringLiteral("/me ");
 namespace {
 QString secondsToDHMS(quint32 duration)
 {
-    QString res;
-    QString cD = ChatForm::tr("Call duration: ");
-    quint32 seconds = duration % 60;
+    const QString res;
+    const QString cD = ChatForm::tr("Call duration: ");
+    const quint32 seconds = duration % 60;
     duration /= 60;
-    quint32 minutes = duration % 60;
+    const quint32 minutes = duration % 60;
     duration /= 60;
-    quint32 hours = duration % 24;
-    quint32 days = duration / 24;
+    const quint32 hours = duration % 24;
+    const quint32 days = duration / 24;
 
     // I assume no one will ever have call longer than a month
     if (days) {
@@ -254,7 +254,7 @@ void ChatForm::onTextEditChanged()
 
         return;
     }
-    bool isTypingNow = !msgEdit->toPlainText().isEmpty();
+    const bool isTypingNow = !msgEdit->toPlainText().isEmpty();
     if (isTyping != isTypingNow) {
         core.sendTyping(f->getId(), isTypingNow);
         if (isTypingNow) {
@@ -267,16 +267,16 @@ void ChatForm::onTextEditChanged()
 
 void ChatForm::onAttachClicked()
 {
-    QStringList paths = QFileDialog::getOpenFileNames(Q_NULLPTR, tr("Send a file"),
-                                                      QDir::homePath(), QString(), nullptr);
+    const QStringList paths = QFileDialog::getOpenFileNames(Q_NULLPTR, tr("Send a file"),
+                                                            QDir::homePath(), QString(), nullptr);
 
     if (paths.isEmpty()) {
         return;
     }
 
-    for (QString path : paths) {
+    for (const QString& path : paths) {
         QFile file(path);
-        QString fileName = QFileInfo(path).fileName();
+        const QString fileName = QFileInfo(path).fileName();
         if (!file.exists() || !file.open(QIODevice::ReadOnly)) {
             QMessageBox::warning(this, tr("Unable to open"),
                                  tr("qTox wasn't able to open %1").arg(fileName));
@@ -291,7 +291,7 @@ void ChatForm::onAttachClicked()
             continue;
         }
 
-        qint64 filesize = file.size();
+        const qint64 filesize = file.size();
         core.getCoreFile()->sendFile(f->getId(), fileName, path, filesize);
     }
 }
@@ -302,7 +302,7 @@ void ChatForm::onAvInvite(uint32_t friendId, bool video)
         return;
     }
 
-    QString displayedName = f->getDisplayedName();
+    const QString displayedName = f->getDisplayedName();
 
     SystemMessage systemMessage;
     systemMessage.messageType = SystemMessageType::incomingCall;
@@ -373,7 +373,7 @@ void ChatForm::showOutgoingCall(bool video)
 void ChatForm::onAnswerCallTriggered(bool video)
 {
     headWidget->removeCallConfirm();
-    uint32_t friendId = f->getId();
+    const uint32_t friendId = f->getId();
     emit stopNotification();
     emit acceptCall(friendId);
 
@@ -398,7 +398,7 @@ void ChatForm::onRejectCallTriggered()
 void ChatForm::onCallTriggered()
 {
     CoreAV* av = core.getAv();
-    uint32_t friendId = f->getId();
+    const uint32_t friendId = f->getId();
     if (av->isCallStarted(f)) {
         av->cancelCall(friendId);
     } else if (av->startCall(friendId, false)) {
@@ -409,7 +409,7 @@ void ChatForm::onCallTriggered()
 void ChatForm::onVideoCallTriggered()
 {
     CoreAV* av = core.getAv();
-    uint32_t friendId = f->getId();
+    const uint32_t friendId = f->getId();
     if (av->isCallStarted(f)) {
         // TODO: We want to activate video on the active call.
         if (av->isCallVideoEnabled(f)) {
@@ -459,7 +459,7 @@ void ChatForm::onFriendStatusChanged(const ToxPk& friendPk, Status::Status statu
     updateCallButtons();
 
     if (settings.getStatusChangeNotificationEnabled()) {
-        QString fStatus = Status::getTitle(status);
+        const QString fStatus = Status::getTitle(status);
         addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::peerStateChange,
                              {f->getDisplayedName(), fStatus});
     }
@@ -498,7 +498,7 @@ void ChatForm::onAvatarChanged(const ToxPk& friendPk, const QPixmap& pic)
 std::unique_ptr<NetCamView> ChatForm::createNetcam()
 {
     qDebug() << "creating netcam";
-    uint32_t friendId = f->getId();
+    const uint32_t friendId = f->getId();
     std::unique_ptr<NetCamView> view =
         std::make_unique<NetCamView>(f->getPublicKey(), cameraSource, settings, style, profile, this);
     CoreAV* av = core.getAv();
@@ -527,7 +527,7 @@ void ChatForm::dropEvent(QDropEvent* ev)
         QFileInfo info(url.path());
         QFile file(info.absoluteFilePath());
 
-        QString urlString = url.toString();
+        const QString urlString = url.toString();
         if (url.isValid() && !url.isLocalFile()
             && urlString.length() < static_cast<int>(tox_max_message_length())) {
             messageDispatcher.sendMessage(false, urlString);
@@ -535,7 +535,7 @@ void ChatForm::dropEvent(QDropEvent* ev)
             continue;
         }
 
-        QString fileName = info.fileName();
+        const QString fileName = info.fileName();
         if (!file.exists() || !file.open(QIODevice::ReadOnly)) {
             info.setFile(url.toLocalFile());
             file.setFileName(info.absoluteFilePath());
@@ -600,19 +600,20 @@ void ChatForm::sendImageFromPreview()
     // https://en.wikipedia.org/wiki/ISO_8601
     // Windows has to be supported, thus filename can't have `:` in it :/
     // Format should be: `qTox_Screenshot_yyyy-MM-dd HH-mm-ss.zzz.png`
-    QString filepath = QString("%1images%2qTox_Image_%3.png")
-                           .arg(settings.getPaths().getAppDataDirPath())
-                           .arg(QDir::separator())
-                           .arg(QDateTime::currentDateTime().toString("yyyy-MM-dd HH-mm-ss.zzz"));
+    const QString filepath =
+        QString("%1images%2qTox_Image_%3.png")
+            .arg(settings.getPaths().getAppDataDirPath())
+            .arg(QDir::separator())
+            .arg(QDateTime::currentDateTime().toString("yyyy-MM-dd HH-mm-ss.zzz"));
     QFile file(filepath);
 
     if (file.open(QFile::ReadWrite)) {
         imagePreviewSource.save(&file, "PNG");
-        qint64 filesize = file.size();
+        const qint64 filesize = file.size();
         imagePreview->hide();
         imagePreviewSource = QPixmap();
         file.close();
-        QFileInfo fi(file);
+        const QFileInfo fi(file);
         CoreFile* coreFile = core.getCoreFile();
         coreFile->sendFile(f->getId(), fi.fileName(), fi.filePath(), filesize);
     } else {
@@ -625,7 +626,7 @@ void ChatForm::sendImageFromPreview()
 void ChatForm::onCopyStatusMessage()
 {
     // make sure to copy not truncated text directly from the friend
-    QString text = f->getStatusMessage();
+    const QString text = f->getStatusMessage();
     QClipboard* clipboard = QApplication::clipboard();
     if (clipboard) {
         clipboard->setText(text, QClipboard::Clipboard);
@@ -635,8 +636,8 @@ void ChatForm::onCopyStatusMessage()
 void ChatForm::updateMuteMicButton()
 {
     const CoreAV* av = core.getAv();
-    bool active = av->isCallActive(f);
-    bool inputMuted = av->isCallInputMuted(f);
+    const bool active = av->isCallActive(f);
+    const bool inputMuted = av->isCallInputMuted(f);
     headWidget->updateMuteMicButton(active, inputMuted);
     if (netcam) {
         netcam->updateMuteMicButton(inputMuted);
@@ -646,8 +647,8 @@ void ChatForm::updateMuteMicButton()
 void ChatForm::updateMuteVolButton()
 {
     const CoreAV* av = core.getAv();
-    bool active = av->isCallActive(f);
-    bool outputMuted = av->isCallOutputMuted(f);
+    const bool active = av->isCallActive(f);
+    const bool outputMuted = av->isCallOutputMuted(f);
     headWidget->updateMuteVolButton(active, outputMuted);
     if (netcam) {
         netcam->updateMuteVolButton(outputMuted);
@@ -671,8 +672,8 @@ void ChatForm::stopCounter(bool error)
     if (!callDurationTimer) {
         return;
     }
-    QString dhms = secondsToDHMS(timeElapsed.elapsed() / 1000);
-    QString name = f->getDisplayedName();
+    const QString dhms = secondsToDHMS(timeElapsed.elapsed() / 1000);
+    const QString name = f->getDisplayedName();
     auto messageType = error ? SystemMessageType::unexpectedCallEnd : SystemMessageType::callEnd;
     // TODO: add notification once notifications are implemented
 
@@ -693,7 +694,7 @@ void ChatForm::onUpdateTime()
 void ChatForm::setFriendTyping(bool isTyping_)
 {
     chatWidget->setTypingNotificationVisible(isTyping_);
-    QString name = f->getDisplayedName();
+    const QString name = f->getDisplayedName();
     chatWidget->setTypingNotificationName(name);
 }
 
@@ -740,7 +741,7 @@ void ChatForm::showNetcam()
     bodySplitter->insertWidget(0, netcam.get());
     bodySplitter->setCollapsible(0, false);
 
-    QSize minSize = netcam->getSurfaceMinSize();
+    const QSize minSize = netcam->getSurfaceMinSize();
     ContentDialog* current = contentDialogManager.current();
     if (current) {
         current->onVideoShow(minSize);

--- a/src/widget/form/conferenceform.cpp
+++ b/src/widget/form/conferenceform.cpp
@@ -288,7 +288,7 @@ void ConferenceForm::dragEnterEvent(QDragEnterEvent* ev)
     if (!ev->mimeData()->hasFormat("toxPk")) {
         return;
     }
-    ToxPk toxPk{ev->mimeData()->data("toxPk")};
+    const ToxPk toxPk{ev->mimeData()->data("toxPk")};
     Friend* frnd = friendList.findFriend(toxPk);
     if (frnd)
         ev->acceptProposedAction();
@@ -299,13 +299,13 @@ void ConferenceForm::dropEvent(QDropEvent* ev)
     if (!ev->mimeData()->hasFormat("toxPk")) {
         return;
     }
-    ToxPk toxPk{ev->mimeData()->data("toxPk")};
+    const ToxPk toxPk{ev->mimeData()->data("toxPk")};
     Friend* frnd = friendList.findFriend(toxPk);
     if (!frnd)
         return;
 
-    int friendId = frnd->getId();
-    int conferenceId = conference->getId();
+    const int friendId = frnd->getId();
+    const int conferenceId = conference->getId();
     if (Status::isOnline(frnd->getStatus())) {
         core.conferenceInviteFriend(friendId, conferenceId);
     }

--- a/src/widget/form/conferenceinviteform.cpp
+++ b/src/widget/form/conferenceinviteform.cpp
@@ -78,7 +78,7 @@ ConferenceInviteForm::~ConferenceInviteForm()
  */
 bool ConferenceInviteForm::isShown() const
 {
-    bool result = isVisible();
+    const bool result = isVisible();
     if (result) {
         headWidget->window()->windowHandle()->alert(0);
     }

--- a/src/widget/form/conferenceinvitewidget.cpp
+++ b/src/widget/form/conferenceinvitewidget.cpp
@@ -47,10 +47,10 @@ ConferenceInviteWidget::ConferenceInviteWidget(QWidget* parent, ConferenceInvite
  */
 void ConferenceInviteWidget::retranslateUi()
 {
-    QString name = core.getFriendUsername(inviteInfo.getFriendId());
-    QDateTime inviteDate = inviteInfo.getInviteDate();
-    QString date = inviteDate.toString(settings.getDateFormat());
-    QString time = inviteDate.toString(settings.getTimestampFormat());
+    const QString name = core.getFriendUsername(inviteInfo.getFriendId());
+    const QDateTime inviteDate = inviteInfo.getInviteDate();
+    const QString date = inviteDate.toString(settings.getDateFormat());
+    const QString time = inviteDate.toString(settings.getTimestampFormat());
 
     inviteMessageLabel->setText(
         tr("Invited by %1 on %2 at %3.").arg("<b>%1</b>").arg(name.toHtmlEscaped(), date, time));

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -28,28 +28,28 @@
 namespace {
 QRect pauseRect(const QStyleOptionViewItem& option)
 {
-    float controlSize = option.rect.height() * 0.8f;
-    float rectWidth = option.rect.width();
-    float buttonHorizontalArea = rectWidth / 2;
+    const float controlSize = option.rect.height() * 0.8f;
+    const float rectWidth = option.rect.width();
+    const float buttonHorizontalArea = rectWidth / 2;
 
     // To center the button, we find the horizontal center and subtract half
     // our width from it
-    int buttonXPos = std::round(option.rect.x() + buttonHorizontalArea / 2 - controlSize / 2);
-    int buttonYPos = std::round(option.rect.y() + option.rect.height() * 0.1f);
+    const int buttonXPos = std::round(option.rect.x() + buttonHorizontalArea / 2 - controlSize / 2);
+    const int buttonYPos = std::round(option.rect.y() + option.rect.height() * 0.1f);
     return {buttonXPos, buttonYPos, static_cast<int>(controlSize), static_cast<int>(controlSize)};
 }
 
 QRect stopRect(const QStyleOptionViewItem& option)
 {
-    float controlSize = option.rect.height() * 0.8;
-    float rectWidth = option.rect.width();
-    float buttonHorizontalArea = rectWidth / 2;
+    const float controlSize = option.rect.height() * 0.8;
+    const float rectWidth = option.rect.width();
+    const float buttonHorizontalArea = rectWidth / 2;
 
     // To center the button, we find the horizontal center and subtract half
     // our width from it
-    int buttonXPos = std::round(option.rect.x() + buttonHorizontalArea + buttonHorizontalArea / 2
-                                - controlSize / 2);
-    int buttonYPos = std::round(option.rect.y() + option.rect.height() * 0.1f);
+    const int buttonXPos = std::round(option.rect.x() + buttonHorizontalArea
+                                      + buttonHorizontalArea / 2 - controlSize / 2);
+    const int buttonYPos = std::round(option.rect.y() + option.rect.height() * 0.1f);
     return {buttonXPos, buttonYPos, static_cast<int>(controlSize), static_cast<int>(controlSize)};
 }
 
@@ -326,7 +326,7 @@ void Delegate::paint(QPainter* painter, const QStyleOptionViewItem& option, cons
     const auto column = toFileTransferListColumn(index.column());
     switch (column) {
     case Column::progress: {
-        int progress = index.data().toInt();
+        const int progress = index.data().toInt();
 
         QStyleOptionProgressBar progressBarOption;
         progressBarOption.rect = option.rect;
@@ -346,13 +346,13 @@ void Delegate::paint(QPainter* painter, const QStyleOptionViewItem& option, cons
             return;
         }
         const auto localPaused = data.toBool();
-        QPixmap pausePixmap =
+        const QPixmap pausePixmap =
             localPaused
                 ? QPixmap(style.getImagePath("fileTransferInstance/arrow_black.svg", settings))
                 : QPixmap(style.getImagePath("fileTransferInstance/pause_dark.svg", settings));
         QApplication::style()->drawItemPixmap(painter, pauseRect(option), Qt::AlignCenter, pausePixmap);
 
-        QPixmap stopPixmap(style.getImagePath("fileTransferInstance/no_dark.svg", settings));
+        const QPixmap stopPixmap(style.getImagePath("fileTransferInstance/no_dark.svg", settings));
         QApplication::style()->drawItemPixmap(painter, stopRect(option), Qt::AlignCenter, stopPixmap);
         return;
     }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -61,11 +61,11 @@ const QString FONT_STYLE[]{"normal", "italic", "oblique"};
  */
 QString fontToCss(const QFont& font, const QString& name)
 {
-    QString result{"%1{"
-                   "font-family: \"%2\"; "
-                   "font-size: %3px; "
-                   "font-style: \"%4\"; "
-                   "font-weight: normal;}"};
+    const QString result{"%1{"
+                         "font-family: \"%2\"; "
+                         "font-size: %3px; "
+                         "font-style: \"%4\"; "
+                         "font-weight: normal;}"};
     return result.arg(name).arg(font.family()).arg(font.pixelSize()).arg(FONT_STYLE[font.style()]);
 }
 } // namespace
@@ -296,8 +296,8 @@ GenericChatForm::~GenericChatForm()
 
 void GenericChatForm::adjustFileMenuPosition()
 {
-    QPoint pos = fileButton->mapTo(bodySplitter, QPoint());
-    QSize size = fileFlyout->size();
+    const QPoint pos = fileButton->mapTo(bodySplitter, QPoint());
+    const QSize size = fileFlyout->size();
     fileFlyout->move(pos.x() - size.width(), pos.y());
 }
 
@@ -421,8 +421,8 @@ void GenericChatForm::onChatContextMenuRequested(QPoint pos)
     bool clickedOnLink = false;
     Text* clickedText = qobject_cast<Text*>(chatWidget->getContentFromGlobalPos(pos));
     if (clickedText) {
-        QPointF scenePos = chatWidget->mapToScene(chatWidget->mapFromGlobal(pos));
-        QString linkTarget = clickedText->getLinkAt(scenePos);
+        const QPointF scenePos = chatWidget->mapToScene(chatWidget->mapFromGlobal(pos));
+        const QString linkTarget = clickedText->getLinkAt(scenePos);
         if (!linkTarget.isEmpty()) {
             clickedOnLink = true;
             copyLinkAction->setData(linkTarget);
@@ -437,7 +437,7 @@ void GenericChatForm::onSendTriggered()
 {
     auto msg = msgEdit->toPlainText();
 
-    bool isAction = msg.startsWith(ChatForm::ACTION_PREFIX, Qt::CaseInsensitive);
+    const bool isAction = msg.startsWith(ChatForm::ACTION_PREFIX, Qt::CaseInsensitive);
     if (isAction) {
         msg.remove(0, ChatForm::ACTION_PREFIX.length());
     }
@@ -465,7 +465,7 @@ void GenericChatForm::onEmoteButtonClicked()
 
     QWidget* sender = qobject_cast<QWidget*>(QObject::sender());
     if (sender) {
-        QPoint pos =
+        const QPoint pos =
             -QPoint(widget.sizeHint().width() / 2, widget.sizeHint().height()) - QPoint(0, 10);
         widget.exec(sender->mapToGlobal(pos));
     }
@@ -539,7 +539,7 @@ void GenericChatForm::clearChatArea()
 void GenericChatForm::clearChatArea(bool confirm, bool inform)
 {
     if (confirm) {
-        QMessageBox::StandardButton mboxResult =
+        const QMessageBox::StandardButton mboxResult =
             QMessageBox::question(this, tr("Confirmation"),
                                   tr("Are you sure that you want to clear all displayed messages?"),
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
@@ -594,13 +594,13 @@ bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
         break;
 
     case QEvent::Leave: {
-        QPoint flyPos = fileFlyout->mapToGlobal(QPoint());
-        QSize flySize = fileFlyout->size();
+        const QPoint flyPos = fileFlyout->mapToGlobal(QPoint());
+        const QSize flySize = fileFlyout->size();
 
-        QPoint filePos = fileButton->mapToGlobal(QPoint());
-        QSize fileSize = fileButton->size();
+        const QPoint filePos = fileButton->mapToGlobal(QPoint());
+        const QSize fileSize = fileButton->size();
 
-        QRect region = QRect(flyPos, flySize).united(QRect(filePos, fileSize));
+        const QRect region = QRect(flyPos, flySize).united(QRect(filePos, fileSize));
 
         if (!region.contains(QCursor::pos()))
             hideFileMenu();
@@ -621,7 +621,7 @@ bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
 
 void GenericChatForm::quoteSelectedText()
 {
-    QString selectedText = chatWidget->getSelectedText();
+    const QString selectedText = chatWidget->getSelectedText();
 
     if (selectedText.isEmpty())
         return;
@@ -644,7 +644,7 @@ void GenericChatForm::quoteSelectedText()
  */
 void GenericChatForm::copyLink()
 {
-    QString linkText = copyLinkAction->data().toString();
+    const QString linkText = copyLinkAction->data().toString();
     auto* clipboard = QApplication::clipboard();
     clipboard->setText(linkText, QClipboard::Clipboard);
     if (clipboard->supportsSelection()) {
@@ -670,7 +670,7 @@ void GenericChatForm::onLoadHistory()
 
 void GenericChatForm::onExportChat()
 {
-    QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Save chat log"));
+    const QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Save chat log"));
     if (path.isEmpty()) {
         return;
     }

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -41,7 +41,7 @@ QDateTime LoadHistoryDialog::getFromDate()
     QDateTime res(ui->fromDate->selectedDate().startOfDay());
     if (res.date().month() != ui->fromDate->monthShown()
         || res.date().year() != ui->fromDate->yearShown()) {
-        QDate newDate(ui->fromDate->yearShown(), ui->fromDate->monthShown(), 1);
+        const QDate newDate(ui->fromDate->yearShown(), ui->fromDate->monthShown(), 1);
         res.setDate(newDate);
     }
 
@@ -60,8 +60,8 @@ void LoadHistoryDialog::setInfoLabel(const QString& info)
 
 void LoadHistoryDialog::highlightDates(int year, int month)
 {
-    QDate monthStart(year, month, 1);
-    QDate monthEnd(year, month + 1, 1);
+    const QDate monthStart(year, month, 1);
+    const QDate monthEnd(year, month + 1, 1);
 
     // Max 31 days in a month
     auto dateIdxs = chatLog->getDateIdxs(monthStart, 31);

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -190,12 +190,12 @@ void ProfileForm::show(ContentLayout* contentLayout)
     contentLayout->mainContent->layout()->addWidget(this);
     QWidget::show();
     prFileLabelUpdate();
-    bool portable = settings.getMakeToxPortable();
-    QString defaultPath = QDir(settings.getPaths().getSettingsDirPath()).path().trimmed();
-    QString appPath = QApplication::applicationDirPath();
-    QString dirPath = portable ? appPath : defaultPath;
+    const bool portable = settings.getMakeToxPortable();
+    const QString defaultPath = QDir(settings.getPaths().getSettingsDirPath()).path().trimmed();
+    const QString appPath = QApplication::applicationDirPath();
+    const QString dirPath = portable ? appPath : defaultPath;
 
-    QString dirPrLink =
+    const QString dirPrLink =
         tr("Current profile location: %1").arg(QString("<a href=\"file://%1\">%1</a>").arg(dirPath));
 
     bodyUI->dirPrLink->setText(dirPrLink);
@@ -258,7 +258,7 @@ void ProfileForm::onSelfAvatarLoaded(const QPixmap& pic)
 
 void ProfileForm::setToxId(const ToxId& id)
 {
-    QString idString = id.toString();
+    const QString idString = id.toString();
     static const QString ToxIdColor = QStringLiteral("%1"
                                                      "<span style='color:blue'>%2</span>"
                                                      "<span style='color:gray'>%3</span>");
@@ -432,7 +432,7 @@ void ProfileForm::onChangePassClicked()
         return;
     }
 
-    QString newPass = dialog->getPassword();
+    const QString newPass = dialog->getPassword();
     if (!profileInfo->setPassword(newPass)) {
         messageBoxManager.showInfo(CAN_NOT_CHANGE_PASSWORD.first, CAN_NOT_CHANGE_PASSWORD.second);
     }

--- a/src/widget/form/setpassworddialog.cpp
+++ b/src/widget/form/setpassworddialog.cpp
@@ -44,7 +44,7 @@ SetPasswordDialog::~SetPasswordDialog()
 
 void SetPasswordDialog::onPasswordEdit()
 {
-    QString password = ui->passwordlineEdit->text();
+    const QString password = ui->passwordlineEdit->text();
 
     if (password.isEmpty()) {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
@@ -70,7 +70,7 @@ int SetPasswordDialog::getPasswordStrength(QString pass)
 
     double fscore = 0;
     QHash<QChar, int> charCounts;
-    for (QChar c : pass) {
+    for (const QChar c : pass) {
         charCounts[c]++;
         fscore += 5. / charCounts[c];
     }

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -73,7 +73,7 @@ AboutForm::AboutForm(UpdateCheck& updateCheck_, QString contactInfo_, Style& sty
  */
 void AboutForm::replaceVersions()
 {
-    QString TOXCORE_VERSION =
+    const QString TOXCORE_VERSION =
         QStringLiteral("%1.%2.%3").arg(tox_version_major()).arg(tox_version_minor()).arg(tox_version_patch());
 
     bodyUI->youAreUsing->setText(tr("You are using qTox version %1.").arg(VersionInfo::gitDescribe()));
@@ -86,7 +86,7 @@ void AboutForm::replaceVersions()
         qDebug() << "AboutForm not showing updates, qTox built without UPDATE_CHECK";
     }
 
-    QString commitLink = "https://github.com/TokTok/qTox/commit/" + VersionInfo::gitVersion();
+    const QString commitLink = "https://github.com/TokTok/qTox/commit/" + VersionInfo::gitVersion();
     bodyUI->gitVersion->setText(
         tr("Commit hash: %1").arg(createLink(commitLink, VersionInfo::gitVersion())));
 
@@ -126,7 +126,7 @@ void AboutForm::replaceVersions()
                  urlEncode(QSysInfo::prettyProductName())),
         QStringLiteral("<b>%1</b>").arg(tr("Click here to report a bug."))));
 
-    QString authorInfo =
+    const QString authorInfo =
         QStringLiteral("<p>%1</p><p>%2</p><p>%3</p>")
             .arg(tr("Original author: %1").arg(createLink("https://github.com/tux3", "tux3")),
                  tr("See a full list of %1 at Github",

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -43,12 +43,12 @@ AdvancedForm::AdvancedForm(Settings& settings_, Style& style, IMessageBoxManager
     bodyUI->cbEnableIPv6->setChecked(settings.getEnableIPv6());
     bodyUI->cbMakeToxPortable->setChecked(settings.getMakeToxPortable());
     bodyUI->proxyAddr->setText(settings.getProxyAddr());
-    quint16 port = settings.getProxyPort();
+    const quint16 port = settings.getProxyPort();
     if (port > 0) {
         bodyUI->proxyPort->setValue(port);
     }
 
-    int index = static_cast<int>(settings.getProxyType());
+    const int index = static_cast<int>(settings.getProxyType());
     bodyUI->proxyType->setCurrentIndex(index);
     on_proxyType_currentIndexChanged(index);
     const bool udpEnabled =
@@ -57,7 +57,7 @@ AdvancedForm::AdvancedForm(Settings& settings_, Style& style, IMessageBoxManager
     bodyUI->cbEnableLanDiscovery->setChecked(settings.getEnableLanDiscovery() && udpEnabled);
     bodyUI->cbEnableLanDiscovery->setEnabled(udpEnabled);
 
-    QString warningBody =
+    const QString warningBody =
         tr("Unless you %1 know what you are doing, "
            "please do %2 change anything here. Changes "
            "made here may lead to problems with qTox, and even "
@@ -67,10 +67,10 @@ AdvancedForm::AdvancedForm(Settings& settings_, Style& style, IMessageBoxManager
             .arg(QString("<b>%1</b>").arg(tr("not")))
             .arg(QString("<p>%1</p>").arg(tr("Changes here are applied only after restarting qTox.")));
 
-    QString warning = QString("<div style=\"color:#ff0000;\">"
-                              "<p><b>%1</b></p><p>%2</p></div>")
-                          .arg(tr("IMPORTANT NOTE"))
-                          .arg(warningBody);
+    const QString warning = QString("<div style=\"color:#ff0000;\">"
+                                    "<p><b>%1</b></p><p>%2</p></div>")
+                                .arg(tr("IMPORTANT NOTE"))
+                                .arg(warningBody);
 
     bodyUI->warningLabel->setText(warning);
 
@@ -90,7 +90,7 @@ void AdvancedForm::on_cbMakeToxPortable_stateChanged()
 }
 void AdvancedForm::on_btnExportLog_clicked()
 {
-    QString savefile =
+    const QString savefile =
         QFileDialog::getSaveFileName(Q_NULLPTR, tr("Save file"), QString{}, tr("Logs (*.log)"));
 
     if (savefile.isNull() || savefile.isEmpty()) {
@@ -98,10 +98,10 @@ void AdvancedForm::on_btnExportLog_clicked()
         return;
     }
 
-    QString logFileDir = settings.getPaths().getAppCacheDirPath();
-    QString logfile = logFileDir + "qtox.log";
+    const QString logFileDir = settings.getPaths().getAppCacheDirPath();
+    const QString logfile = logFileDir + "qtox.log";
 
-    QFile file(logfile);
+    const QFile file(logfile);
     if (file.exists()) {
         qDebug() << "Found debug log for copying";
     } else {
@@ -117,8 +117,8 @@ void AdvancedForm::on_btnExportLog_clicked()
 
 void AdvancedForm::on_btnCopyDebug_clicked()
 {
-    QString logFileDir = settings.getPaths().getAppCacheDirPath();
-    QString logfile = logFileDir + "qtox.log";
+    const QString logFileDir = settings.getPaths().getAppCacheDirPath();
+    const QString logfile = logFileDir + "qtox.log";
 
     QFile file(logfile);
     if (!file.exists()) {
@@ -148,7 +148,7 @@ void AdvancedForm::on_btnCopyDebug_clicked()
 void AdvancedForm::on_resetButton_clicked()
 {
     const QString title = tr("Reset settings");
-    bool result =
+    const bool result =
         messageBoxManager.askQuestion(title,
                                       tr("All settings will be reset to default. Are you sure?"),
                                       tr("Yes"), tr("No"));
@@ -200,7 +200,7 @@ void AdvancedForm::on_proxyPort_valueChanged(int port)
 
 void AdvancedForm::on_proxyType_currentIndexChanged(int index)
 {
-    Settings::ProxyType proxytype = static_cast<Settings::ProxyType>(index);
+    const Settings::ProxyType proxytype = static_cast<Settings::ProxyType>(index);
     const bool proxyEnabled = proxytype != Settings::ProxyType::ptNone;
 
     bodyUI->proxyAddr->setEnabled(proxyEnabled);
@@ -217,7 +217,7 @@ void AdvancedForm::on_proxyType_currentIndexChanged(int index)
  */
 void AdvancedForm::retranslateUi()
 {
-    int proxyType = bodyUI->proxyType->currentIndex();
+    const int proxyType = bodyUI->proxyType->currentIndex();
     bodyUI->retranslateUi(this);
     bodyUI->proxyType->setCurrentIndex(proxyType);
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -139,7 +139,7 @@ void AVForm::showEvent(QShowEvent* event)
 
 void AVForm::open(const QString& devName, const VideoMode& mode)
 {
-    QRect rect = mode.toRect();
+    const QRect rect = mode.toRect();
     videoSettings->setCamVideoRes(rect);
     videoSettings->setCamVideoFPS(mode.fps);
     camera.setupDevice(devName, mode);
@@ -165,15 +165,15 @@ void AVForm::setVolume(qreal value)
 void AVForm::on_videoModesComboBox_currentIndexChanged(int index)
 {
     assert(0 <= index && index < videoModes.size());
-    int devIndex = videoDevCombobox->currentIndex();
+    const int devIndex = videoDevCombobox->currentIndex();
     assert(0 <= devIndex && devIndex < videoDeviceList.size());
 
-    QString devName = videoDeviceList[devIndex].first;
-    VideoMode newMode = videoModes[index];
+    const QString devName = videoDeviceList[devIndex].first;
+    const VideoMode newMode = videoModes[index];
 
     if (CameraDevice::isScreen(devName) && newMode == VideoMode()) {
         if (videoSettings->getScreenGrabbed()) {
-            VideoMode screenMode(videoSettings->getScreenRegion());
+            const VideoMode screenMode(videoSettings->getScreenRegion());
             open(devName, screenMode);
             return;
         }
@@ -184,7 +184,7 @@ void AVForm::on_videoModesComboBox_currentIndexChanged(int index)
             mode.height = mode.height / 2 * 2;
 
             // Needed, if the virtual screen origin is the top left corner of the primary screen
-            QRect screen = QApplication::primaryScreen()->virtualGeometry();
+            const QRect screen = QApplication::primaryScreen()->virtualGeometry();
             mode.x += screen.x();
             mode.y += screen.y();
 
@@ -258,7 +258,8 @@ void AVForm::selectBestModes(QVector<VideoMode>& allVideoModes)
                     continue;
                 }
 
-                bool better = CameraDevice::betterPixelFormat(mode.pixel_format, best.pixel_format);
+                const bool better =
+                    CameraDevice::betterPixelFormat(mode.pixel_format, best.pixel_format);
                 if (mode.fps >= best.fps && better)
                     bestModeIndices[res] = i;
             }
@@ -267,12 +268,12 @@ void AVForm::selectBestModes(QVector<VideoMode>& allVideoModes)
 
     QVector<VideoMode> newVideoModes;
     for (const auto& [_, modeIndex] : qtox::views::reverse(bestModeIndices)) {
-        VideoMode mode_ = allVideoModes[modeIndex];
+        const VideoMode mode_ = allVideoModes[modeIndex];
 
         if (newVideoModes.empty()) {
             newVideoModes.push_back(mode_);
         } else {
-            int size = getModeSize(mode_);
+            const int size = getModeSize(mode_);
             auto result = std::find_if(newVideoModes.cbegin(), newVideoModes.cend(),
                                        [size](VideoMode mode) { return getModeSize(mode) == size; });
 
@@ -286,12 +287,13 @@ void AVForm::selectBestModes(QVector<VideoMode>& allVideoModes)
 void AVForm::fillCameraModesComboBox()
 {
     qDebug() << "selected Modes:";
-    bool previouslyBlocked = videoModesComboBox->blockSignals(true);
+    const bool previouslyBlocked = videoModesComboBox->blockSignals(true);
     videoModesComboBox->clear();
 
     for (auto mode : videoModes) {
         QString str;
-        std::string pixelFormat = CameraDevice::getPixelFormatString(mode.pixel_format).toStdString();
+        const std::string pixelFormat =
+            CameraDevice::getPixelFormatString(mode.pixel_format).toStdString();
         qDebug("width: %d, height: %d, fps: %f, pixel format: %s", mode.width, mode.height,
                static_cast<double>(mode.fps), pixelFormat.c_str());
 
@@ -312,11 +314,11 @@ void AVForm::fillCameraModesComboBox()
 
 int AVForm::searchPreferredIndex()
 {
-    QRect prefRes = videoSettings->getCamVideoRes();
-    float prefFPS = videoSettings->getCamVideoFPS();
+    const QRect prefRes = videoSettings->getCamVideoRes();
+    const float prefFPS = videoSettings->getCamVideoFPS();
 
     for (int i = 0; i < videoModes.size(); ++i) {
-        VideoMode mode = videoModes[i];
+        const VideoMode mode = videoModes[i];
         if (mode.width == prefRes.width() && mode.height == prefRes.height()
             && (qAbs(mode.fps - prefFPS) < 0.0001f)) {
             return i;
@@ -328,12 +330,13 @@ int AVForm::searchPreferredIndex()
 
 void AVForm::fillScreenModesComboBox()
 {
-    bool previouslyBlocked = videoModesComboBox->blockSignals(true);
+    const bool previouslyBlocked = videoModesComboBox->blockSignals(true);
     videoModesComboBox->clear();
 
     for (int i = 0; i < videoModes.size(); ++i) {
-        VideoMode mode = videoModes[i];
-        std::string pixelFormat = CameraDevice::getPixelFormatString(mode.pixel_format).toStdString();
+        const VideoMode mode = videoModes[i];
+        const std::string pixelFormat =
+            CameraDevice::getPixelFormatString(mode.pixel_format).toStdString();
         qDebug("%dx%d+%d,%d fps: %f, pixel format: %s", mode.width, mode.height, mode.x, mode.y,
                static_cast<double>(mode.fps), pixelFormat.c_str());
 
@@ -371,11 +374,11 @@ void AVForm::updateVideoModes(int curIndex)
         qWarning() << "Invalid index:" << curIndex;
         return;
     }
-    QString devName = videoDeviceList[curIndex].first;
+    const QString devName = videoDeviceList[curIndex].first;
     QVector<VideoMode> allVideoModes = CameraDevice::getVideoModes(devName);
 
     qDebug("available Modes:");
-    bool isScreen = CameraDevice::isScreen(devName);
+    const bool isScreen = CameraDevice::isScreen(devName);
     if (isScreen) {
         // Add extra video mode to region selection
         allVideoModes.push_back(VideoMode());
@@ -387,7 +390,7 @@ void AVForm::updateVideoModes(int curIndex)
         fillCameraModesComboBox();
     }
 
-    int preferredIndex = searchPreferredIndex();
+    const int preferredIndex = searchPreferredIndex();
     if (preferredIndex != -1) {
         videoSettings->setScreenGrabbed(false);
         videoModesComboBox->blockSignals(true);
@@ -398,8 +401,8 @@ void AVForm::updateVideoModes(int curIndex)
     }
 
     if (isScreen) {
-        QRect rect = videoSettings->getScreenRegion();
-        VideoMode mode(rect);
+        const QRect rect = videoSettings->getScreenRegion();
+        const VideoMode mode(rect);
 
         videoSettings->setScreenGrabbed(true);
         videoModesComboBox->setCurrentIndex(videoModes.size() - 1);
@@ -412,7 +415,7 @@ void AVForm::updateVideoModes(int curIndex)
     // and the best FPS for that resolution.
     // If we picked the lowest resolution, the quality would be awful
     // but if we picked the largest, FPS would be bad and thus quality bad too.
-    int mid = (videoModes.size() - 1) / 2;
+    const int mid = (videoModes.size() - 1) / 2;
     videoModesComboBox->setCurrentIndex(mid);
 }
 
@@ -421,9 +424,9 @@ void AVForm::on_videoDevCombobox_currentIndexChanged(int index)
     assert(0 <= index && index < videoDeviceList.size());
 
     videoSettings->setScreenGrabbed(false);
-    QString dev = videoDeviceList[index].first;
+    const QString dev = videoDeviceList[index].first;
     videoSettings->setVideoDev(dev);
-    bool previouslyBlocked = videoModesComboBox->blockSignals(true);
+    const bool previouslyBlocked = videoModesComboBox->blockSignals(true);
     updateVideoModes(index);
     videoModesComboBox->blockSignals(previouslyBlocked);
 
@@ -431,7 +434,7 @@ void AVForm::on_videoDevCombobox_currentIndexChanged(int index)
         return;
     }
 
-    int modeIndex = videoModesComboBox->currentIndex();
+    const int modeIndex = videoModesComboBox->currentIndex();
     VideoMode mode = VideoMode();
     if (0 <= modeIndex && modeIndex < videoModes.size()) {
         mode = videoModes[modeIndex];
@@ -451,13 +454,13 @@ void AVForm::on_audioQualityComboBox_currentIndexChanged(int index)
 
 void AVForm::getVideoDevices()
 {
-    QString settingsInDev = videoSettings->getVideoDev();
+    const QString settingsInDev = videoSettings->getVideoDev();
     int videoDevIndex = 0;
     videoDeviceList = CameraDevice::getDeviceList();
     // prevent currentIndexChanged to be fired while adding items
     videoDevCombobox->blockSignals(true);
     videoDevCombobox->clear();
-    for (QPair<QString, QString> device : videoDeviceList) {
+    for (const QPair<QString, QString>& device : videoDeviceList) {
         videoDevCombobox->addItem(device.second);
         if (device.first == settingsInDev)
             videoDevIndex = videoDevCombobox->count() - 1;
@@ -483,9 +486,9 @@ void AVForm::getAudioInDevices()
     inDevCombobox->blockSignals(false);
 
     int idx = 0;
-    bool enabled = audioSettings->getAudioInDevEnabled();
+    const bool enabled = audioSettings->getAudioInDevEnabled();
     if (enabled && deviceNames.size() > 1) {
-        QString dev = audioSettings->getInDev();
+        const QString dev = audioSettings->getInDev();
         idx = qMax(deviceNames.indexOf(dev), 1);
     }
     inDevCombobox->setCurrentIndex(idx);
@@ -502,9 +505,9 @@ void AVForm::getAudioOutDevices()
     outDevCombobox->blockSignals(false);
 
     int idx = 0;
-    bool enabled = audioSettings->getAudioOutDevEnabled();
+    const bool enabled = audioSettings->getAudioOutDevEnabled();
     if (enabled && deviceNames.size() > 1) {
-        QString dev = audioSettings->getOutDev();
+        const QString dev = audioSettings->getOutDev();
         idx = qMax(deviceNames.indexOf(dev), 1);
     }
     outDevCombobox->setCurrentIndex(idx);

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -208,7 +208,7 @@ GeneralForm::GeneralForm(Settings& settings_, Style& style_)
 
     bodyUI->cbSpellChecking->setChecked(settings.getSpellCheckingEnabled());
     bodyUI->lightTrayIcon->setChecked(settings.getLightTrayIcon());
-    bool showSystemTray = settings.getShowSystemTray();
+    const bool showSystemTray = settings.getShowSystemTray();
 
     bodyUI->showSystemTray->setChecked(showSystemTray);
     bodyUI->startInTray->setChecked(settings.getAutostartInTray());
@@ -297,7 +297,7 @@ void GeneralForm::on_conferenceJoinLeaveMessages_stateChanged()
 
 void GeneralForm::on_autoAwaySpinBox_editingFinished()
 {
-    int minutes = bodyUI->autoAwaySpinBox->value();
+    const int minutes = bodyUI->autoAwaySpinBox->value();
     settings.setAutoAwayTime(minutes);
 }
 
@@ -308,7 +308,7 @@ void GeneralForm::on_autoacceptFiles_stateChanged()
 
 void GeneralForm::on_autoSaveFilesDir_clicked()
 {
-    QString previousDir = settings.getGlobalAutoAcceptDir();
+    const QString previousDir = settings.getGlobalAutoAcceptDir();
     QString directory =
         QFileDialog::getExistingDirectory(Q_NULLPTR,
                                           tr("Choose an auto accept directory", "popup title"),

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -69,10 +69,10 @@ void PrivacyForm::on_cbTypingNotification_stateChanged()
 
 void PrivacyForm::on_nospamLineEdit_editingFinished()
 {
-    QString newNospam = bodyUI->nospamLineEdit->text();
+    const QString newNospam = bodyUI->nospamLineEdit->text();
 
     bool ok;
-    uint32_t nospam = newNospam.toLongLong(&ok, 16);
+    const uint32_t nospam = newNospam.toLongLong(&ok, 16);
     if (ok) {
         core->setNospam(nospam);
     }
@@ -102,7 +102,7 @@ void PrivacyForm::on_randomNospamButton_clicked()
 void PrivacyForm::on_nospamLineEdit_textChanged()
 {
     QString str = bodyUI->nospamLineEdit->text();
-    int curs = bodyUI->nospamLineEdit->cursorPosition();
+    const int curs = bodyUI->nospamLineEdit->cursorPosition();
     if (str.length() != 8) {
         str = QString("00000000").replace(0, str.length(), str);
         bodyUI->nospamLineEdit->setText(str);

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -56,7 +56,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
     const QFont chatBaseFont = settings.getChatMessageFont();
     bodyUI->txtChatFontSize->setValue(QFontInfo(chatBaseFont).pixelSize());
     bodyUI->txtChatFont->setCurrentFont(chatBaseFont);
-    int index = static_cast<int>(settings.getStylePreference());
+    const int index = static_cast<int>(settings.getStylePreference());
     bodyUI->textStyleComboBox->setCurrentIndex(index);
     bodyUI->useNameColors->setChecked(settings.getEnableConferencesColor());
 
@@ -90,7 +90,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
 
     smileLabels = {bodyUI->smile1, bodyUI->smile2, bodyUI->smile3, bodyUI->smile4, bodyUI->smile5};
 
-    int currentPack = bodyUI->smileyPackBrowser->findData(settings.getSmileyPack());
+    const int currentPack = bodyUI->smileyPackBrowser->findData(settings.getSmileyPack());
     bodyUI->smileyPackBrowser->setCurrentIndex(currentPack);
     reloadSmileys();
     bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
@@ -106,13 +106,13 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
 
     bodyUI->styleBrowser->setCurrentText(textStyle);
 
-    for (QString color : Style::getThemeColorNames())
+    for (const QString& color : Style::getThemeColorNames())
         bodyUI->themeColorCBox->addItem(color);
 
     bodyUI->themeColorCBox->setCurrentIndex(settings.getThemeColor());
     bodyUI->emoticonSize->setValue(settings.getEmojiFontPointSize());
 
-    QLocale ql;
+    const QLocale ql;
     QStringList timeFormats;
     timeFormats << ql.timeFormat(QLocale::ShortFormat) << ql.timeFormat(QLocale::LongFormat)
                 << "hh:mm AP"
@@ -121,7 +121,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
     timeFormats.removeDuplicates();
     bodyUI->timestamp->addItems(timeFormats);
 
-    QRegularExpression re(QString("^[^\\n]{0,%0}$").arg(MAX_FORMAT_LENGTH));
+    const QRegularExpression re(QString("^[^\\n]{0,%0}$").arg(MAX_FORMAT_LENGTH));
     QRegularExpressionValidator* validator = new QRegularExpressionValidator(re, this);
     QString timeFormat = settings.getTimestampFormat();
 
@@ -180,21 +180,21 @@ void UserInterfaceForm::on_emoticonSize_editingFinished()
 
 void UserInterfaceForm::on_timestamp_editTextChanged(const QString& format)
 {
-    QString timeExample = QTime::currentTime().toString(format);
+    const QString timeExample = QTime::currentTime().toString(format);
     bodyUI->timeExample->setText(timeExample);
 
     settings.setTimestampFormat(format);
-    QString locale = settings.getTranslation();
+    const QString locale = settings.getTranslation();
     Translator::translate(locale);
 }
 
 void UserInterfaceForm::on_dateFormats_editTextChanged(const QString& format)
 {
-    QString dateExample = QDate::currentDate().toString(format);
+    const QString dateExample = QDate::currentDate().toString(format);
     bodyUI->dateExample->setText(dateExample);
 
     settings.setDateFormat(format);
-    QString locale = settings.getTranslation();
+    const QString locale = settings.getTranslation();
     Translator::translate(locale);
 }
 
@@ -206,14 +206,14 @@ void UserInterfaceForm::on_useEmoticons_stateChanged()
 
 void UserInterfaceForm::on_textStyleComboBox_currentTextChanged()
 {
-    Settings::StyleType styleType =
+    const Settings::StyleType styleType =
         static_cast<Settings::StyleType>(bodyUI->textStyleComboBox->currentIndex());
     settings.setStylePreference(styleType);
 }
 
 void UserInterfaceForm::on_smileyPackBrowser_currentIndexChanged(int index)
 {
-    QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
+    const QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
     settings.setSmileyPack(filename);
     reloadSmileys();
 }
@@ -223,7 +223,7 @@ void UserInterfaceForm::on_smileyPackBrowser_currentIndexChanged(int index)
  */
 void UserInterfaceForm::reloadSmileys()
 {
-    QList<QStringList> emoticons = smileyPack.getEmoticons();
+    const QList<QStringList> emoticons = smileyPack.getEmoticons();
 
     // sometimes there are no emoticons available, don't crash in this case
     if (emoticons.isEmpty()) {
@@ -239,7 +239,7 @@ void UserInterfaceForm::reloadSmileys()
     emoticonsIcons.clear();
     const QSize size(18, 18);
     for (int i = 0; i < smileLabels.size(); ++i) {
-        std::shared_ptr<QIcon> icon = smileyPack.getAsIcon(smileys[i]);
+        const std::shared_ptr<QIcon> icon = smileyPack.getAsIcon(smileys[i]);
         emoticonsIcons.append(icon);
         smileLabels[i]->setPixmap(icon->pixmap(size));
         smileLabels[i]->setToolTip(smileys[i]);
@@ -249,10 +249,10 @@ void UserInterfaceForm::reloadSmileys()
     auto geometry = QGuiApplication::primaryScreen()->geometry();
     // 8 is the count of row and column in emoji's in widget
     const int sideSize = 8;
-    int maxSide = qMin(geometry.height() / sideSize, geometry.width() / sideSize);
-    QSize maxSize(maxSide, maxSide);
+    const int maxSide = qMin(geometry.height() / sideSize, geometry.width() / sideSize);
+    const QSize maxSize(maxSide, maxSide);
 
-    QSize actualSize = emoticonsIcons.first()->actualSize(maxSize);
+    const QSize actualSize = emoticonsIcons.first()->actualSize(maxSize);
     bodyUI->emoticonSize->setMaximum(actualSize.width());
 }
 
@@ -315,7 +315,7 @@ void UserInterfaceForm::on_cbCompactLayout_stateChanged()
 
 void UserInterfaceForm::on_cbSeparateWindow_stateChanged()
 {
-    bool checked = bodyUI->cbSeparateWindow->isChecked();
+    const bool checked = bodyUI->cbSeparateWindow->isChecked();
     bodyUI->cbDontGroupWindows->setEnabled(checked);
     settings.setSeparateWindow(checked);
 }
@@ -348,7 +348,7 @@ void UserInterfaceForm::on_themeColorCBox_currentIndexChanged(int index)
 void UserInterfaceForm::retranslateUi()
 {
     // Block signals during translation to prevent settings change
-    RecursiveSignalBlocker signalBlocker{this};
+    const RecursiveSignalBlocker signalBlocker{this};
 
     bodyUI->retranslateUi(this);
 

--- a/src/widget/form/tabcompleter.cpp
+++ b/src/widget/form/tabcompleter.cpp
@@ -48,13 +48,13 @@ void TabCompleter::buildCompletionList()
 
     // split the string on the given RE (not chars, nums or braces/brackets) and take the last
     // section
-    QString tabAbbrev = msgEdit->toPlainText()
-                            .left(msgEdit->textCursor().position())
-                            .section(QRegularExpression(R"([^\w\d\$:@_\[\]{}|`^.\\-])"), -1, -1);
+    const QString tabAbbrev = msgEdit->toPlainText()
+                                  .left(msgEdit->textCursor().position())
+                                  .section(QRegularExpression(R"([^\w\d\$:@_\[\]{}|`^.\\-])"), -1, -1);
     // that section is then used as the completion regex
-    QRegularExpression regex(QStringLiteral(R"(^[-_\[\]{}|`^.\\]*)")
-                                 .append(QRegularExpression::escape(tabAbbrev)),
-                             QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpression regex(QStringLiteral(R"(^[-_\[\]{}|`^.\\]*)")
+                                       .append(QRegularExpression::escape(tabAbbrev)),
+                                   QRegularExpression::CaseInsensitiveOption);
 
     const QString ownNick = conference->getSelfName();
     for (const auto& name : conference->getPeerList()) {
@@ -62,7 +62,7 @@ void TabCompleter::buildCompletionList()
             continue; // don't auto complete own name
         }
         if (regex.match(name).hasMatch()) {
-            SortableString lower = SortableString(name.toLower());
+            const SortableString lower = SortableString(name.toLower());
             completionMap[lower] = name;
         }
     }

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -48,7 +48,7 @@ Time getTimeBucket(const QDateTime& date)
         return Time::Never;
     }
 
-    QDate today = QDate::currentDate();
+    const QDate today = QDate::currentDate();
     // clang-format off
     const QMap<Time, QDate> dates {
         { Time::Today,     today.addDays(0)    },
@@ -63,7 +63,7 @@ Time getTimeBucket(const QDateTime& date)
     };
     // clang-format on
 
-    for (Time time : dates.keys()) {
+    for (const Time time : dates.keys()) {
         if (dates[time] <= date.date()) {
             return time;
         }
@@ -79,7 +79,7 @@ QDateTime getActiveTimeFriend(const Friend* contact, Settings& settings)
 
 qint64 timeUntilTomorrow()
 {
-    QDateTime now = QDateTime::currentDateTime();
+    const QDateTime now = QDateTime::currentDateTime();
     QDateTime tomorrow = now.addDays(1); // Tomorrow.
     tomorrow.setTime(QTime());           // Midnight.
     return now.msecsTo(tomorrow);
@@ -99,7 +99,7 @@ FriendListWidget::FriendListWidget(const Core& core_, Widget* parent, Settings& 
     , conferenceList{conferenceList_}
     , profile{profile_}
 {
-    int countContacts = core.getFriendList().size();
+    const int countContacts = core.getFriendList().size();
     manager = new FriendListManager(countContacts, this);
     manager->setConferencesOnTop(conferencesOnTop);
     connect(manager, &FriendListManager::itemsChanged, this, &FriendListWidget::itemsChanged);
@@ -154,7 +154,7 @@ void FriendListWidget::sortByMode()
             addCircleWidget(i);
         }
 
-        QVector<std::shared_ptr<IFriendListItem>> itemsTmp = manager->getItems(); // Sorted items
+        const QVector<std::shared_ptr<IFriendListItem>> itemsTmp = manager->getItems(); // Sorted items
         QVector<IFriendListItem*> friendItems; // Items that are not included in the circle
         int posByName = 0;                     // Needed for scroll contacts
         // Linking a friend with a circle and setting scroll position
@@ -194,7 +194,8 @@ void FriendListWidget::sortByMode()
 
             for (auto circle : circles) {
 
-                QVector<std::shared_ptr<IFriendListItem>> itemsInCircle = getItemsFromCircle(circle);
+                const QVector<std::shared_ptr<IFriendListItem>> itemsInCircle =
+                    getItemsFromCircle(circle);
                 for (const auto& j : itemsInCircle) {
                     j->setNameSortedPos(posByName++);
                 }
@@ -210,8 +211,8 @@ void FriendListWidget::sortByMode()
         }
         cleanMainLayout();
 
-        QLocale ql(settings.getTranslation());
-        QDate today = QDate::currentDate();
+        const QLocale ql(settings.getTranslation());
+        const QDate today = QDate::currentDate();
 #define COMMENT "Category for sorting friends by activity"
         // clang-format off
         const QMap<Time, QString> names {
@@ -230,15 +231,15 @@ void FriendListWidget::sortByMode()
 // clang-format on
 #undef COMMENT
 
-        QVector<std::shared_ptr<IFriendListItem>> itemsTmp = manager->getItems();
+        const QVector<std::shared_ptr<IFriendListItem>> itemsTmp = manager->getItems();
 
         for (auto& i : itemsTmp) {
             listLayout->addWidget(i->getWidget());
         }
 
         activityLayout = new QVBoxLayout();
-        bool compact = settings.getCompactLayout();
-        for (Time t : names.keys()) {
+        const bool compact = settings.getCompactLayout();
+        for (const Time t : names.keys()) {
             CategoryWidget* category = new CategoryWidget(compact, settings, style, this);
             category->setName(names[t]);
             activityLayout->addWidget(category);
@@ -250,7 +251,7 @@ void FriendListWidget::sortByMode()
         // Insert widgets to CategoryWidget
         for (auto& i : itemsTmp) {
             if (i->isFriend()) {
-                int timeIndex = static_cast<int>(getTimeBucket(i->getLastActivity()));
+                const int timeIndex = static_cast<int>(getTimeBucket(i->getLastActivity()));
                 QWidget* widget = activityLayout->itemAt(timeIndex)->widget();
                 CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(widget);
                 FriendWidget* frnd = qobject_cast<FriendWidget*>((i.get())->getWidget());
@@ -299,7 +300,7 @@ void FriendListWidget::cleanMainLayout()
 
 QWidget* FriendListWidget::getNextWidgetForName(IFriendListItem* currentPos, bool forward) const
 {
-    int pos = currentPos->getNameSortedPos();
+    const int pos = currentPos->getNameSortedPos();
     int nextPos = forward ? pos + 1 : pos - 1;
     if (nextPos >= manager->getItems().size()) {
         nextPos = 0;
@@ -317,10 +318,10 @@ QWidget* FriendListWidget::getNextWidgetForName(IFriendListItem* currentPos, boo
 
 QVector<std::shared_ptr<IFriendListItem>> FriendListWidget::getItemsFromCircle(CircleWidget* circle) const
 {
-    QVector<std::shared_ptr<IFriendListItem>> itemsTmp = manager->getItems();
+    const QVector<std::shared_ptr<IFriendListItem>> itemsTmp = manager->getItems();
     QVector<std::shared_ptr<IFriendListItem>> itemsInCircle;
     for (const auto& i : itemsTmp) {
-        int circleId = i->getCircleId();
+        const int circleId = i->getCircleId();
         if (CircleWidget::getFromID(circleId) == circle) {
             itemsInCircle.push_back(i);
         }
@@ -331,7 +332,7 @@ QVector<std::shared_ptr<IFriendListItem>> FriendListWidget::getItemsFromCircle(C
 CategoryWidget* FriendListWidget::getTimeCategoryWidget(const Friend* frd) const
 {
     const auto activityTime = getActiveTimeFriend(frd, settings);
-    int timeIndex = static_cast<int>(getTimeBucket(activityTime));
+    const int timeIndex = static_cast<int>(getTimeBucket(activityTime));
     QWidget* widget = activityLayout->itemAt(timeIndex)->widget();
     return qobject_cast<CategoryWidget*>(widget);
 }
@@ -366,7 +367,7 @@ void FriendListWidget::removeConferenceWidget(ConferenceWidget* w)
 void FriendListWidget::removeFriendWidget(FriendWidget* w)
 {
     const Friend* contact = w->getFriend();
-    int id = settings.getFriendCircleID(contact->getPublicKey());
+    const int id = settings.getFriendCircleID(contact->getPublicKey());
     CircleWidget* circleWidget = CircleWidget::getFromID(id);
     if (circleWidget != nullptr) {
         circleWidget->removeFriendWidget(w, contact->getStatus());
@@ -515,7 +516,7 @@ void FriendListWidget::dragEnterEvent(QDragEnterEvent* event)
     if (!event->mimeData()->hasFormat("toxPk")) {
         return;
     }
-    ToxPk toxPk(event->mimeData()->data("toxPk"));
+    const ToxPk toxPk(event->mimeData()->data("toxPk"));
     Friend* frnd = friendList.findFriend(toxPk);
     if (frnd)
         event->acceptProposedAction();
@@ -537,7 +538,7 @@ void FriendListWidget::dropEvent(QDropEvent* event)
         return;
 
     // Save CircleWidget before changing the Id
-    int circleId = settings.getFriendCircleID(f->getPublicKey());
+    const int circleId = settings.getFriendCircleID(f->getPublicKey());
     CircleWidget* circleWidget = CircleWidget::getFromID(circleId);
 
     moveWidget(widget, f->getStatus(), true);
@@ -564,7 +565,7 @@ void FriendListWidget::moveWidget(FriendWidget* widget, Status::Status s, bool a
 {
     if (mode == SortingMode::Name) {
         const Friend* f = widget->getFriend();
-        int circleId = settings.getFriendCircleID(f->getPublicKey());
+        const int circleId = settings.getFriendCircleID(f->getPublicKey());
         CircleWidget* circleWidget = CircleWidget::getFromID(circleId);
 
         if (circleWidget == nullptr || add) {
@@ -592,7 +593,7 @@ void FriendListWidget::updateActivityTime(const QDateTime& time)
     if (mode != SortingMode::Activity)
         return;
 
-    int timeIndex = static_cast<int>(getTimeBucket(time));
+    const int timeIndex = static_cast<int>(getTimeBucket(time));
     QWidget* widget = activityLayout->itemAt(timeIndex)->widget();
     CategoryWidget* categoryWidget = static_cast<CategoryWidget*>(widget);
     categoryWidget->updateStatus();

--- a/src/widget/genericchatitemlayout.cpp
+++ b/src/widget/genericchatitemlayout.cpp
@@ -27,7 +27,7 @@ GenericChatItemLayout::~GenericChatItemLayout()
 void GenericChatItemLayout::addSortedWidget(GenericChatItemWidget* widget, int stretch,
                                             Qt::Alignment alignment)
 {
-    int closest = indexOfClosestSortedWidget(widget);
+    const int closest = indexOfClosestSortedWidget(widget);
     layout->insertWidget(closest, widget, stretch, alignment);
 }
 
@@ -36,7 +36,7 @@ int GenericChatItemLayout::indexOfSortedWidget(GenericChatItemWidget* widget) co
     if (layout->isEmpty())
         return -1;
 
-    int index = indexOfClosestSortedWidget(widget);
+    const int index = indexOfClosestSortedWidget(widget);
 
     if (index >= layout->count())
         return -1;
@@ -61,7 +61,7 @@ void GenericChatItemLayout::removeSortedWidget(GenericChatItemWidget* widget)
     if (layout->isEmpty())
         return;
 
-    int index = indexOfClosestSortedWidget(widget);
+    const int index = indexOfClosestSortedWidget(widget);
 
     if (layout->itemAt(index) == nullptr)
         return;
@@ -95,7 +95,7 @@ int GenericChatItemLayout::indexOfClosestSortedWidget(GenericChatItemWidget* wid
     // Binary search: Deferred test of equality.
     int min = 0, max = layout->count();
     while (min < max) {
-        int mid = (max - min) / 2 + min;
+        const int mid = (max - min) / 2 + min;
         GenericChatItemWidget* atMid =
             qobject_cast<GenericChatItemWidget*>(layout->itemAt(mid)->widget());
         assert(atMid != nullptr);
@@ -105,7 +105,7 @@ int GenericChatItemLayout::indexOfClosestSortedWidget(GenericChatItemWidget* wid
         QCollator collator;
         collator.setNumericMode(true);
 
-        int compareValue = collator.compare(atMid->getName(), widget->getName());
+        const int compareValue = collator.compare(atMid->getName(), widget->getName());
 
         if (compareValue < 0)
             lessThan = true;

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -76,7 +76,7 @@ void LoginScreen::reset(const QString& initialProfileName)
     ui->loginPassword->clear();
     ui->loginUsernames->clear();
 
-    QStringList allProfileNames = Profile::getAllProfileNames(paths);
+    const QStringList allProfileNames = Profile::getAllProfileNames(paths);
 
     if (allProfileNames.isEmpty()) {
         ui->stackedWidget->setCurrentIndex(0);
@@ -137,8 +137,8 @@ void LoginScreen::onLoginPageClicked()
 
 void LoginScreen::onCreateNewProfile()
 {
-    QString name = ui->newUsername->text();
-    QString pass = ui->newPass->text();
+    const QString name = ui->newUsername->text();
+    const QString pass = ui->newPass->text();
 
     if (name.isEmpty()) {
         emit failure(tr("Couldn't create a new profile"), tr("The username must not be empty."));
@@ -191,8 +191,8 @@ void LoginScreen::onLoginUsernameSelected(const QString& name)
 
 void LoginScreen::onLogin()
 {
-    QString name = ui->loginUsernames->currentText();
-    QString pass = ui->loginPassword->text();
+    const QString name = ui->loginUsernames->currentText();
+    const QString pass = ui->loginPassword->text();
 
     // name can be empty when there are no profiles
     if (name.isEmpty()) {

--- a/src/widget/maskablepixmapwidget.cpp
+++ b/src/widget/maskablepixmapwidget.cpp
@@ -61,7 +61,7 @@ void MaskablePixmapWidget::setSize(QSize size)
     delete renderTarget;
     renderTarget = new QPixmap(size);
 
-    QPixmap pmapMask = QPixmap(maskName);
+    const QPixmap pmapMask = QPixmap(maskName);
     if (!pmapMask.isNull()) {
         mask = pmapMask.scaled(size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     }
@@ -85,8 +85,8 @@ void MaskablePixmapWidget::updatePixmap()
 {
     renderTarget->fill(Qt::transparent);
 
-    QPoint offset((width() - pixmap.size().width()) / 2,
-                  (height() - pixmap.size().height()) / 2); // centering the pixmap
+    const QPoint offset((width() - pixmap.size().width()) / 2,
+                        (height() - pixmap.size().height()) / 2); // centering the pixmap
 
     QPainter painter(renderTarget);
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -22,7 +22,7 @@ void NotificationScrollArea::trackWidget(Settings& settings, Style& style, Gener
     if (trackedWidgets.contains(widget))
         return;
 
-    Visibility visibility = widgetVisible(widget);
+    const Visibility visibility = widgetVisible(widget);
     if (visibility != Visible) {
         if (visibility == Above) {
             if (referencesAbove++ == 0) {
@@ -119,7 +119,7 @@ void NotificationScrollArea::findNextWidget()
     // Try finding a closer one.
     for (; i != trackedWidgets.end(); ++i) {
         if (i.value() == Below) {
-            int y = i.key()->mapTo(viewport(), QPoint()).y();
+            const int y = i.key()->mapTo(viewport(), QPoint()).y();
             if (y < value) {
                 next = i.key();
                 value = y;
@@ -149,7 +149,7 @@ void NotificationScrollArea::findPreviousWidget()
     // Try finding a closer one.
     for (; i != trackedWidgets.end(); ++i) {
         if (i.value() == Above) {
-            int y = i.key()->mapTo(viewport(), QPoint()).y();
+            const int y = i.key()->mapTo(viewport(), QPoint()).y();
             if (y > value) {
                 next = i.key();
                 value = y;
@@ -163,7 +163,7 @@ void NotificationScrollArea::findPreviousWidget()
 
 NotificationScrollArea::Visibility NotificationScrollArea::widgetVisible(QWidget* widget) const
 {
-    int y = widget->mapTo(viewport(), QPoint()).y();
+    const int y = widget->mapTo(viewport(), QPoint()).y();
 
     if (y < 0)
         return Above;

--- a/src/widget/passwordedit.cpp
+++ b/src/widget/passwordedit.cpp
@@ -81,7 +81,7 @@ PasswordEdit::EventHandler::~EventHandler()
 void PasswordEdit::EventHandler::updateActions()
 {
 #ifdef QTOX_PLATFORM_EXT
-    bool caps = Platform::capsLockEnabled();
+    const bool caps = Platform::capsLockEnabled();
 
     for (QAction* actionIt : actions)
         actionIt->setVisible(caps);

--- a/src/widget/qrwidget.cpp
+++ b/src/widget/qrwidget.cpp
@@ -70,8 +70,8 @@ void QRWidget::paintImage()
     QRcode* qr = QRcode_encodeString(dataString.c_str(), 1, QR_ECLEVEL_M, QR_MODE_8, 1);
 
     if (qr != nullptr) {
-        QColor fg("black");
-        QColor bg("white");
+        const QColor fg("black");
+        const QColor bg("white");
         painter.setBrush(bg);
         painter.setPen(Qt::NoPen);
         painter.drawRect(0, 0, size.width(), size.height());
@@ -91,14 +91,14 @@ void QRWidget::paintImage()
                 const unsigned char b = qr->data[xx];
                 if (b & 0x01) {
                     const double rx1 = x * scale, ry1 = y * scale;
-                    QRectF r(rx1, ry1, scale, scale);
+                    const QRectF r(rx1, ry1, scale, scale);
                     painter.drawRects(&r, 1);
                 }
             }
         }
         QRcode_free(qr);
     } else {
-        QColor error("red");
+        const QColor error("red");
         painter.setBrush(error);
         painter.drawRect(0, 0, width(), height());
         qDebug() << "QR FAIL:" << strerror(errno);

--- a/src/widget/searchform.cpp
+++ b/src/widget/searchform.cpp
@@ -303,7 +303,7 @@ LineEdit::LineEdit(QWidget* parent)
 
 void LineEdit::keyPressEvent(QKeyEvent* event)
 {
-    int key = event->key();
+    const int key = event->key();
 
     if ((key == Qt::Key_Enter || key == Qt::Key_Return)) {
         if ((event->modifiers() & Qt::ShiftModifier)) {

--- a/src/widget/splitterrestorer.cpp
+++ b/src/widget/splitterrestorer.cpp
@@ -42,8 +42,9 @@ SplitterRestorer::SplitterRestorer(QSplitter* splitter_)
  */
 void SplitterRestorer::restore(const QByteArray& state, const QSize& windowSize)
 {
-    bool brokenSplitter = !splitter->restoreState(state) || splitter->orientation() != Qt::Horizontal
-                          || splitter->handleWidth() > defaultWidth;
+    const bool brokenSplitter = !splitter->restoreState(state)
+                                || splitter->orientation() != Qt::Horizontal
+                                || splitter->handleWidth() > defaultWidth;
 
     if (splitter->count() == 2 && brokenSplitter) {
         splitter->setOrientation(Qt::Horizontal);

--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -234,7 +234,7 @@ QFont Style::getFont(Font font)
 
 const QString Style::resolve(const QString& filename, int themeColor, const QFont& baseFont)
 {
-    QString themePath = getThemeFolder(themeColor);
+    const QString themePath = getThemeFolder(themeColor);
     QString fullPath = themePath + filename;
     QString qss;
 
@@ -294,7 +294,7 @@ const QString Style::resolve(const QString& filename, int themeColor, const QFon
     QRegularExpressionMatchIterator i = re.globalMatch(qss);
 
     while (i.hasNext()) {
-        QRegularExpressionMatch match = i.next();
+        const QRegularExpressionMatch match = i.next();
         QString path = match.captured(0);
         const QString phrase = path;
 

--- a/src/widget/tool/adjustingscrollarea.cpp
+++ b/src/widget/tool/adjustingscrollarea.cpp
@@ -17,7 +17,7 @@ AdjustingScrollArea::AdjustingScrollArea(QWidget* parent)
 
 void AdjustingScrollArea::resizeEvent(QResizeEvent* ev)
 {
-    int scrollBarWidth =
+    const int scrollBarWidth =
         verticalScrollBar()->isVisible() ? verticalScrollBar()->sizeHint().width() : 0;
 
     if (layoutDirection() == Qt::RightToLeft)
@@ -30,7 +30,7 @@ void AdjustingScrollArea::resizeEvent(QResizeEvent* ev)
 QSize AdjustingScrollArea::sizeHint() const
 {
     if (widget()) {
-        int scrollbarWidth = verticalScrollBar()->isVisible() ? verticalScrollBar()->width() : 0;
+        const int scrollbarWidth = verticalScrollBar()->isVisible() ? verticalScrollBar()->width() : 0;
         return widget()->sizeHint() + QSize(scrollbarWidth, 0);
     }
 

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -62,11 +62,11 @@ CallConfirmWidget::CallConfirmWidget(Settings& settings, Style& style, const QWi
     // Note: At the moment this may not work properly. For languages written
     // from right to left, there is no translation for the phrase "Incoming call...".
     // In this situation, the phrase "Incoming call..." looks as "...oming call..."
-    Qt::TextElideMode elideMode =
+    const Qt::TextElideMode elideMode =
         (QGuiApplication::layoutDirection() == Qt::LeftToRight) ? Qt::ElideRight : Qt::ElideLeft;
-    int marginSize = 12;
-    QFontMetrics fontMetrics(callLabel->font());
-    QString elidedText =
+    const int marginSize = 12;
+    const QFontMetrics fontMetrics(callLabel->font());
+    const QString elidedText =
         fontMetrics.elidedText(callLabel->text(), elideMode, rectW - marginSize * 2 - 4);
     callLabel->setText(elidedText);
 

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -29,7 +29,7 @@ ChatTextEdit::~ChatTextEdit()
 
 void ChatTextEdit::keyPressEvent(QKeyEvent* event)
 {
-    int key = event->key();
+    const int key = event->key();
     if ((key == Qt::Key_Enter || key == Qt::Key_Return) && !(event->modifiers() & Qt::ShiftModifier)) {
         emit enterPressed();
         return;

--- a/src/widget/tool/croppinglabel.cpp
+++ b/src/widget/tool/croppinglabel.cpp
@@ -117,7 +117,7 @@ void CroppingLabel::paintEvent(QPaintEvent* paintEvent)
 
 void CroppingLabel::setElidedText()
 {
-    QString elidedText = fontMetrics().elidedText(origText, elideMode, width());
+    const QString elidedText = fontMetrics().elidedText(origText, elideMode, width());
     if (elidedText != origText)
         setToolTip(Qt::convertFromPlainText(origText, Qt::WhiteSpaceNormal));
     else
@@ -164,7 +164,7 @@ void CroppingLabel::minimizeMaximumWidth()
 void CroppingLabel::editingFinished()
 {
     hideTextEdit();
-    QString newText =
+    const QString newText =
         textEdit->text().trimmed().remove(QRegularExpression("[\\t\\n\\v\\f\\r\\x0000]"));
 
     if (origText != newText)

--- a/src/widget/tool/flyoutoverlaywidget.cpp
+++ b/src/widget/tool/flyoutoverlaywidget.cpp
@@ -48,7 +48,7 @@ void FlyoutOverlayWidget::setFlyoutPercent(qreal progress)
 {
     percent = progress;
 
-    QSize self = size();
+    const QSize self = size();
     setMask(QRegion(0, 0, self.width() * progress + 1, self.height()));
     move(startPos.x() + self.width() - self.width() * percent, startPos.y());
     setVisible(progress != 0);
@@ -90,7 +90,7 @@ void FlyoutOverlayWidget::animateHide()
 
 void FlyoutOverlayWidget::finishedAnimation()
 {
-    bool hide = (animation->direction() == QAbstractAnimation::Backward);
+    const bool hide = (animation->direction() == QAbstractAnimation::Backward);
 
     // Delay it by a few frames to let the system catch up on rendering
     if (hide)

--- a/src/widget/tool/messageboxmanager.cpp
+++ b/src/widget/tool/messageboxmanager.cpp
@@ -122,12 +122,12 @@ void MessageBoxManager::confirmExecutableOpen(const QFileInfo& file)
     };
 
     if (dangerousExtensions.contains(file.suffix())) {
-        bool answer = askQuestion(tr("Executable file", "popup title"),
-                                  tr("You have asked qTox to open an executable file. "
-                                     "Executable files can potentially damage your computer. "
-                                     "Are you sure want to open this file?",
-                                     "popup text"),
-                                  false, true);
+        const bool answer = askQuestion(tr("Executable file", "popup title"),
+                                        tr("You have asked qTox to open an executable file. "
+                                           "Executable files can potentially damage your computer. "
+                                           "Are you sure want to open this file?",
+                                           "popup text"),
+                                        false, true);
         if (!answer) {
             return;
         }
@@ -161,8 +161,8 @@ void MessageBoxManager::_showError(const QString& title, const QString& msg)
 bool MessageBoxManager::_askQuestion(const QString& title, const QString& msg, bool defaultAns,
                                      bool warning, bool yesno)
 {
-    QString positiveButton = yesno ? QApplication::tr("Yes") : QApplication::tr("Ok");
-    QString negativeButton = yesno ? QApplication::tr("No") : QApplication::tr("Cancel");
+    const QString positiveButton = yesno ? QApplication::tr("Yes") : QApplication::tr("Ok");
+    const QString negativeButton = yesno ? QApplication::tr("No") : QApplication::tr("Cancel");
 
     return _askQuestion(title, msg, positiveButton, negativeButton, defaultAns, warning);
 }
@@ -170,7 +170,7 @@ bool MessageBoxManager::_askQuestion(const QString& title, const QString& msg, b
 bool MessageBoxManager::_askQuestion(const QString& title, const QString& msg, const QString& button1,
                                      const QString& button2, bool defaultAns, bool warning)
 {
-    QMessageBox::Icon icon = warning ? QMessageBox::Warning : QMessageBox::Question;
+    const QMessageBox::Icon icon = warning ? QMessageBox::Warning : QMessageBox::Question;
     QMessageBox box(icon, title, msg, QMessageBox::NoButton, this);
     QPushButton* pushButton1 = box.addButton(button1, QMessageBox::AcceptRole);
     QPushButton* pushButton2 = box.addButton(button2, QMessageBox::RejectRole);

--- a/src/widget/tool/movablewidget.cpp
+++ b/src/widget/tool/movablewidget.cpp
@@ -38,11 +38,12 @@ void MovableWidget::setBoundary(QRect newBoundary)
         return;
     }
 
-    qreal changeX = newBoundary.width() / static_cast<qreal>(boundaryRect.width());
-    qreal changeY = newBoundary.height() / static_cast<qreal>(boundaryRect.height());
+    const qreal changeX = newBoundary.width() / static_cast<qreal>(boundaryRect.width());
+    const qreal changeY = newBoundary.height() / static_cast<qreal>(boundaryRect.height());
 
-    qreal percentageX = (x() - boundaryRect.x()) / static_cast<qreal>(boundaryRect.width() - width());
-    qreal percentageY =
+    const qreal percentageX =
+        (x() - boundaryRect.x()) / static_cast<qreal>(boundaryRect.width() - width());
+    const qreal percentageY =
         (y() - boundaryRect.y()) / static_cast<qreal>(boundaryRect.height() - height());
 
     actualSize.setWidth(actualSize.width() * changeX);
@@ -60,7 +61,7 @@ void MovableWidget::setBoundary(QRect newBoundary)
                         percentageY * (newBoundary.height() - height()));
     actualPos += QPointF(newBoundary.topLeft());
 
-    QPoint moveTo = QPoint(round(actualPos.x()), round(actualPos.y()));
+    const QPoint moveTo = QPoint(round(actualPos.x()), round(actualPos.y()));
     move(moveTo);
 
     boundaryRect = newBoundary;
@@ -143,7 +144,7 @@ void MovableWidget::mouseMoveEvent(QMouseEvent* event)
 
             if (event->buttons() & Qt::LeftButton) {
                 QPoint lastPosition = pos();
-                QPoint displacement = lastPoint - event->globalPosition().toPoint();
+                const QPoint displacement = lastPoint - event->globalPosition().toPoint();
                 QSize lastSize = size();
 
 
@@ -179,7 +180,7 @@ void MovableWidget::mouseMoveEvent(QMouseEvent* event)
 
                 if (mode & (ResizeLeft | ResizeRight)) {
                     if (mode & (ResizeUp | ResizeDown)) {
-                        int height = lastSize.width() / getRatio();
+                        const int height = lastSize.width() / getRatio();
 
                         if (!(mode & ResizeDown))
                             lastPosition.setY(lastPosition.y() - (height - lastSize.height()));

--- a/src/widget/tool/profileimporter.cpp
+++ b/src/widget/tool/profileimporter.cpp
@@ -32,14 +32,14 @@ ProfileImporter::ProfileImporter(Paths& paths_, QWidget* parent)
  */
 bool ProfileImporter::importProfile()
 {
-    QString title = tr("Import profile", "import dialog title");
-    QString filter = tr("Tox save file (*.tox)", "import dialog filter");
-    QString dir = QDir::homePath();
+    const QString title = tr("Import profile", "import dialog title");
+    const QString filter = tr("Tox save file (*.tox)", "import dialog filter");
+    const QString dir = QDir::homePath();
 
     // TODO: Change all QFileDialog instances across project to use
     // this instead of Q_NULLPTR. Possibly requires >Qt 5.9 due to:
     // https://bugreports.qt.io/browse/QTBUG-59184
-    QString path = QFileDialog::getOpenFileName(Q_NULLPTR, title, dir, filter);
+    const QString path = QFileDialog::getOpenFileName(Q_NULLPTR, title, dir, filter);
 
     return importProfile(path);
 }
@@ -52,7 +52,7 @@ bool ProfileImporter::importProfile()
  */
 bool ProfileImporter::askQuestion(QString title, QString message)
 {
-    QMessageBox::Icon icon = QMessageBox::Warning;
+    const QMessageBox::Icon icon = QMessageBox::Warning;
     QMessageBox box(icon, title, message, QMessageBox::NoButton, this);
     QPushButton* pushButton1 = box.addButton(QApplication::tr("Yes"), QMessageBox::AcceptRole);
     QPushButton* pushButton2 = box.addButton(QApplication::tr("No"), QMessageBox::RejectRole);
@@ -73,14 +73,14 @@ bool ProfileImporter::importProfile(const QString& path)
     if (path.isEmpty())
         return false;
 
-    QFileInfo info(path);
+    const QFileInfo info(path);
     if (!info.exists()) {
         QMessageBox::warning(this, tr("File doesn't exist"), tr("Profile doesn't exist"),
                              QMessageBox::Ok);
         return false;
     }
 
-    QString profile = info.completeBaseName();
+    const QString profile = info.completeBaseName();
 
     if (info.suffix() != "tox") {
         QMessageBox::warning(this, tr("Ignoring non-Tox file", "popup title"),
@@ -91,16 +91,16 @@ bool ProfileImporter::importProfile(const QString& path)
         return false; // ignore importing non-tox file
     }
 
-    QString settingsPath = paths.getSettingsDirPath();
-    QString profilePath = QDir(settingsPath).filePath(profile + Core::TOX_EXT);
+    const QString settingsPath = paths.getSettingsDirPath();
+    const QString profilePath = QDir(settingsPath).filePath(profile + Core::TOX_EXT);
 
     if (QFileInfo(profilePath).exists()) {
-        QString title = tr("Profile already exists", "import confirm title");
-        QString message = tr("A profile named \"%1\" already exists. "
-                             "Do you want to erase it?",
-                             "import confirm text")
-                              .arg(profile);
-        bool erase = askQuestion(title, message);
+        const QString title = tr("Profile already exists", "import confirm title");
+        const QString message = tr("A profile named \"%1\" already exists. "
+                                   "Do you want to erase it?",
+                                   "import confirm text")
+                                    .arg(profile);
+        const bool erase = askQuestion(title, message);
 
         if (!erase)
             return false; // import cancelled

--- a/src/widget/tool/removechatdialog.cpp
+++ b/src/widget/tool/removechatdialog.cpp
@@ -15,9 +15,9 @@ RemoveChatDialog::RemoveChatDialog(QWidget* parent, const Chat& contact)
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     setAttribute(Qt::WA_QuitOnClose, false);
     ui.setupUi(this);
-    QString name = contact.getDisplayedName().toHtmlEscaped();
-    QString text = tr("Are you sure you want to remove %1 from your contacts list?")
-                       .arg(QString("<b>%1</b>").arg(name));
+    const QString name = contact.getDisplayedName().toHtmlEscaped();
+    const QString text = tr("Are you sure you want to remove %1 from your contacts list?")
+                             .arg(QString("<b>%1</b>").arg(name));
 
     ui.label->setText(text);
     auto removeButton = ui.buttonBox->button(QDialogButtonBox::Ok);

--- a/src/widget/tool/screengrabberchooserrectitem.cpp
+++ b/src/widget/tool/screengrabberchooserrectitem.cpp
@@ -116,11 +116,11 @@ void ScreenGrabberChooserRectItem::mousePress(QGraphicsSceneMouseEvent* event)
 void ScreenGrabberChooserRectItem::mouseMove(QGraphicsSceneMouseEvent* event)
 {
     if (state == Moving) {
-        QPointF delta = event->scenePos() - event->lastScenePos();
+        const QPointF delta = event->scenePos() - event->lastScenePos();
         moveBy(delta.x(), delta.y());
     } else if (state == Resizing) {
         prepareGeometryChange();
-        QPointF size = event->scenePos() - scenePos();
+        const QPointF size = event->scenePos() - scenePos();
         mainRect->setRect(0, 0, size.x(), size.y());
         rectWidth = size.x();
         rectHeight = size.y();
@@ -138,12 +138,12 @@ void ScreenGrabberChooserRectItem::mouseRelease(QGraphicsSceneMouseEvent* event)
     if (event->button() == Qt::LeftButton) {
         setCursor(QCursor(Qt::OpenHandCursor));
 
-        QPointF delta = (event->scenePos() - startPos);
+        const QPointF delta = (event->scenePos() - startPos);
         if (qAbs(delta.x()) < MinRectSize || qAbs(delta.y()) < MinRectSize) {
             rectWidth = rectHeight = 0;
             mainRect->setRect(QRect());
         } else {
-            QRect normalized = chosenRect();
+            const QRect normalized = chosenRect();
 
             rectWidth = normalized.width();
             rectHeight = normalized.height();
@@ -185,8 +185,8 @@ void ScreenGrabberChooserRectItem::mouseMoveHandle(int x, int y, QGraphicsSceneM
     delta.ry() *= qAbs(y);
 
     // We increase if the multiplier and the delta have the same sign
-    bool increaseX = ((x < 0) == (delta.x() < 0));
-    bool increaseY = ((y < 0) == (delta.y() < 0));
+    const bool increaseX = ((x < 0) == (delta.x() < 0));
+    const bool increaseY = ((y < 0) == (delta.y() < 0));
 
     if ((delta.x() < 0 && increaseX) || (delta.x() >= 0 && !increaseX)) {
         moveBy(delta.x(), 0);
@@ -300,7 +300,7 @@ void ScreenGrabberChooserRectItem::forwardMainRectEvent(QEvent* event)
 void ScreenGrabberChooserRectItem::forwardHandleEvent(QGraphicsItem* watched, QEvent* event)
 {
     QGraphicsSceneMouseEvent* mouseEvent = static_cast<QGraphicsSceneMouseEvent*>(event);
-    QPoint multiplier = getHandleMultiplier(watched);
+    const QPoint multiplier = getHandleMultiplier(watched);
 
     if (multiplier.isNull())
         return;

--- a/src/widget/tool/screengrabberoverlayitem.cpp
+++ b/src/widget/tool/screengrabberoverlayitem.cpp
@@ -15,7 +15,7 @@
 ScreenGrabberOverlayItem::ScreenGrabberOverlayItem(ScreenshotGrabber* grabber)
     : screenshotGrabber(grabber)
 {
-    QBrush overlayBrush(QColor(0x00, 0x00, 0x00, 0x70)); // Translucent black
+    const QBrush overlayBrush(QColor(0x00, 0x00, 0x00, 0x70)); // Translucent black
 
     setCursor(QCursor(Qt::CrossCursor));
     setBrush(overlayBrush);
@@ -26,7 +26,7 @@ ScreenGrabberOverlayItem::~ScreenGrabberOverlayItem() = default;
 
 void ScreenGrabberOverlayItem::setChosenRect(QRect rect)
 {
-    QRect oldRect = chosenRect;
+    const QRect oldRect = chosenRect;
     chosenRect = rect;
     update(oldRect.united(rect));
 }
@@ -45,11 +45,11 @@ void ScreenGrabberOverlayItem::paint(QPainter* painter, const QStyleOptionGraphi
     painter->setBrush(brush());
     painter->setPen(pen());
 
-    QRectF self = rect();
-    qreal leftX = chosenRect.x();
-    qreal rightX = chosenRect.x() + chosenRect.width();
-    qreal topY = chosenRect.y();
-    qreal bottomY = chosenRect.y() + chosenRect.height();
+    const QRectF self = rect();
+    const qreal leftX = chosenRect.x();
+    const qreal rightX = chosenRect.x() + chosenRect.width();
+    const qreal topY = chosenRect.y();
+    const qreal bottomY = chosenRect.y() + chosenRect.height();
 
     painter->drawRect(0, 0, leftX, self.height());                      // Left of chosen
     painter->drawRect(rightX, 0, self.width() - rightX, self.height()); // Right of chosen

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -68,8 +68,8 @@ void ScreenshotGrabber::showGrabber()
     window->setFocus();
     window->grabKeyboard();
 
-    QRect fullGrabbedRect = screenGrab.rect();
-    QRect rec = QApplication::primaryScreen()->virtualGeometry();
+    const QRect fullGrabbedRect = screenGrab.rect();
+    const QRect rec = QApplication::primaryScreen()->virtualGeometry();
 
     window->setGeometry(rec);
     scene->setSceneRect(fullGrabbedRect);
@@ -115,7 +115,7 @@ void ScreenshotGrabber::acceptRegion()
 
     emit regionChosen(rect);
     qDebug() << "Screenshot accepted, chosen region" << rect;
-    QPixmap pixmap = screenGrab.copy(rect);
+    const QPixmap pixmap = screenGrab.copy(rect);
     restoreHiddenWindows();
     emit screenshotTaken(pixmap);
 
@@ -187,11 +187,11 @@ void ScreenshotGrabber::chooseHelperTooltipText(QRect rect)
  */
 void ScreenshotGrabber::adjustTooltipPosition()
 {
-    QRect recGL = QGuiApplication::primaryScreen()->virtualGeometry();
+    const QRect recGL = QGuiApplication::primaryScreen()->virtualGeometry();
     const auto rec = QGuiApplication::screenAt(QCursor::pos())->geometry();
     const QRectF ttRect = helperToolbox->childrenBoundingRect();
-    int x = qAbs(recGL.x()) + rec.x() + ((rec.width() - ttRect.width()) / 2);
-    int y = qAbs(recGL.y()) + rec.y();
+    const int x = qAbs(recGL.x()) + rec.x() + ((rec.width() - ttRect.width()) / 2);
+    const int y = qAbs(recGL.y()) + rec.y();
 
     helperToolbox->setX(x);
     helperToolbox->setY(y);
@@ -206,7 +206,7 @@ void ScreenshotGrabber::reject()
 QPixmap ScreenshotGrabber::grabScreen() const
 {
     QScreen* screen = QGuiApplication::primaryScreen();
-    QRect rec = screen->virtualGeometry();
+    const QRect rec = screen->virtualGeometry();
 
     // Multiply by devicePixelRatio to get actual desktop size
     return screen->grabWindow(0, rec.x() * pixRatio, rec.y() * pixRatio, rec.width() * pixRatio,
@@ -238,7 +238,7 @@ void ScreenshotGrabber::restoreHiddenWindows()
 
 void ScreenshotGrabber::beginRectChooser(QGraphicsSceneMouseEvent* event)
 {
-    QPointF pos = event->scenePos();
+    const QPointF pos = event->scenePos();
     chooserRect->setX(pos.x());
     chooserRect->setY(pos.y());
     chooserRect->beginResize(event->scenePos());

--- a/src/widget/translator.cpp
+++ b/src/widget/translator.cpp
@@ -24,7 +24,7 @@ QMutex Translator::lock;
  */
 void Translator::translate(const QString& localeName)
 {
-    QMutexLocker<QMutex> locker{&lock};
+    const QMutexLocker<QMutex> locker{&lock};
 
     if (!core_translator)
         core_translator = new QTranslator();
@@ -37,14 +37,15 @@ void Translator::translate(const QString& localeName)
     QApplication::removeTranslator(app_translator);
 
     // Load translations
-    QString locale = localeName.isEmpty() ? QLocale::system().name().section('_', 0, 0) : localeName;
+    const QString locale =
+        localeName.isEmpty() ? QLocale::system().name().section('_', 0, 0) : localeName;
 
     if (core_translator->load(locale, ":translations/")) {
         qDebug() << "Loaded translation" << locale;
 
         // System menu translation
-        QString s_locale = "qt_" + locale;
-        QString location = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+        const QString s_locale = "qt_" + locale;
+        const QString location = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
         if (app_translator->load(s_locale, location)) {
             QApplication::installTranslator(app_translator);
             qDebug() << "System translation loaded" << locale;
@@ -78,7 +79,7 @@ void Translator::translate(const QString& localeName)
  */
 void Translator::registerHandler(const std::function<void()>& f, void* owner)
 {
-    QMutexLocker<QMutex> locker{&lock};
+    const QMutexLocker<QMutex> locker{&lock};
     callbacks.push_back({owner, f});
 }
 
@@ -88,7 +89,7 @@ void Translator::registerHandler(const std::function<void()>& f, void* owner)
  */
 void Translator::unregister(void* owner)
 {
-    QMutexLocker<QMutex> locker{&lock};
+    const QMutexLocker<QMutex> locker{&lock};
     callbacks.erase(std::remove_if(begin(callbacks), end(callbacks),
                                    [=](const Callback& c) { return c.first == owner; }),
                     end(callbacks));

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -80,7 +80,7 @@ namespace {
 bool tryRemoveFile(const QString& filepath)
 {
     QFile tmp(filepath);
-    bool writable = tmp.open(QIODevice::WriteOnly);
+    const bool writable = tmp.open(QIODevice::WriteOnly);
     tmp.remove();
     return writable;
 }
@@ -104,8 +104,8 @@ void Widget::acceptFileTransfer(const ToxFile& file, const QString& path)
     QString filepath;
     int number = 0;
 
-    QString suffix = QFileInfo(file.fileName).completeSuffix();
-    QString base = QFileInfo(file.fileName).baseName();
+    const QString suffix = QFileInfo(file.fileName).completeSuffix();
+    const QString base = QFileInfo(file.fileName).baseName();
 
     do {
         filepath = QString("%1/%2%3.%4")
@@ -151,7 +151,7 @@ Widget::Widget(Profile& profile_, IAudioControl& audio_, CameraSource& cameraSou
     , nexus{nexus_}
 {
     installEventFilter(this);
-    QString locale = settings.getTranslation();
+    const QString locale = settings.getTranslation();
     Translator::translate(locale);
 }
 
@@ -159,7 +159,7 @@ void Widget::init()
 {
     ui->setupUi(this);
 
-    QIcon themeIcon = QIcon::fromTheme("qtox");
+    const QIcon themeIcon = QIcon::fromTheme("qtox");
     if (!themeIcon.isNull()) {
         setWindowIcon(themeIcon);
     }
@@ -522,7 +522,7 @@ void Widget::init()
 bool Widget::eventFilter(QObject* obj, QEvent* event)
 {
     QWindowStateChangeEvent* ce = nullptr;
-    Qt::WindowStates state = windowState();
+    const Qt::WindowStates state = windowState();
 
     switch (event->type()) {
     case QEvent::Close:
@@ -587,8 +587,9 @@ void Widget::updateIcons()
     if (!hasThemeIconBug && QIcon::hasThemeIcon("qtox-" + assetSuffix)) {
         ico = QIcon::fromTheme("qtox-" + assetSuffix);
     } else {
-        QString color = settings.getLightTrayIcon() ? QStringLiteral("light") : QStringLiteral("dark");
-        QString path = ":/img/taskbar/" + color + "/taskbar_" + assetSuffix + ".svg";
+        const QString color =
+            settings.getLightTrayIcon() ? QStringLiteral("light") : QStringLiteral("dark");
+        const QString path = ":/img/taskbar/" + color + "/taskbar_" + assetSuffix + ".svg";
         QSvgRenderer renderer(path);
 
         // Prepare a QImage with desired characteristics
@@ -611,7 +612,7 @@ Widget::~Widget()
     ipc.unregisterEventHandler(activateHandlerKey);
 #endif
 
-    QWidgetList windowList = QApplication::topLevelWidgets();
+    const QWidgetList windowList = QApplication::topLevelWidgets();
 
     for (QWidget* window : windowList) {
         if (window != this) {
@@ -799,7 +800,7 @@ void Widget::onSeparateWindowClicked(bool separate)
 void Widget::onSeparateWindowChanged(bool separate, bool clicked)
 {
     if (!separate) {
-        QWindowList windowList = QGuiApplication::topLevelWindows();
+        const QWindowList windowList = QGuiApplication::topLevelWindows();
 
         for (QWindow* window : windowList) {
             if (window->objectName() == "detachedWindow") {
@@ -820,7 +821,7 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
 
         onShowSettings();
     } else {
-        int width = ui->friendList->size().width();
+        const int width = ui->friendList->size().width();
         QSize size;
         QPoint pos;
 
@@ -1125,7 +1126,7 @@ void Widget::dispatchFile(ToxFile file)
         }
 
         auto maxAutoAcceptSize = settings.getMaxAutoAcceptSize();
-        bool autoAcceptSizeCheckPassed =
+        const bool autoAcceptSizeCheckPassed =
             maxAutoAcceptSize == 0 || maxAutoAcceptSize >= file.progress.getFileSize();
 
         if (!autoAcceptDir.isEmpty() && autoAcceptSizeCheckPassed) {
@@ -1172,7 +1173,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
     Friend* newFriend = friendList->addFriend(friendId, friendPk, settings);
     auto rawChatroom =
         new FriendChatroom(newFriend, contentDialogManager.get(), *core, settings, *conferenceList);
-    std::shared_ptr<FriendChatroom> chatroom(rawChatroom);
+    const std::shared_ptr<FriendChatroom> chatroom(rawChatroom);
     const auto compact = settings.getCompactLayout();
     auto widget = new FriendWidget(chatroom, compact, settings, style, *messageBoxManager, profile);
     connectFriendWidget(*widget);
@@ -1239,7 +1240,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
     connect(&profile, &Profile::friendAvatarRemoved, widget, &FriendWidget::onAvatarRemoved);
 
     // Try to get the avatar from the cache
-    QPixmap avatar = profile.loadAvatar(friendPk);
+    const QPixmap avatar = profile.loadAvatar(friendPk);
     if (!avatar.isNull()) {
         friendForm->onAvatarChanged(friendPk, avatar);
         widget->onAvatarSet(friendPk, avatar);
@@ -1434,9 +1435,9 @@ void Widget::addFriendDialog(const Friend* frnd, ContentDialog* dialog)
 {
     const ToxPk& friendPk = frnd->getPublicKey();
     ContentDialog* contentDialog = contentDialogManager->getFriendDialog(friendPk);
-    bool isSeparate = settings.getSeparateWindow();
+    const bool isSeparate = settings.getSeparateWindow();
     FriendWidget* widget = friendWidgets[friendPk];
-    bool isCurrent = activeChatroomWidget == widget;
+    const bool isCurrent = activeChatroomWidget == widget;
     if (!contentDialog && !isSeparate && isCurrent) {
         onAddClicked();
     }
@@ -1476,7 +1477,7 @@ void Widget::addFriendDialog(const Friend* frnd, ContentDialog* dialog)
     connect(&profile, &Profile::friendAvatarSet, friendWidget, &FriendWidget::onAvatarSet);
     connect(&profile, &Profile::friendAvatarRemoved, friendWidget, &FriendWidget::onAvatarRemoved);
 
-    QPixmap avatar = profile.loadAvatar(frnd->getPublicKey());
+    const QPixmap avatar = profile.loadAvatar(frnd->getPublicKey());
     if (!avatar.isNull()) {
         friendWidget->onAvatarSet(frnd->getPublicKey(), avatar);
     }
@@ -1486,10 +1487,10 @@ void Widget::addConferenceDialog(const Conference* conference, ContentDialog* di
 {
     const ConferenceId& conferenceId = conference->getPersistentId();
     ContentDialog* conferenceDialog = contentDialogManager->getConferenceDialog(conferenceId);
-    bool separated = settings.getSeparateWindow();
+    const bool separated = settings.getSeparateWindow();
     Q_ASSERT(conferenceWidgets.contains(conferenceId));
     ConferenceWidget* widget = conferenceWidgets[conferenceId];
-    bool isCurrentWindow = activeChatroomWidget == widget;
+    const bool isCurrentWindow = activeChatroomWidget == widget;
     if (!conferenceDialog && !separated && isCurrentWindow) {
         onAddClicked();
     }
@@ -1649,7 +1650,7 @@ QString Widget::fromDialogType(DialogType type)
 
 bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, bool notify)
 {
-    bool inactiveWindow = isMinimized() || !currentWindow->isActiveWindow();
+    const bool inactiveWindow = isMinimized() || !currentWindow->isActiveWindow();
 
     if (!inactiveWindow && isActive) {
         return false;
@@ -1667,9 +1668,9 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, 
                 }
                 eventFlag = true;
             }
-            bool isBusy = core->getStatus() == Status::Status::Busy;
-            bool busySound = settings.getBusySound();
-            bool notifySound = settings.getNotifySound();
+            const bool isBusy = core->getStatus() == Status::Status::Busy;
+            const bool busySound = settings.getBusySound();
+            const bool notifySound = settings.getNotifySound();
 
             if (notifySound && sound && (!isBusy || busySound)) {
                 playNotificationSound(IAudioSink::Sound::NewMessage);
@@ -1975,7 +1976,7 @@ void Widget::onConferenceMessageReceived(uint32_t conferencenumber, uint32_t pee
     const ConferenceId& conferenceId = conferenceList->id2Key(conferencenumber);
     assert(conferenceList->findConference(conferenceId));
 
-    ToxPk author = core->getConferencePeerPk(conferencenumber, peernumber);
+    const ToxPk author = core->getConferencePeerPk(conferencenumber, peernumber);
 
     conferenceMessageDispatchers[conferenceId]->onMessageReceived(author, isAction, message);
 }
@@ -2120,7 +2121,7 @@ Conference* Widget::createConference(uint32_t conferencenumber, const Conference
     }
     auto rawChatroom =
         new ConferenceRoom(newConference, contentDialogManager.get(), *core, *friendList);
-    std::shared_ptr<ConferenceRoom> chatroom(rawChatroom);
+    const std::shared_ptr<ConferenceRoom> chatroom(rawChatroom);
 
     const auto compact = settings.getCompactLayout();
     auto widget = new ConferenceWidget(chatroom, compact, settings, style);
@@ -2248,10 +2249,10 @@ bool Widget::event(QEvent* e)
 void Widget::onUserAwayCheck()
 {
 #ifdef QTOX_PLATFORM_EXT
-    uint32_t autoAwayTime = settings.getAutoAwayTime() * 60 * 1000;
-    bool online = static_cast<Status::Status>(ui->statusButton->property("status").toInt())
-                  == Status::Status::Online;
-    bool away = autoAwayTime && Platform::getIdleTime() >= autoAwayTime;
+    const uint32_t autoAwayTime = settings.getAutoAwayTime() * 60 * 1000;
+    const bool online = static_cast<Status::Status>(ui->statusButton->property("status").toInt())
+                        == Status::Status::Online;
+    const bool away = autoAwayTime && Platform::getIdleTime() >= autoAwayTime;
 
     if (online && away) {
         qDebug() << "auto away activated at" << QTime::currentTime().toString();
@@ -2439,7 +2440,7 @@ bool Widget::filterOnline(FilterCriteria index)
 
 void Widget::clearAllReceipts()
 {
-    QList<Friend*> friends = friendList->getAllFriends();
+    const QList<Friend*> friends = friendList->getAllFriends();
     for (Friend* f : friends) {
         friendMessageDispatchers[f->getPublicKey()]->clearOutgoingMessages();
     }
@@ -2448,13 +2449,13 @@ void Widget::clearAllReceipts()
 void Widget::reloadTheme()
 {
     setStyleSheet("");
-    QWidgetList wgts = findChildren<QWidget*>();
+    const QWidgetList wgts = findChildren<QWidget*>();
     for (auto x : wgts) {
         x->setStyleSheet("");
     }
 
     setStyleSheet(style.getStylesheet("window/general.qss", settings));
-    QString statusPanelStyle = style.getStylesheet("window/statusPanel.qss", settings);
+    const QString statusPanelStyle = style.getStylesheet("window/statusPanel.qss", settings);
     ui->tooliconsZone->setStyleSheet(style.getStylesheet("tooliconsZone/tooliconsZone.qss", settings));
     ui->statusPanel->setStyleSheet(statusPanelStyle);
     ui->statusHead->setStyleSheet(statusPanelStyle);
@@ -2506,8 +2507,8 @@ inline QIcon Widget::prepareIcon(QString path, int w, int h)
 
 void Widget::searchChats()
 {
-    QString searchString = ui->searchContactText->text();
-    FilterCriteria filter = getFilterCriteria();
+    const QString searchString = ui->searchContactText->text();
+    const FilterCriteria filter = getFilterCriteria();
 
     chatListWidget->searchChatRooms(searchString, filterOnline(filter), filterOffline(filter),
                                     filterGroups(filter));
@@ -2533,7 +2534,7 @@ void Widget::changeDisplayMode()
 
 void Widget::updateFilterText()
 {
-    QString action = filterDisplayGroup->checkedAction()->text();
+    const QString action = filterDisplayGroup->checkedAction()->text();
     QString text = filterGroup->checkedAction()->text();
     text = action + QStringLiteral(" | ") + text;
     ui->searchContactFilterBox->setText(text);
@@ -2558,15 +2559,15 @@ Widget::FilterCriteria Widget::getFilterCriteria() const
 void Widget::searchCircle(CircleWidget& circleWidget)
 {
     if (chatListWidget->getMode() == FriendListWidget::SortingMode::Name) {
-        FilterCriteria filter = getFilterCriteria();
-        QString text = ui->searchContactText->text();
+        const FilterCriteria filter = getFilterCriteria();
+        const QString text = ui->searchContactText->text();
         circleWidget.search(text, true, filterOnline(filter), filterOffline(filter));
     }
 }
 
 bool Widget::conferencesVisible() const
 {
-    FilterCriteria filter = getFilterCriteria();
+    const FilterCriteria filter = getFilterCriteria();
     return !filterGroups(filter);
 }
 
@@ -2586,7 +2587,7 @@ void Widget::friendListContextMenu(const QPoint& pos)
 
 void Widget::friendRequestsUpdate()
 {
-    unsigned int unreadFriendRequests = settings.getUnreadFriendRequests();
+    const unsigned int unreadFriendRequests = settings.getUnreadFriendRequests();
 
     if (unreadFriendRequests == 0) {
         delete friendRequestsButton;

--- a/test/mock/include/mock/mockbootstraplistgenerator.h
+++ b/test/mock/include/mock/mockbootstraplistgenerator.h
@@ -34,7 +34,7 @@ public:
     static QList<DhtServer> makeListFromSelf(const Core& core)
     {
         auto selfDhtId = core.getSelfDhtId();
-        quint16 selfDhtPort = core.getSelfUdpPort();
+        const quint16 selfDhtPort = core.getSelfUdpPort();
 
         DhtServer ret;
         ret.ipv4 = "localhost";

--- a/util/include/util/strongtype.h
+++ b/util/include/util/strongtype.h
@@ -13,7 +13,7 @@ struct Addable
     T operator+(const T& other) const
     {
         return static_cast<const T&>(*this).get() + other.get();
-    };
+    }
 };
 
 template <typename T, typename Underlying>
@@ -22,7 +22,7 @@ struct UnderlyingAddable
     T operator+(const Underlying& other) const
     {
         return T(static_cast<const T&>(*this).get() + other);
-    };
+    }
 };
 
 template <typename T, typename Underlying>
@@ -31,7 +31,7 @@ struct UnitlessSubtractable
     T operator-(const Underlying& other) const
     {
         return T(static_cast<const T&>(*this).get() - other);
-    };
+    }
 
     Underlying operator-(const T& other) const
     {
@@ -64,11 +64,11 @@ struct EqualityComparable
     bool operator==(const T& other) const
     {
         return static_cast<const T&>(*this).get() == other.get();
-    };
+    }
     bool operator!=(const T& other) const
     {
         return static_cast<const T&>(*this).get() != other.get();
-    };
+    }
 };
 
 template <typename T, typename Underlying>


### PR DESCRIPTION
To reproduce:
```sh
run-clang-tidy \
  -checks="-*,misc-const-correctness" \
  -p _build \
  -fix \
  $(find . -name "*.h" -or -name "*.cpp" | grep -v "/_build/")
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/74)
<!-- Reviewable:end -->
