### PR TITLE
cleanup: Use `make_unique` and `make_shared` instead of `new`.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,9 @@
 Checks: "-*
 , modernize-avoid-bind
+, modernize-deprecated-headers
 , modernize-loop-convert
+, modernize-make-shared
+, modernize-make-unique
 , modernize-return-braced-init-list
 , modernize-use-bool-literals
 , modernize-use-emplace

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -25,6 +25,7 @@
 #include <QFontDatabase>
 #include <QMessageBox>
 #include <QObject>
+#include <memory>
 
 namespace {
 // logMessageHandler and associated data must be static due to qInstallMessageHandler's
@@ -316,8 +317,8 @@ int AppManager::startGui(QCommandLineParser& parser)
     // TODO(kriby): Consider moving application initializing variables into a globalSettings object
     //  note: Because Settings is shouldering global settings as well as model specific ones it
     //  cannot be integrated into a central model object yet
-    cameraSource = std::unique_ptr<CameraSource>(new CameraSource{*settings});
-    nexus = std::unique_ptr<Nexus>(new Nexus{*settings, *messageBoxManager, *cameraSource, *ipc});
+    cameraSource = std::make_unique<CameraSource>(*settings);
+    nexus = std::make_unique<Nexus>(*settings, *messageBoxManager, *cameraSource, *ipc);
     // Autologin
     // TODO (kriby): Shift responsibility of linking views to model objects from nexus
     // Further: generate view instances separately (loginScreen, mainGUI, audio)
@@ -341,8 +342,7 @@ int AppManager::startGui(QCommandLineParser& parser)
         profile = nexus->getProfile();
     }
 
-    uriDialog = std::unique_ptr<ToxURIDialog>(
-        new ToxURIDialog(nullptr, profile->getCore(), *messageBoxManager));
+    uriDialog = std::make_unique<ToxURIDialog>(nullptr, profile->getCore(), *messageBoxManager);
 
     if (ipc->isAttached()) {
         // Start to accept Inter-process communication

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -18,6 +18,7 @@
 
 #include <QCryptographicHash>
 #include <QDebug>
+#include <memory>
 
 #include "src/persistence/history.h"
 #include "src/persistence/settings.h"
@@ -42,7 +43,7 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QSt
                                                 SmileyPack& smileyPack, Settings& settings,
                                                 Style& style, bool colorizeName)
 {
-    ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage(documentCache, settings, style));
+    ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
 
     QString text = rawMessage.toHtmlEscaped();
     QString senderText = sender;
@@ -132,7 +133,7 @@ ChatMessage::Ptr ChatMessage::createChatInfoMessage(const QString& rawMessage,
                                                     DocumentCache& documentCache,
                                                     Settings& settings, Style& style)
 {
-    ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage(documentCache, settings, style));
+    ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
     QString text = rawMessage.toHtmlEscaped();
 
     QString img;
@@ -167,7 +168,7 @@ ChatMessage::Ptr ChatMessage::createFileTransferMessage(const QString& sender, C
                                                         Settings& settings, Style& style,
                                                         IMessageBoxManager& messageBoxManager)
 {
-    ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage(documentCache, settings, style));
+    ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
 
     QFont baseFont = settings.getChatMessageFont();
     QFont authorFont = baseFont;
@@ -191,7 +192,7 @@ ChatMessage::Ptr ChatMessage::createFileTransferMessage(const QString& sender, C
 ChatMessage::Ptr ChatMessage::createTypingNotification(DocumentCache& documentCache,
                                                        Settings& settings, Style& style)
 {
-    ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage(documentCache, settings, style));
+    ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
 
     QFont baseFont = settings.getChatMessageFont();
 
@@ -221,7 +222,7 @@ ChatMessage::Ptr ChatMessage::createTypingNotification(DocumentCache& documentCa
 ChatMessage::Ptr ChatMessage::createBusyNotification(DocumentCache& documentCache,
                                                      Settings& settings, Style& style)
 {
-    ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage(documentCache, settings, style));
+    ChatMessage::Ptr msg = std::make_shared<ChatMessage>(documentCache, settings, style);
     QFont baseFont = settings.getChatMessageFont();
     baseFont.setPixelSize(baseFont.pixelSize() + 2);
     baseFont.setBold(true);

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -25,7 +25,7 @@
 #include <QVariantAnimation>
 
 #include <cassert>
-#include <math.h>
+#include <cmath>
 
 
 // The leftButton is used to accept, pause, or resume a file transfer, as well as to open a

--- a/src/chatlog/content/spinner.cpp
+++ b/src/chatlog/content/spinner.cpp
@@ -12,7 +12,7 @@
 #include <QTime>
 #include <QVariantAnimation>
 
-#include <math.h>
+#include <cmath>
 
 Spinner::Spinner(const QString& img, QSize Size, qreal speed)
     : size(Size)

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -24,6 +24,7 @@
 #include <tox/toxav.h>
 
 #include <cassert>
+#include <memory>
 
 /**
  * @fn void CoreAV::avInvite(uint32_t friendId, bool video)
@@ -283,7 +284,7 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
     // Audio backend must be set before making a call
     assert(audio != nullptr);
     ToxFriendCallPtr call =
-        ToxFriendCallPtr(new ToxFriendCall(friendNum, video, *this, *audio, cameraSource));
+        std::make_unique<ToxFriendCall>(friendNum, video, *this, *audio, cameraSource);
     // Call object must be owned by this thread or there will be locking problems with Audio
     call->moveToThread(thread());
     assert(call != nullptr);
@@ -560,7 +561,7 @@ void CoreAV::joinConferenceCall(const Conference& conference)
     assert(audio != nullptr);
 
     ToxConferenceCallPtr conferencecall =
-        ToxConferenceCallPtr(new ToxConferenceCall{conference, *this, *audio});
+        std::make_unique<ToxConferenceCall>(conference, *this, *audio);
     // Call Objects must be owned by CoreAV or there will be locking problems with Audio
     conferencecall->moveToThread(thread());
     assert(conferencecall != nullptr);
@@ -737,7 +738,7 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
     // Audio backend must be set before receiving a call
     assert(self->audio != nullptr);
     ToxFriendCallPtr call =
-        ToxFriendCallPtr(new ToxFriendCall{friendNum, video, *self, *self->audio, self->cameraSource});
+        std::make_unique<ToxFriendCall>(friendNum, video, *self, *self->audio, self->cameraSource);
     // Call object must be owned by CoreAV thread or there will be locking problems with Audio
     call->moveToThread(self->thread());
     assert(call != nullptr);

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -9,9 +9,9 @@
 #include <QThread>
 
 #include <chrono>
+#include <cstdlib>
 #include <ctime>
 #include <random>
-#include <stdlib.h>
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -10,8 +10,8 @@
 
 #if defined(USING_V4L)
 #include <QDebug>
+#include <cerrno>
 #include <dirent.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <linux/videodev2.h>
 #include <map>

--- a/src/platform/posixsignalnotifier.cpp
+++ b/src/platform/posixsignalnotifier.cpp
@@ -12,8 +12,8 @@
 #include <array>
 #include <atomic>
 
-#include <errno.h>
-#include <signal.h>     // sigaction()
+#include <cerrno>
+#include <csignal>      // sigaction()
 #include <sys/socket.h> // socketpair()
 #include <sys/types.h>  // may be needed for BSD
 #include <unistd.h>     // close()

--- a/src/widget/chatformheader.cpp
+++ b/src/widget/chatformheader.cpp
@@ -19,6 +19,7 @@
 #include <QStyle>
 #include <QTextDocument>
 #include <QToolButton>
+#include <memory>
 
 namespace {
 const QSize AVATAR_SIZE{40, 40};
@@ -202,7 +203,7 @@ void ChatFormHeader::showOutgoingCall(bool video)
 void ChatFormHeader::createCallConfirm(bool video)
 {
     QWidget* btn = video ? videoButton : callButton;
-    callConfirm = std::unique_ptr<CallConfirmWidget>(new CallConfirmWidget(settings, style, btn));
+    callConfirm = std::make_unique<CallConfirmWidget>(settings, style, btn);
     connect(callConfirm.get(), &CallConfirmWidget::accepted, this, &ChatFormHeader::callAccepted);
     connect(callConfirm.get(), &CallConfirmWidget::rejected, this, &ChatFormHeader::callRejected);
 }

--- a/src/widget/emoticonswidget.cpp
+++ b/src/widget/emoticonswidget.cpp
@@ -15,7 +15,7 @@
 #include <QPushButton>
 #include <QRadioButton>
 
-#include <math.h>
+#include <cmath>
 
 EmoticonsWidget::EmoticonsWidget(SmileyPack& smileyPack, Settings& settings, Style& style,
                                  QWidget* parent)
@@ -37,7 +37,7 @@ EmoticonsWidget::EmoticonsWidget(SmileyPack& smileyPack, Settings& settings, Sty
 
     const QList<QStringList>& emoticons = smileyPack.getEmoticons();
     int itemCount = emoticons.size();
-    int pageCount = ceil(float(itemCount) / float(itemsPerPage));
+    int pageCount = std::ceil(float(itemCount) / float(itemsPerPage));
     int currPage = 0;
     int currItem = 0;
     int row = 0;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -46,6 +46,7 @@
 #include <QStringBuilder>
 
 #include <cassert>
+#include <memory>
 
 /**
  * @brief ChatForm::incomingNotification Notify that we are called by someone.
@@ -498,8 +499,8 @@ std::unique_ptr<NetCamView> ChatForm::createNetcam()
 {
     qDebug() << "creating netcam";
     uint32_t friendId = f->getId();
-    std::unique_ptr<NetCamView> view = std::unique_ptr<NetCamView>(
-        new NetCamView(f->getPublicKey(), cameraSource, settings, style, profile, this));
+    std::unique_ptr<NetCamView> view =
+        std::make_unique<NetCamView>(f->getPublicKey(), cameraSource, settings, style, profile, this);
     CoreAV* av = core.getAv();
     VideoSource* source = av->getVideoSourceFromCall(friendId);
     view->show(source, f->getDisplayedName());

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -39,9 +39,9 @@ SettingsWidget::SettingsWidget(UpdateCheck& updateCheck, IAudioControl& audio, C
 
     setAttribute(Qt::WA_DeleteOnClose);
 
-    bodyLayout = std::unique_ptr<QVBoxLayout>(new QVBoxLayout());
+    bodyLayout = std::make_unique<QVBoxLayout>();
 
-    settingsWidgets = std::unique_ptr<QTabWidget>(new QTabWidget(this));
+    settingsWidgets = std::make_unique<QTabWidget>(this);
     settingsWidgets->setTabPosition(QTabWidget::North);
     bodyLayout->addWidget(settingsWidgets.get());
 

--- a/src/widget/qrwidget.cpp
+++ b/src/widget/qrwidget.cpp
@@ -11,7 +11,7 @@
 #include <QPainter>
 #include <qrencode.h>
 
-#include <errno.h>
+#include <cerrno>
 
 /**
  * @file qrwidget.cpp

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -17,7 +17,7 @@
 #include <QPushButton>
 #include <QRect>
 #include <QVBoxLayout>
-#include <assert.h>
+#include <cassert>
 
 /**
  * @class CallConfirmWidget

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -18,6 +18,7 @@
 #include <QString>
 #include <QSvgRenderer>
 #include <QWindow>
+#include <memory>
 #ifdef Q_OS_MAC
 #include <QMenuBar>
 #include <QSignalMapper>
@@ -257,7 +258,8 @@ void Widget::init()
 
     core = &profile.getCore();
 
-    sharedMessageProcessorParams.reset(new MessageProcessor::SharedParams(core->getMaxMessageSize()));
+    sharedMessageProcessorParams =
+        std::make_unique<MessageProcessor::SharedParams>(core->getMaxMessageSize());
 
     chatListWidget =
         new FriendListWidget(*core, this, settings, style, *messageBoxManager, *friendList,
@@ -2275,7 +2277,7 @@ void Widget::onTryCreateTrayIcon()
     static int32_t tries = 15;
     if (!icon && tries--) {
         if (QSystemTrayIcon::isSystemTrayAvailable()) {
-            icon = std::unique_ptr<QSystemTrayIcon>(new QSystemTrayIcon(this));
+            icon = std::make_unique<QSystemTrayIcon>(this);
             updateIcons();
             trayMenu = new QMenu(this);
 

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -7,6 +7,7 @@
 
 #include <QSignalSpy>
 #include <QTest>
+#include <memory>
 
 class MockFriend : public IFriendListItem
 {
@@ -359,7 +360,7 @@ private:
 
 void TestFriendListManager::testAddFriendListItem()
 {
-    auto manager = std::unique_ptr<FriendListManager>(new FriendListManager(0, this));
+    auto manager = std::make_unique<FriendListManager>(0, this);
     QSignalSpy spy(manager.get(), &FriendListManager::itemsChanged);
     FriendItemsBuilder listBuilder;
 
@@ -596,8 +597,7 @@ void TestFriendListManager::testSetConferencesOnTop()
 std::unique_ptr<FriendListManager>
 TestFriendListManager::createManagerWithItems(const QVector<IFriendListItem*> itemsVec)
 {
-    std::unique_ptr<FriendListManager> manager =
-        std::unique_ptr<FriendListManager>(new FriendListManager(0, this));
+    std::unique_ptr<FriendListManager> manager = std::make_unique<FriendListManager>(0, this);
 
     for (auto item : itemsVec) {
         manager->addFriendListItem(item);

--- a/test/persistence/dbschema_test.cpp
+++ b/test/persistence/dbschema_test.cpp
@@ -139,7 +139,7 @@ private:
 
 void TestDbSchema::init()
 {
-    testDatabaseFile = std::unique_ptr<QTemporaryFile>(new QTemporaryFile());
+    testDatabaseFile = std::make_unique<QTemporaryFile>();
     // fileName is only defined once the file is opened. Since RawDatabase
     // will be opening the file itself not using QFile, open and close it now.
     QVERIFY(testDatabaseFile->open());

--- a/test/persistence/dbupgrade/dbTo11_test.cpp
+++ b/test/persistence/dbupgrade/dbTo11_test.cpp
@@ -12,6 +12,7 @@
 #include <QByteArray>
 #include <QTemporaryFile>
 #include <QTest>
+#include <memory>
 
 namespace {
 const auto selfPk = ToxPk{QByteArray(32, 0)};

--- a/test/platform/posixsignalnotifier_test.cpp
+++ b/test/platform/posixsignalnotifier_test.cpp
@@ -8,7 +8,7 @@
 #include <QCoreApplication>
 #include <QSignalSpy>
 #include <QtTest/QtTest>
-#include <signal.h>
+#include <csignal>
 #include <unistd.h>
 
 class TestPosixSignalNotifier : public QObject

--- a/test/widget/filesform_test.cpp
+++ b/test/widget/filesform_test.cpp
@@ -9,6 +9,7 @@
 
 #include <QTest>
 #include <limits>
+#include <memory>
 
 #include <tox/tox.h> // TOX_FILE_KIND_*
 
@@ -42,8 +43,8 @@ using namespace FileTransferList;
 
 void TestFileTransferList::init()
 {
-    friendList = std::unique_ptr<FriendList>(new FriendList());
-    model = std::unique_ptr<Model>(new Model(*friendList));
+    friendList = std::make_unique<FriendList>();
+    model = std::make_unique<Model>(*friendList);
 }
 
 void TestFileTransferList::testFileTransferListConversion()


### PR DESCRIPTION
Also replace deprecated C header includes with their C++ versions.

To reproduce:
```sh
run-clang-tidy -p _build -fix \
  $(find . -name "*.h" -or -name "*.cpp" | grep -v "/_build/") \
  -checks="-*,modernize-deprecated-headers,modernize-make-shared,modernize-make-unique"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/76)
<!-- Reviewable:end -->
