### PR TITLE
cleanup: Avoid implicit bool conversions.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: "-*
 , performance-move-const-arg
 , readability-container-*
 , readability-else-after-return
+, readability-implicit-bool-conversion
 , readability-isolate-declaration
 , readability-make-member-function-const
 , readability-named-parameter

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -103,7 +103,7 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
 
     const QString file = canonicalLogFilePath(ctxt.file);
     const QString category =
-        ctxt.category ? QString::fromUtf8(ctxt.category) : QStringLiteral("default");
+        (ctxt.category != nullptr) ? QString::fromUtf8(ctxt.category) : QStringLiteral("default");
     if ((type == QtDebugMsg && category == QStringLiteral("tox.core")
          && (file == QStringLiteral("rtp.c") || file == QStringLiteral("video.c")))
         || (file == QStringLiteral("bwcontroller.c") && msg.contains("update"))) {
@@ -146,15 +146,15 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
 
 #ifdef LOG_TO_FILE
     FILE* logFilePtr = logFileFile.loadRelaxed(); // atomically load the file pointer
-    if (!logFilePtr) {
+    if (logFilePtr == nullptr) {
         logBufferMutex->lock();
-        if (logBuffer)
+        if (logBuffer != nullptr)
             logBuffer->append(LogMsgBytes);
 
         logBufferMutex->unlock();
     } else {
         logBufferMutex->lock();
-        if (logBuffer) {
+        if (logBuffer != nullptr) {
             // empty logBuffer to file
             for (const QByteArray& bufferedMsg : *logBuffer) {
                 fwrite(bufferedMsg.constData(), 1, bufferedMsg.size(), logFilePtr);
@@ -178,7 +178,7 @@ bool toxURIEventHandler(const QByteArray& eventData, void* userData)
         return false;
     }
 
-    if (!uriDialog) {
+    if (uriDialog == nullptr) {
         return false;
     }
 
@@ -221,7 +221,7 @@ int AppManager::startGui(QCommandLineParser& parser)
         qDebug() << "Log file over 1MB, rotating...";
 
         // close old logfile (need for windows)
-        if (mainLogFilePtr)
+        if (mainLogFilePtr != nullptr)
             fclose(mainLogFilePtr);
 
         QDir dir(logFileDir);
@@ -239,7 +239,7 @@ int AppManager::startGui(QCommandLineParser& parser)
         mainLogFilePtr = fopen(logfile.toLocal8Bit().constData(), "a");
     }
 
-    if (!mainLogFilePtr) {
+    if (mainLogFilePtr == nullptr) {
         qCritical() << "Couldn't open logfile" << logfile;
     } else {
         qDebug() << "Logging to" << logfile;
@@ -329,11 +329,11 @@ int AppManager::startGui(QCommandLineParser& parser)
         && !Profile::isEncrypted(profileName, settings->getPaths())) {
         profile = Profile::loadProfile(profileName, QString(), *settings, &parser, *cameraSource,
                                        *messageBoxManager);
-        if (!profile) {
+        if (profile == nullptr) {
             QMessageBox::information(nullptr, tr("Error"), tr("Failed to load profile automatically."));
         }
     }
-    if (profile) {
+    if (profile != nullptr) {
         nexus->bootstrapWithProfile(profile);
     } else {
         nexus->setParser(&parser);

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -14,7 +14,7 @@ ChatLine::ChatLine() = default;
 ChatLine::~ChatLine()
 {
     for (ChatLineContent* c : content) {
-        if (c->scene())
+        if (c->scene() != nullptr)
             c->scene()->removeItem(c);
 
         delete c;
@@ -52,14 +52,14 @@ ChatLineContent* ChatLine::getContent(QPointF scenePos) const
 void ChatLine::removeFromScene()
 {
     for (ChatLineContent* c : content) {
-        if (c->scene())
+        if (c->scene() != nullptr)
             c->scene()->removeItem(c);
     }
 }
 
 void ChatLine::addToScene(QGraphicsScene* scene)
 {
-    if (!scene)
+    if (scene == nullptr)
         return;
 
     for (ChatLineContent* c : content)
@@ -119,7 +119,7 @@ QRectF ChatLine::sceneBoundingRect() const
 
 void ChatLine::addColumn(ChatLineContent* item, ColumnFormat fmt)
 {
-    if (!item)
+    if (item == nullptr)
         return;
 
     format.push_back(fmt);
@@ -129,14 +129,14 @@ void ChatLine::addColumn(ChatLineContent* item, ColumnFormat fmt)
 
 void ChatLine::replaceContent(int col, ChatLineContent* lineContent)
 {
-    if (col >= 0 && col < content.size() && lineContent) {
+    if (col >= 0 && col < content.size() && (lineContent != nullptr)) {
         QGraphicsScene* scene = content[col]->scene();
         delete content[col];
 
         content[col] = lineContent;
         lineContent->setIndex(row, col);
 
-        if (scene)
+        if (scene != nullptr)
             scene->addItem(content[col]);
 
         layout(width, bbox.topLeft());

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -253,7 +253,7 @@ void ChatMessage::markAsBroken()
 QString ChatMessage::toString() const
 {
     ChatLineContent* c = getContent(1);
-    if (c)
+    if (c != nullptr)
         return c->getText();
 
     return {};
@@ -272,14 +272,14 @@ void ChatMessage::setAsAction()
 void ChatMessage::hideSender()
 {
     ChatLineContent* c = getContent(0);
-    if (c)
+    if (c != nullptr)
         c->hide();
 }
 
 void ChatMessage::hideDate()
 {
     ChatLineContent* c = getContent(2);
-    if (c)
+    if (c != nullptr)
         c->hide();
 }
 

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -88,7 +88,7 @@ void renderMessageRaw(const QString& displayName, bool isSelf, bool colorizeName
     // ChatLine a QObject which I didn't think was worth it.
     auto chatMessage = static_cast<ChatMessage*>(chatLine.get());
 
-    if (chatMessage) {
+    if (chatMessage != nullptr) {
         if (chatLogMessage.state == MessageState::complete) {
             chatMessage->markAsDelivered(chatLogMessage.message.timestamp);
         } else if (chatLogMessage.state == MessageState::broken) {
@@ -391,7 +391,7 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
 
     const QPointF scenePos = mapToScene(ev->pos());
 
-    if (ev->buttons() & Qt::LeftButton) {
+    if ((ev->buttons() & Qt::LeftButton) != 0u) {
         // autoscroll
         if (ev->pos().y() < 0)
             selectionScrollDir = AutoScrollDirection::Up;
@@ -407,7 +407,7 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
             const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
             ChatLineContent* content = getContentFromPos(sceneClickPos);
-            if (content) {
+            if (content != nullptr) {
                 selClickedRow = line;
                 selClickedCol = content->getColumn();
                 selFirstRow = line;
@@ -418,9 +418,9 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
                 selectionMode = SelectionMode::Precise;
 
                 // ungrab mouse grabber
-                if (scene->mouseGrabberItem())
+                if (scene->mouseGrabberItem() != nullptr)
                     scene->mouseGrabberItem()->ungrabMouse();
-            } else if (line.get()) {
+            } else if (line.get() != nullptr) {
                 selClickedRow = line;
                 selFirstRow = selClickedRow;
                 selLastRow = selClickedRow;
@@ -433,7 +433,7 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
             ChatLineContent* content = getContentFromPos(scenePos);
             const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
-            if (content) {
+            if (content != nullptr) {
                 const int col = content->getColumn();
 
                 if (line == selClickedRow && col == selClickedCol) {
@@ -446,7 +446,7 @@ void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
 
                     line->selectionCleared();
                 }
-            } else if (line.get()) {
+            } else if (line.get() != nullptr) {
                 if (line != selClickedRow) {
                     selectionMode = SelectionMode::Multi;
                     line->selectionCleared();
@@ -491,7 +491,7 @@ bool ChatWidget::isOverSelection(QPointF scenePos) const
     if (selectionMode == SelectionMode::Precise) {
         ChatLineContent* content = getContentFromPos(scenePos);
 
-        if (content)
+        if (content != nullptr)
             return content->isOverSelection(scenePos);
     } else if (selectionMode == SelectionMode::Multi) {
         if (selGraphItem->rect().contains(scenePos))
@@ -621,7 +621,7 @@ void ChatWidget::mouseDoubleClickEvent(QMouseEvent* ev)
     ChatLineContent* content = getContentFromPos(scenePos);
     const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
-    if (content) {
+    if (content != nullptr) {
         content->selectionDoubleClick(scenePos);
         selClickedCol = content->getColumn();
         selClickedRow = line;
@@ -720,13 +720,13 @@ void ChatWidget::copySelectedText(bool toSelectionBuffer) const
     const QString text = getSelectedText();
     QClipboard* clipboard = QApplication::clipboard();
 
-    if (clipboard && !text.isNull())
+    if ((clipboard != nullptr) && !text.isNull())
         clipboard->setText(text, toSelectionBuffer ? QClipboard::Selection : QClipboard::Clipboard);
 }
 
 void ChatWidget::setTypingNotificationVisible(bool visible)
 {
-    if (typingNotification.get()) {
+    if (typingNotification.get() != nullptr) {
         typingNotification->setVisible(visible);
         updateTypingNotification();
     }
@@ -734,7 +734,7 @@ void ChatWidget::setTypingNotificationVisible(bool visible)
 
 void ChatWidget::setTypingNotificationName(const QString& displayName)
 {
-    if (!typingNotification.get()) {
+    if (typingNotification.get() == nullptr) {
         setTypingNotification();
     }
 
@@ -747,7 +747,7 @@ void ChatWidget::setTypingNotificationName(const QString& displayName)
 
 void ChatWidget::scrollToLine(ChatLine::Ptr line)
 {
-    if (!line.get())
+    if (line.get() == nullptr)
         return;
 
     updateSceneRect();
@@ -961,7 +961,7 @@ void ChatWidget::updateMultiSelectionRect()
 void ChatWidget::updateTypingNotification()
 {
     ChatLine* notification = typingNotification.get();
-    if (!notification)
+    if (notification == nullptr)
         return;
 
     qreal posY = 0.0;
@@ -1267,7 +1267,7 @@ void ChatWidget::handleMultiClickEvent()
         ChatLineContent* content = getContentFromPos(scenePos);
         const ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
-        if (content) {
+        if (content != nullptr) {
             content->selectionTripleClick(scenePos);
             selClickedCol = content->getColumn();
             selClickedRow = line;
@@ -1363,12 +1363,12 @@ bool ChatWidget::isActiveFileTransfer(ChatLine::Ptr l)
     for (int i = 0; i < count; ++i) {
         ChatLineContent* content = l->getContent(i);
         ChatLineContentProxy* proxy = qobject_cast<ChatLineContentProxy*>(content);
-        if (!proxy)
+        if (proxy == nullptr)
             continue;
 
         QWidget* widget = proxy->getWidget();
         FileTransferWidget* transferWidget = qobject_cast<FileTransferWidget*>(widget);
-        if (transferWidget && transferWidget->isActive())
+        if ((transferWidget != nullptr) && transferWidget->isActive())
             return true;
     }
 

--- a/src/chatlog/content/notificationicon.cpp
+++ b/src/chatlog/content/notificationicon.cpp
@@ -73,7 +73,7 @@ void NotificationIcon::updateGradient()
     grad.setColorAt(qMin(1.0, alpha + dotWidth), Qt::lightGray);
     grad.setColorAt(1, Qt::lightGray);
 
-    if (scene() && isVisible()) {
+    if ((scene() != nullptr) && isVisible()) {
         scene()->invalidate(sceneBoundingRect());
     }
 }

--- a/src/chatlog/content/spinner.cpp
+++ b/src/chatlog/content/spinner.cpp
@@ -78,7 +78,7 @@ void Spinner::timeout()
     // limit to the range [0.0 - 360.0]
     curRot = remainderf(angle, 360.0f);
 
-    if (scene()) {
+    if (scene() != nullptr) {
         scene()->invalidate(sceneBoundingRect());
     }
 }

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -46,7 +46,7 @@ Text::Text(DocumentCache& documentCache_, Settings& settings_, Style& style_, co
 
 Text::~Text()
 {
-    if (doc)
+    if (doc != nullptr)
         documentCache.push(doc);
 }
 
@@ -60,7 +60,7 @@ void Text::selectText(const QString& txt, const std::pair<int, int>& point)
 {
     regenerate();
 
-    if (!doc) {
+    if (doc == nullptr) {
         return;
     }
 
@@ -73,7 +73,7 @@ void Text::selectText(const QRegularExpression& exp, const std::pair<int, int>& 
 {
     regenerate();
 
-    if (!doc) {
+    if (doc == nullptr) {
         return;
     }
 
@@ -99,7 +99,7 @@ void Text::setWidth(float w)
 
 void Text::selectionMouseMove(QPointF scenePos)
 {
-    if (!doc)
+    if (doc == nullptr)
         return;
 
     const int cur = cursorFromPos(scenePos);
@@ -133,7 +133,7 @@ void Text::selectionCleared()
 
 void Text::selectionDoubleClick(QPointF scenePos)
 {
-    if (!doc)
+    if (doc == nullptr)
         return;
 
     const int cur = cursorFromPos(scenePos);
@@ -154,7 +154,7 @@ void Text::selectionDoubleClick(QPointF scenePos)
 
 void Text::selectionTripleClick(QPointF scenePos)
 {
-    if (!doc)
+    if (doc == nullptr)
         return;
 
     const int cur = cursorFromPos(scenePos);
@@ -211,7 +211,7 @@ void Text::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWid
     std::ignore = option;
     std::ignore = widget;
 
-    if (!doc)
+    if (doc == nullptr)
         return;
 
     painter->setClipRect(boundingRect());
@@ -267,7 +267,7 @@ void Text::mousePressEvent(QGraphicsSceneMouseEvent* event)
 
 void Text::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-    if (!doc)
+    if (doc == nullptr)
         return;
 
     const QString anchor = doc->documentLayout()->anchorAt(event->pos());
@@ -279,7 +279,7 @@ void Text::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 
 void Text::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
 {
-    if (!doc)
+    if (doc == nullptr)
         return;
 
     const QString anchor = doc->documentLayout()->anchorAt(event->pos());
@@ -312,7 +312,7 @@ QString Text::getLinkAt(QPointF scenePos) const
 
 void Text::regenerate()
 {
-    if (!doc) {
+    if (doc == nullptr) {
         doc = documentCache.pop();
         dirty = true;
     }
@@ -366,7 +366,7 @@ void Text::freeResources()
 
 QSizeF Text::idealSize()
 {
-    if (doc)
+    if (doc != nullptr)
         return doc->size();
 
     return size;
@@ -374,7 +374,7 @@ QSizeF Text::idealSize()
 
 int Text::cursorFromPos(QPointF scenePos, bool fuzzy) const
 {
-    if (doc)
+    if (doc != nullptr)
         return doc->documentLayout()->hitTest(mapFromScene(scenePos),
                                               fuzzy ? Qt::FuzzyHit : Qt::ExactHit);
 
@@ -398,7 +398,7 @@ bool Text::hasSelection() const
 
 QString Text::extractSanitizedText(int from, int to) const
 {
-    if (!doc)
+    if (doc == nullptr)
         return "";
 
     QString txt;

--- a/src/chatlog/content/timestamp.cpp
+++ b/src/chatlog/content/timestamp.cpp
@@ -20,7 +20,7 @@ QDateTime Timestamp::getTime()
 
 QSizeF Timestamp::idealSize()
 {
-    if (doc) {
+    if (doc != nullptr) {
         return {qMin(doc->idealWidth(), width), doc->size().height()};
     }
     return size;

--- a/src/chatlog/documentcache.cpp
+++ b/src/chatlog/documentcache.cpp
@@ -27,7 +27,7 @@ QTextDocument* DocumentCache::pop()
 
 void DocumentCache::push(QTextDocument* doc)
 {
-    if (doc) {
+    if (doc != nullptr) {
         doc->clear();
         documents.push(doc);
     }

--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -228,7 +228,7 @@ QString TextFormatter::applyMarkdown(const QString& message, bool showFormatting
         int offset = 0;
         while (iter.hasNext()) {
             const QRegularExpressionMatch match = iter.next();
-            const QString captured = match.captured(!showFormattingSymbols);
+            const QString captured = match.captured(static_cast<int>(!showFormattingSymbols));
             if (isTagIntersection(captured)) {
                 continue;
             }

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -161,7 +161,7 @@ void CoreFile::pauseResumeFile(uint32_t friendId, uint32_t fileId)
     const QMutexLocker<QRecursiveMutex> locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("pauseResumeFileSend: No such file in queue");
         return;
     }
@@ -196,7 +196,7 @@ void CoreFile::cancelFileSend(uint32_t friendId, uint32_t fileId)
     const QMutexLocker<QRecursiveMutex> locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("cancelFileSend: No such file in queue");
         return;
     }
@@ -216,7 +216,7 @@ void CoreFile::cancelFileRecv(uint32_t friendId, uint32_t fileId)
     const QMutexLocker<QRecursiveMutex> locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("cancelFileRecv: No such file in queue");
         return;
     }
@@ -235,7 +235,7 @@ void CoreFile::rejectFileRecvRequest(uint32_t friendId, uint32_t fileId)
     const QMutexLocker<QRecursiveMutex> locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("rejectFileRecvRequest: No such file in queue");
         return;
     }
@@ -254,7 +254,7 @@ void CoreFile::acceptFileRecvRequest(uint32_t friendId, uint32_t fileId, QString
     const QMutexLocker<QRecursiveMutex> locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("acceptFileRecvRequest: No such file in queue");
         return;
     }
@@ -326,7 +326,7 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
     const ToxPk friendPk = core->getFriendPublicKey(friendId);
 
     if (kind == TOX_FILE_KIND_AVATAR) {
-        if (!filesize) {
+        if (filesize == 0u) {
             qDebug("Received empty avatar request %d:%d", friendId, fileId);
             // Avatars of size 0 means explicitly no avatar
             Tox_Err_File_Control err;
@@ -423,7 +423,7 @@ void CoreFile::onFileControlCallback(Tox* tox, uint32_t friendId, uint32_t fileI
     Core* core = static_cast<Core*>(vCore);
     CoreFile* coreFile = core->getCoreFile();
     ToxFile* file = coreFile->findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("onFileControlCallback: No such file in queue");
         return;
     }
@@ -459,13 +459,13 @@ void CoreFile::onFileDataCallback(Tox* tox, uint32_t friendId, uint32_t fileId, 
     Core* core = static_cast<Core*>(vCore);
     CoreFile* coreFile = core->getCoreFile();
     ToxFile* file = coreFile->findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("onFileDataCallback: No such file in queue");
         return;
     }
 
     // If we reached EOF, ack and cleanup the transfer
-    if (!length) {
+    if (length == 0u) {
         file->status = ToxFile::FINISHED;
         if (file->fileKind != TOX_FILE_KIND_AVATAR) {
             emit coreFile->fileTransferFinished(*file);
@@ -519,7 +519,7 @@ void CoreFile::onFileRecvChunkCallback(Tox* tox, uint32_t friendId, uint32_t fil
     Core* core = static_cast<Core*>(vCore);
     CoreFile* coreFile = core->getCoreFile();
     ToxFile* file = coreFile->findFile(friendId, fileId);
-    if (!file) {
+    if (file == nullptr) {
         qWarning("onFileRecvChunkCallback: No such file in queue");
         Tox_Err_File_Control err;
         tox_file_control(tox, friendId, fileId, TOX_FILE_CONTROL_CANCEL, &err);
@@ -540,7 +540,7 @@ void CoreFile::onFileRecvChunkCallback(Tox* tox, uint32_t friendId, uint32_t fil
         return;
     }
 
-    if (!length) {
+    if (length == 0u) {
         file->status = ToxFile::FINISHED;
         if (file->fileKind == TOX_FILE_KIND_AVATAR) {
             QPixmap pic;

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -135,7 +135,7 @@ ToxFriendCall::ToxFriendCall(uint32_t friendNum, bool VideoEnabled, CoreAV& av_,
                                        [&av_, friendNum](std::shared_ptr<VideoFrame> frame) {
                                            av_.sendCallVideo(friendNum, frame);
                                        });
-        if (!videoInConn) {
+        if (videoInConn == nullptr) {
             qDebug() << "Video connection not working";
         }
     }

--- a/src/core/toxencrypt.cpp
+++ b/src/core/toxencrypt.cpp
@@ -291,7 +291,7 @@ std::unique_ptr<ToxEncrypt> ToxEncrypt::makeToxEncrypt(const QString& password, 
  */
 QByteArray ToxEncrypt::encrypt(const QByteArray& plaintext) const
 {
-    if (!passKey) {
+    if (passKey == nullptr) {
         qCritical() << "The passkey is invalid.";
         return QByteArray{};
     }

--- a/src/core/toxfileprogress.cpp
+++ b/src/core/toxfileprogress.cpp
@@ -30,7 +30,7 @@ bool ToxFileProgress::addSample(uint64_t bytesSent, QTime now)
     }
 
     auto* active = &samples[activeSample];
-    auto* inactive = &samples[!activeSample];
+    auto* inactive = &samples[activeSample == 0 ? 1 : 0];
 
     if (bytesSent < active->bytesSent || bytesSent < inactive->bytesSent) {
         qWarning("Bytes sent has decreased since last sample, ignoring sample");
@@ -55,7 +55,7 @@ bool ToxFileProgress::addSample(uint64_t bytesSent, QTime now)
 
     if (active->timestamp.msecsTo(now) >= samplePeriodMs) {
         // Swap samples and set the newly active sample
-        activeSample = !activeSample;
+        activeSample = activeSample == 0 ? 1 : 0;
         std::swap(active, inactive);
     }
 
@@ -99,7 +99,7 @@ double ToxFileProgress::getSpeed() const
     }
 
     const auto& active = samples[activeSample];
-    const auto& inactive = samples[!activeSample];
+    const auto& inactive = samples[activeSample == 0 ? 1 : 0];
 
     return (active.bytesSent - inactive.bytesSent)
            / double(inactive.timestamp.msecsTo(active.timestamp)) * 1000.0;

--- a/src/core/toxoptions.cpp
+++ b/src/core/toxoptions.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<ToxOptions> ToxOptions::makeToxOptions(const QByteArray& savedat
     Tox_Err_Options_New err;
     Tox_Options* tox_opts = tox_options_new(&err);
 
-    if (!PARSE_ERR(err) || !tox_opts) {
+    if (!PARSE_ERR(err) || (tox_opts == nullptr)) {
         qWarning() << "Failed to create Tox_Options";
         return {};
     }

--- a/src/model/about/aboutfriend.cpp
+++ b/src/model/about/aboutfriend.cpp
@@ -112,7 +112,7 @@ bool AboutFriend::clearHistory()
 {
     const ToxPk pk = f->getPublicKey();
     History* const history = profile.getHistory();
-    if (history) {
+    if (history != nullptr) {
         history->removeChatHistory(pk);
         return true;
     }
@@ -123,7 +123,7 @@ bool AboutFriend::clearHistory()
 bool AboutFriend::isHistoryExistence()
 {
     History* const history = profile.getHistory();
-    if (history) {
+    if (history != nullptr) {
         const ToxPk pk = f->getPublicKey();
         return history->historyExists(pk);
     }

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -486,7 +486,7 @@ void ChatHistory::breakMessage(DispatchedMessageId id, BrokenMessageReason reaso
 
 bool ChatHistory::canUseHistory() const
 {
-    return history && settings.getEnableLogging();
+    return (history != nullptr) && settings.getEnableLogging();
 }
 
 /**

--- a/src/model/chatroom/conferenceroom.cpp
+++ b/src/model/chatroom/conferenceroom.cpp
@@ -65,14 +65,14 @@ bool ConferenceRoom::possibleToOpenInNewWindow() const
 {
     const auto conferenceId = conference->getPersistentId();
     const auto dialogs = dialogsManager->getConferenceDialogs(conferenceId);
-    return !dialogs || dialogs->chatroomCount() > 1;
+    return (dialogs == nullptr) || dialogs->chatroomCount() > 1;
 }
 
 bool ConferenceRoom::canBeRemovedFromWindow() const
 {
     const auto conferenceId = conference->getPersistentId();
     const auto dialogs = dialogsManager->getConferenceDialogs(conferenceId);
-    return dialogs && dialogs->hasChat(conferenceId);
+    return (dialogs != nullptr) && dialogs->hasChat(conferenceId);
 }
 
 void ConferenceRoom::removeConferenceFromDialogs()

--- a/src/model/chatroom/friendchatroom.cpp
+++ b/src/model/chatroom/friendchatroom.cpp
@@ -157,21 +157,21 @@ bool FriendChatroom::possibleToOpenInNewWindow() const
 {
     const auto friendPk = frnd->getPublicKey();
     const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
-    return !dialogs || dialogs->chatroomCount() > 1;
+    return (dialogs == nullptr) || dialogs->chatroomCount() > 1;
 }
 
 bool FriendChatroom::canBeRemovedFromWindow() const
 {
     const auto friendPk = frnd->getPublicKey();
     const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
-    return dialogs && dialogs->hasChat(friendPk);
+    return (dialogs != nullptr) && dialogs->hasChat(friendPk);
 }
 
 bool FriendChatroom::friendCanBeRemoved() const
 {
     const auto friendPk = frnd->getPublicKey();
     const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
-    return !dialogs || !dialogs->hasChat(friendPk);
+    return (dialogs == nullptr) || !dialogs->hasChat(friendPk);
 }
 
 void FriendChatroom::removeFriendFromDialogs()

--- a/src/model/debug/debugobjecttreemodel.cpp
+++ b/src/model/debug/debugobjecttreemodel.cpp
@@ -95,7 +95,7 @@ void DebugObjectTreeModel::reload()
 {
     // Find the root object
     QObject* root = this;
-    while (root->parent()) {
+    while (root->parent() != nullptr) {
         root = root->parent();
     }
 

--- a/src/model/exiftransform.cpp
+++ b/src/model/exiftransform.cpp
@@ -17,14 +17,14 @@ Orientation getOrientation(QByteArray imageData)
 
     ExifData* exifData = exif_data_new_from_data(reinterpret_cast<const unsigned char*>(data), size);
 
-    if (!exifData) {
+    if (exifData == nullptr) {
         return Orientation::TopLeft;
     }
 
     const ExifByteOrder byteOrder = exif_data_get_byte_order(exifData);
     const ExifEntry* const exifEntry = exif_data_get_entry(exifData, EXIF_TAG_ORIENTATION);
 
-    if (!exifEntry) {
+    if (exifEntry == nullptr) {
         exif_data_free(exifData);
         return Orientation::TopLeft;
     }

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -117,7 +117,7 @@ QString generateContent(const QHash<const Friend*, size_t>& friendNotifications,
 
 QPixmap getSenderAvatar(Profile* profile, const ToxPk& sender)
 {
-    return profile ? profile->loadAvatar(sender) : QPixmap();
+    return profile != nullptr ? profile->loadAvatar(sender) : QPixmap();
 }
 } // namespace
 

--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -81,7 +81,7 @@ firstItemAfterDate(QDate date, const std::map<ChatLogIdx, ChatLogItem>& items)
 QString resolveToxPk(FriendList& friendList, ConferenceList& conferenceList, const ToxPk& pk)
 {
     Friend* f = friendList.findFriend(pk);
-    if (f) {
+    if (f != nullptr) {
         return f->getDisplayedName();
     }
 

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -189,7 +189,7 @@ void Nexus::bootstrapWithProfile(Profile* p)
     // We take ownership of the profile here.
     profile = std::unique_ptr<Profile>(p);
 
-    if (profile) {
+    if (profile != nullptr) {
         audioControl = std::unique_ptr<IAudioControl>(Audio::makeAudio(settings));
         assert(audioControl != nullptr);
         profile->getCore().getAv()->setAudio(*audioControl);
@@ -287,7 +287,7 @@ void Nexus::onLoadProfile(const QString& name, const QString& pass)
  */
 void Nexus::setProfile(Profile* p)
 {
-    if (!p) {
+    if (p == nullptr) {
         emit profileLoadFailed();
         // Warnings are issued during respective createNew/load calls
         return;

--- a/src/persistence/db/rawdatabaseimpl.cpp
+++ b/src/persistence/db/rawdatabaseimpl.cpp
@@ -100,14 +100,16 @@ bool RawDatabaseImpl::open(const QString& path_, const QString& hexKey)
     }
 
     if (sqlite3_create_function(sqlite, "regexp", 2, SQLITE_UTF8, nullptr,
-                                &RawDatabaseImpl::regexpInsensitive, nullptr, nullptr)) {
+                                &RawDatabaseImpl::regexpInsensitive, nullptr, nullptr)
+        != 0) {
         qWarning() << "Failed to create function regexp";
         close();
         return false;
     }
 
     if (sqlite3_create_function(sqlite, "regexpsensitive", 2, SQLITE_UTF8, nullptr,
-                                &RawDatabaseImpl::regexpSensitive, nullptr, nullptr)) {
+                                &RawDatabaseImpl::regexpSensitive, nullptr, nullptr)
+        != 0) {
         qWarning() << "Failed to create function regexpsensitive";
         close();
         return false;
@@ -362,7 +364,7 @@ bool RawDatabaseImpl::execNow(RawDatabase::Query statement)
  */
 bool RawDatabaseImpl::execNow(std::vector<RawDatabase::Query> statements)
 {
-    if (!sqlite) {
+    if (sqlite == nullptr) {
         qWarning() << "Trying to exec, but the database is not open";
         return false;
     }
@@ -406,7 +408,7 @@ void RawDatabaseImpl::execLater(RawDatabase::Query statement)
 
 void RawDatabaseImpl::execLater(std::vector<RawDatabase::Query> statements)
 {
-    if (!sqlite) {
+    if (sqlite == nullptr) {
         qWarning() << "Trying to exec, but the database is not open";
         return;
     }
@@ -437,7 +439,7 @@ void RawDatabaseImpl::sync()
  */
 bool RawDatabaseImpl::setPassword(const QString& password)
 {
-    if (!sqlite) {
+    if (sqlite == nullptr) {
         qWarning() << "Trying to change the password, but the database is not open";
         return false;
     }
@@ -556,7 +558,7 @@ bool RawDatabaseImpl::commitDbSwap(const QString& hexKey)
  */
 bool RawDatabaseImpl::rename(const QString& newPath)
 {
-    if (!sqlite) {
+    if (sqlite == nullptr) {
         qWarning() << "Trying to change the password, but the database is not open";
         return false;
     }
@@ -590,7 +592,7 @@ bool RawDatabaseImpl::rename(const QString& newPath)
  */
 bool RawDatabaseImpl::remove()
 {
-    if (!sqlite) {
+    if (sqlite == nullptr) {
         qWarning() << "Trying to remove the database, but it is not open";
         return false;
     }
@@ -788,7 +790,7 @@ void RawDatabaseImpl::process()
 {
     assert(QThread::currentThread() == workerThread.get());
 
-    if (!sqlite)
+    if (sqlite == nullptr)
         return;
 
     forever

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -417,7 +417,7 @@ RawDatabase::Query History::generateFileFinished(RowId id, bool success, const Q
                                                  const QByteArray& fileHash)
 {
     auto file_state = success ? ToxFile::FINISHED : ToxFile::CANCELED;
-    if (filePath.length()) {
+    if (filePath.length() != 0) {
         return RawDatabase::Query{
             QStringLiteral( //
                 "UPDATE file_transfers "
@@ -870,7 +870,7 @@ QList<History::DateIdx> History::getNumMessagesForChatBeforeDateBoundaries(const
         "AND countHistory.id <= history.id" // and filter that our unfiltered table history id only has elements up to history.id
     );
 
-    auto limitString = (maxNum) ? QString("LIMIT %1").arg(maxNum) : QString("");
+    auto limitString = ((maxNum) != 0u) ? QString("LIMIT %1").arg(maxNum) : QString("");
 
     db->execNow(RawDatabase::Query( //
         QStringLiteral(             //

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -280,7 +280,7 @@ void Settings::updateProfileData(Profile* profile, const QCommandLineParser* par
     setCurrentProfile(profile->getName());
     saveGlobal();
     loadPersonal(*profile, newProfile);
-    if (parser) {
+    if (parser != nullptr) {
         applyCommandLineOptions(*parser);
     }
 }
@@ -724,7 +724,7 @@ void Settings::saveGlobal()
  */
 void Settings::savePersonal()
 {
-    if (!loadedProfile) {
+    if (loadedProfile == nullptr) {
         qDebug() << "Could not save personal settings because there is no active profile";
         return;
     }

--- a/src/platform/capslock_x11.cpp
+++ b/src/platform/capslock_x11.cpp
@@ -20,7 +20,7 @@ bool Platform::capsLockEnabled()
 {
     Display* d = X11Display::lock();
     bool caps_state = false;
-    if (d) {
+    if (d != nullptr) {
         unsigned n;
         XkbGetIndicatorState(d, XkbUseCoreKbd, &n);
         caps_state = (n & 0x01) == 1;

--- a/src/platform/desktop_notifications/desktopnotify.cpp
+++ b/src/platform/desktop_notifications/desktopnotify.cpp
@@ -26,7 +26,7 @@ DesktopNotify::DesktopNotify(INotificationSettings& settings, QObject* parent)
       })}
 {
     connect(d->dbus, &DesktopNotifyBackend::messageClicked, this, &DesktopNotify::notificationClosed);
-    if (d->icon) {
+    if (d->icon != nullptr) {
         connect(d->icon, &QSystemTrayIcon::messageClicked, this, &DesktopNotify::notificationClosed);
     }
 }

--- a/src/platform/posixsignalnotifier.cpp
+++ b/src/platform/posixsignalnotifier.cpp
@@ -97,7 +97,7 @@ void installCrashHandler()
     };
 
     for (auto s : crashSignals) {
-        if (::sigaction(s, &action, nullptr)) {
+        if (::sigaction(s, &action, nullptr) != 0) {
             qFatal("Failed to setup crash signal %d, error = %d", s, errno);
         }
     }
@@ -128,7 +128,7 @@ void PosixSignalNotifier::watchSignal(int signum)
     action.sa_handler = signalHandler;
     action.sa_mask = blockMask; // allow old signal to finish before new is raised
 
-    if (::sigaction(signum, &action, nullptr)) {
+    if (::sigaction(signum, &action, nullptr) != 0) {
         qFatal("Failed to setup signal %d, error = %d", signum, errno);
     }
 }
@@ -158,7 +158,7 @@ void PosixSignalNotifier::unwatchSignal(int signum)
         ::exit(EXIT_FAILURE);
     };
 
-    if (::sigaction(signum, &action, nullptr)) {
+    if (::sigaction(signum, &action, nullptr) != 0) {
         qFatal("Failed to reset signal %d, error = %d", signum, errno);
     }
 }
@@ -187,7 +187,7 @@ void PosixSignalNotifier::onSignalReceived()
 
 PosixSignalNotifier::PosixSignalNotifier()
 {
-    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, g_signalSocketPair.data())) {
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, g_signalSocketPair.data()) != 0) {
         qFatal("Failed to create socket pair, error = %d", errno);
     }
 

--- a/src/platform/stacktrace.cpp
+++ b/src/platform/stacktrace.cpp
@@ -86,7 +86,7 @@ using char_ptr = std::unique_ptr<char, FreeDeleter>;
 const char* pathBasename(const char* path)
 {
     const char* base = std::strrchr(path, '/');
-    return base ? base + 1 : path;
+    return (base != nullptr) ? base + 1 : path;
 }
 
 char_ptr demangle(const char* name)

--- a/src/platform/timer_x11.cpp
+++ b/src/platform/timer_x11.cpp
@@ -18,7 +18,7 @@ uint32_t Platform::getIdleTime()
     uint32_t idleTime = 0;
 
     Display* display = X11Display::lock();
-    if (!display) {
+    if (display == nullptr) {
         qDebug() << "XOpenDisplay failed";
         X11Display::unlock();
         return 0;
@@ -27,9 +27,9 @@ uint32_t Platform::getIdleTime()
     int32_t x11event = 0;
     int32_t x11error = 0;
     static const int32_t hasExtension = XScreenSaverQueryExtension(display, &x11event, &x11error);
-    if (hasExtension) {
+    if (hasExtension != 0) {
         XScreenSaverInfo* info = XScreenSaverAllocInfo();
-        if (info) {
+        if (info != nullptr) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
             XScreenSaverQueryInfo(display, DefaultRootWindow(display), info);

--- a/src/platform/x11_display.cpp
+++ b/src/platform/x11_display.cpp
@@ -25,7 +25,7 @@ struct X11DisplayPrivate
     }
     ~X11DisplayPrivate()
     {
-        if (display) {
+        if (display != nullptr) {
             XCloseDisplay(display);
         }
     }

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -61,7 +61,7 @@ QDebug operator<<(QDebug dbg, const AVDictionary* const* dict)
 {
     QVector<QString> options;
     AVDictionaryEntry* entry = nullptr;
-    while ((entry = av_dict_get(*dict, "", entry, AV_DICT_IGNORE_SUFFIX))) {
+    while ((entry = av_dict_get(*dict, "", entry, AV_DICT_IGNORE_SUFFIX)) != nullptr) {
         options.append(QStringLiteral("%1: %2").arg(QString::fromUtf8(entry->key),
                                                     QString::fromUtf8(entry->value)));
     }
@@ -72,7 +72,7 @@ QDebug operator<<(QDebug dbg, const AVDictionary* const* dict)
 constexpr int numDigits(uint32_t num)
 {
     int digits = 0;
-    while (num) {
+    while (num != 0u) {
         num /= 10;
         ++digits;
     }
@@ -116,7 +116,7 @@ CameraDevice* CameraDevice::open(QString devName, AVDictionary** options)
 {
     const QMutexLocker<QMutex> lock(&openDeviceLock);
     CameraDevice* dev = openDevices.value(devName);
-    if (dev) {
+    if (dev != nullptr) {
         return dev;
     }
 
@@ -198,12 +198,12 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
 #endif
 
     ScopedAVDictionary options;
-    if (!iformat)
+    if (iformat == nullptr)
         ;
 #if defined(USING_V4L)
     else if (devName.startsWith("x11grab#")) {
         QSize screen;
-        if (mode.width && mode.height) {
+        if ((mode.width != 0) && (mode.height != 0)) {
             screen.setWidth(mode.width);
             screen.setHeight(mode.height);
         } else {
@@ -318,7 +318,7 @@ QVector<QPair<QString, QString>> CameraDevice::getRawDeviceListGeneric()
         return {};
     }
 
-    if (!iformat->priv_class || !AV_IS_INPUT_DEVICE(iformat->priv_class->category)) {
+    if ((iformat->priv_class == nullptr) || !AV_IS_INPUT_DEVICE(iformat->priv_class->category)) {
         return {};
     }
 
@@ -347,7 +347,7 @@ QVector<QPair<QString, QString>> CameraDevice::getRawDeviceListGeneric()
 
     AVDeviceInfoList* devlist = nullptr;
     avdevice_list_devices(s.get(), &devlist);
-    if (!devlist) {
+    if (devlist == nullptr) {
         qWarning() << "avdevice_list_devices failed";
         return {};
     }
@@ -377,7 +377,7 @@ QVector<QPair<QString, QString>> CameraDevice::getDeviceList()
     if (!getDefaultInputFormat())
         return devices;
 
-    if (!iformat)
+    if (iformat == nullptr)
         ;
 #if defined(USING_V4L)
     else if (QString::fromUtf8(iformat->name) == QStringLiteral("video4linux2,v4l2"))
@@ -394,7 +394,7 @@ QVector<QPair<QString, QString>> CameraDevice::getDeviceList()
     else
         devices += getRawDeviceListGeneric();
 
-    if (idesktopFormat) {
+    if (idesktopFormat != nullptr) {
         if (QString::fromUtf8(idesktopFormat->name) == QStringLiteral("x11grab")) {
             QString dev = "x11grab#";
             const QByteArray display = qgetenv("DISPLAY");
@@ -480,7 +480,7 @@ QVector<VideoMode> CameraDevice::getVideoModes(QString devName)
 {
     std::ignore = devName;
 
-    if (!iformat)
+    if (iformat == nullptr)
         ;
     else if (isScreen(devName))
         return getScreenModes();
@@ -542,7 +542,7 @@ bool CameraDevice::betterPixelFormat(uint32_t a, uint32_t b)
 bool CameraDevice::getDefaultInputFormat()
 {
     const QMutexLocker<QMutex> locker(&iformatLock);
-    if (iformat) {
+    if (iformat != nullptr) {
         return true;
     }
 
@@ -558,7 +558,7 @@ bool CameraDevice::getDefaultInputFormat()
 
 // Webcam input formats
 #if defined(USING_V4L)
-    if ((iformat = av_find_input_format("v4l2")))
+    if ((iformat = av_find_input_format("v4l2")) != nullptr)
         return true;
 #endif
 

--- a/src/video/corevideosource.cpp
+++ b/src/video/corevideosource.cpp
@@ -59,7 +59,7 @@ void CoreVideoSource::pushFrame(const vpx_image_t* vpxFrame)
         return;
 
     AVFrame* avFrame = av_frame_alloc();
-    if (!avFrame)
+    if (avFrame == nullptr)
         return;
 
     avFrame->width = width;

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -167,7 +167,7 @@ void NetCamView::hide()
     setSource(nullptr);
     selfVideoSurface->setSource(nullptr);
 
-    if (selfFrame)
+    if (selfFrame != nullptr)
         selfFrame->deleteLater();
 
     selfFrame = nullptr;

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -425,7 +425,7 @@ size_t VideoFrame::FrameBufferKey::hash(const FrameBufferKey& key)
     ret = 37 * ret + key.frameWidth;
     ret = 37 * ret + key.frameHeight;
     ret = 37 * ret + key.pixelFormat;
-    ret = 37 * ret + key.linesizeAligned;
+    ret = 37 * ret + static_cast<size_t>(key.linesizeAligned);
 
     return ret;
 }
@@ -509,7 +509,7 @@ AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFor
 {
     AVFrame* ret = av_frame_alloc();
 
-    if (!ret) {
+    if (ret == nullptr) {
         return nullptr;
     }
 
@@ -550,7 +550,7 @@ AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFor
                        dimensions.height(), static_cast<AVPixelFormat>(pixelFormat), resizeAlgo,
                        nullptr, nullptr, nullptr);
 
-    if (!swsCtx) {
+    if (swsCtx == nullptr) {
         av_freep(&ret->data[0]);
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 48, 101)
         av_frame_unref(ret);

--- a/src/video/videosurface.cpp
+++ b/src/video/videosurface.cpp
@@ -98,7 +98,7 @@ QPixmap VideoSurface::getAvatar() const
 
 void VideoSurface::subscribe()
 {
-    if (source && hasSubscribed++ == 0) {
+    if ((source != nullptr) && hasSubscribed++ == 0) {
         source->subscribe();
         connect(source, &VideoSource::frameAvailable, this, &VideoSurface::onNewFrameAvailable);
         connect(source, &VideoSource::sourceStopped, this, &VideoSurface::onSourceStopped);
@@ -107,7 +107,7 @@ void VideoSurface::subscribe()
 
 void VideoSurface::unsubscribe()
 {
-    if (!source || hasSubscribed == 0)
+    if ((source == nullptr) || hasSubscribed == 0)
         return;
 
     if (--hasSubscribed != 0)

--- a/src/widget/chatformheader.cpp
+++ b/src/widget/chatformheader.cpp
@@ -221,8 +221,8 @@ void ChatFormHeader::removeCallConfirm()
 
 void ChatFormHeader::updateCallButtons(bool online, bool audio, bool video)
 {
-    const bool audioAvailable = online && (mode & Mode::Audio);
-    const bool videoAvailable = online && (mode & Mode::Video);
+    const bool audioAvailable = online && ((mode & Mode::Audio) != 0);
+    const bool videoAvailable = online && ((mode & Mode::Video) != 0);
     if (!audioAvailable) {
         callState = CallButtonState::Disabled;
     } else if (video) {

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -89,7 +89,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
     QAction* selectedItem = menu.exec(mapToGlobal(event->pos()));
 
-    if (selectedItem) {
+    if (selectedItem != nullptr) {
         if (selectedItem == renameAction) {
             editName();
         } else if (selectedItem == removeAction) {
@@ -162,7 +162,7 @@ void CircleWidget::dropEvent(QDropEvent* event)
     // Check, that the element is dropped from qTox
     QObject* o = event->source();
     FriendWidget* widget = qobject_cast<FriendWidget*>(o);
-    if (!widget)
+    if (widget == nullptr)
         return;
 
     if (!event->mimeData()->hasFormat("toxPk")) {
@@ -171,7 +171,7 @@ void CircleWidget::dropEvent(QDropEvent* event)
     // Check, that the user has a friend with the same ToxId
     const ToxPk toxPk{event->mimeData()->data("toxPk")};
     Friend* f = friendList.findFriend(toxPk);
-    if (!f)
+    if (f == nullptr)
         return;
 
     // Save CircleWidget before changing the Id
@@ -222,7 +222,7 @@ void CircleWidget::updateID(int index)
         const QWidget* w = friendOnlineLayout()->itemAt(i)->widget();
         const FriendWidget* friendWidget = qobject_cast<const FriendWidget*>(w);
 
-        if (friendWidget) {
+        if (friendWidget != nullptr) {
             const Friend* f = friendWidget->getFriend();
             settings.setFriendCircleID(f->getPublicKey(), id);
         }
@@ -232,7 +232,7 @@ void CircleWidget::updateID(int index)
         const QWidget* w = friendOfflineLayout()->itemAt(i)->widget();
         const FriendWidget* friendWidget = qobject_cast<const FriendWidget*>(w);
 
-        if (friendWidget) {
+        if (friendWidget != nullptr) {
             const Friend* f = friendWidget->getFriend();
             settings.setFriendCircleID(f->getPublicKey(), id);
         }

--- a/src/widget/conferencewidget.cpp
+++ b/src/widget/conferencewidget.cpp
@@ -93,7 +93,7 @@ void ConferenceWidget::contextMenuEvent(QContextMenuEvent* event)
         setBackgroundRole(QPalette::Window);
     }
 
-    if (!selectedItem) {
+    if (selectedItem == nullptr) {
         return;
     }
 

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -298,7 +298,7 @@ void ContentDialog::cycleChats(bool forward, bool inverse)
 {
     QLayout* currentLayout;
     int index = getCurrentLayout(currentLayout);
-    if (!currentLayout || index == -1) {
+    if ((currentLayout == nullptr) || index == -1) {
         return;
     }
 
@@ -339,7 +339,7 @@ void ContentDialog::cycleChats(bool forward, bool inverse)
 
     QWidget* widget = currentLayout->itemAt(index)->widget();
     GenericChatroomWidget* chatWidget = qobject_cast<GenericChatroomWidget*>(widget);
-    if (chatWidget && chatWidget != activeChatroomWidget) {
+    if ((chatWidget != nullptr) && chatWidget != activeChatroomWidget) {
         // FIXME: emit should be removed
         emit chatWidget->chatroomWidgetClicked(chatWidget);
     }
@@ -375,7 +375,7 @@ void ContentDialog::onVideoHide()
  */
 void ContentDialog::updateTitleAndStatusIcon()
 {
-    if (!activeChatroomWidget) {
+    if (activeChatroomWidget == nullptr) {
         setWindowTitle(username);
         return;
     }
@@ -437,7 +437,7 @@ bool ContentDialog::event(QEvent* event)
 {
     switch (event->type()) {
     case QEvent::WindowActivate:
-        if (activeChatroomWidget) {
+        if (activeChatroomWidget != nullptr) {
             activeChatroomWidget->resetEventFlags();
             activeChatroomWidget->updateStatusLight();
 
@@ -446,9 +446,9 @@ bool ContentDialog::event(QEvent* event)
             const Friend* frnd = activeChatroomWidget->getFriend();
             Conference* conference = activeChatroomWidget->getConference();
 
-            if (frnd) {
+            if (frnd != nullptr) {
                 emit friendDialogShown(frnd);
-            } else if (conference) {
+            } else if (conference != nullptr) {
                 emit conferenceDialogShown(conference);
             }
         }
@@ -466,11 +466,11 @@ void ContentDialog::dragEnterEvent(QDragEnterEvent* event)
     QObject* o = event->source();
     FriendWidget* frnd = qobject_cast<FriendWidget*>(o);
     ConferenceWidget* conference = qobject_cast<ConferenceWidget*>(o);
-    if (frnd) {
+    if (frnd != nullptr) {
         assert(event->mimeData()->hasFormat("toxPk"));
         const ToxPk toxPk{event->mimeData()->data("toxPk")};
         Friend* contact = friendList.findFriend(toxPk);
-        if (!contact) {
+        if (contact == nullptr) {
             return;
         }
 
@@ -480,11 +480,11 @@ void ContentDialog::dragEnterEvent(QDragEnterEvent* event)
         if (!hasChat(friendId)) {
             event->acceptProposedAction();
         }
-    } else if (conference) {
+    } else if (conference != nullptr) {
         assert(event->mimeData()->hasFormat("conferenceId"));
         const ConferenceId conferenceId = ConferenceId{event->mimeData()->data("conferenceId")};
         Conference* contact = conferenceList.findConference(conferenceId);
-        if (!contact) {
+        if (contact == nullptr) {
             return;
         }
 
@@ -499,21 +499,21 @@ void ContentDialog::dropEvent(QDropEvent* event)
     QObject* o = event->source();
     FriendWidget* frnd = qobject_cast<FriendWidget*>(o);
     ConferenceWidget* conference = qobject_cast<ConferenceWidget*>(o);
-    if (frnd) {
+    if (frnd != nullptr) {
         assert(event->mimeData()->hasFormat("toxPk"));
         const ToxPk toxId(event->mimeData()->data("toxPk"));
         Friend* contact = friendList.findFriend(toxId);
-        if (!contact) {
+        if (contact == nullptr) {
             return;
         }
 
         emit addFriendDialog(contact, this);
         ensureSplitterVisible();
-    } else if (conference) {
+    } else if (conference != nullptr) {
         assert(event->mimeData()->hasFormat("conferenceId"));
         const ConferenceId conferenceId(event->mimeData()->data("conferenceId"));
         Conference* contact = conferenceList.findConference(conferenceId);
-        if (!contact) {
+        if (contact == nullptr) {
             return;
         }
 
@@ -581,7 +581,7 @@ void ContentDialog::activate(GenericChatroomWidget* widget)
 
     contentLayout->clear();
 
-    if (activeChatroomWidget) {
+    if (activeChatroomWidget != nullptr) {
         activeChatroomWidget->setAsInactiveChatroom();
     }
 

--- a/src/widget/contentdialogmanager.cpp
+++ b/src/widget/contentdialogmanager.cpp
@@ -56,7 +56,7 @@ FriendWidget* ContentDialogManager::addFriendToDialog(ContentDialog* dialog,
     const auto& friendPk = friendWidget->getFriend()->getPublicKey();
 
     ContentDialog* lastDialog = getFriendDialog(friendPk);
-    if (lastDialog) {
+    if (lastDialog != nullptr) {
         lastDialog->removeFriend(friendPk);
     }
 
@@ -72,7 +72,7 @@ ConferenceWidget* ContentDialogManager::addConferenceToDialog(ContentDialog* dia
     const auto& conferenceId = conferenceWidget->getConference()->getPersistentId();
 
     ContentDialog* lastDialog = getConferenceDialog(conferenceId);
-    if (lastDialog) {
+    if (lastDialog != nullptr) {
         lastDialog->removeConference(conferenceId);
     }
 
@@ -103,7 +103,7 @@ ContentDialog* ContentDialogManager::focusDialog(
     }
 
     ContentDialog* dialog = *iter;
-    if (dialog->windowState() & Qt::WindowMinimized) {
+    if ((dialog->windowState() & Qt::WindowMinimized) != 0u) {
         dialog->showNormal();
     }
 

--- a/src/widget/emoticonswidget.cpp
+++ b/src/widget/emoticonswidget.cpp
@@ -114,7 +114,7 @@ void EmoticonsWidget::onSmileyClicked()
 {
     // emit insert emoticon
     QWidget* sender = qobject_cast<QWidget*>(QObject::sender());
-    if (sender) {
+    if (sender != nullptr) {
         const QString sequence =
             sender->property("sequence").toString().replace("&lt;", "<").replace("&gt;", ">");
         emit insertEmoticon(sequence);
@@ -124,7 +124,7 @@ void EmoticonsWidget::onSmileyClicked()
 void EmoticonsWidget::onPageButtonClicked()
 {
     QWidget* sender = qobject_cast<QRadioButton*>(QObject::sender());
-    if (sender) {
+    if (sender != nullptr) {
         const int page = sender->property("pageIndex").toInt();
         stack.setCurrentIndex(page);
     }

--- a/src/widget/flowlayout.cpp
+++ b/src/widget/flowlayout.cpp
@@ -25,7 +25,7 @@ FlowLayout::FlowLayout(int margin, int hSpacing, int vSpacing)
 FlowLayout::~FlowLayout()
 {
     QLayoutItem* item;
-    while ((item = takeAt(0)))
+    while ((item = takeAt(0)) != nullptr)
         delete item;
 }
 //! [2]
@@ -166,7 +166,7 @@ int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
 int FlowLayout::smartSpacing(QStyle::PixelMetric pm) const
 {
     QObject* parent = this->parent();
-    if (!parent) {
+    if (parent == nullptr) {
         return -1;
     }
     if (parent->isWidgetType()) {

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -77,15 +77,15 @@ QString secondsToDHMS(quint32 duration)
     const quint32 days = duration / 24;
 
     // I assume no one will ever have call longer than a month
-    if (days) {
+    if (days != 0u) {
         return cD + res.asprintf("%dd%02dh %02dm %02ds", days, hours, minutes, seconds);
     }
 
-    if (hours) {
+    if (hours != 0u) {
         return cD + res.asprintf("%02dh %02dm %02ds", hours, minutes, seconds);
     }
 
-    if (minutes) {
+    if (minutes != 0u) {
         return cD + res.asprintf("%02dm %02ds", minutes, seconds);
     }
 
@@ -628,7 +628,7 @@ void ChatForm::onCopyStatusMessage()
     // make sure to copy not truncated text directly from the friend
     const QString text = f->getStatusMessage();
     QClipboard* clipboard = QApplication::clipboard();
-    if (clipboard) {
+    if (clipboard != nullptr) {
         clipboard->setText(text, QClipboard::Clipboard);
     }
 }
@@ -657,7 +657,7 @@ void ChatForm::updateMuteVolButton()
 
 void ChatForm::startCounter()
 {
-    if (callDurationTimer) {
+    if (callDurationTimer != nullptr) {
         return;
     }
     callDurationTimer = new QTimer();
@@ -669,7 +669,7 @@ void ChatForm::startCounter()
 
 void ChatForm::stopCounter(bool error)
 {
-    if (!callDurationTimer) {
+    if (callDurationTimer == nullptr) {
         return;
     }
     const QString dhms = secondsToDHMS(timeElapsed.elapsed() / 1000);
@@ -743,7 +743,7 @@ void ChatForm::showNetcam()
 
     const QSize minSize = netcam->getSurfaceMinSize();
     ContentDialog* current = contentDialogManager.current();
-    if (current) {
+    if (current != nullptr) {
         current->onVideoShow(minSize);
     }
 }
@@ -755,7 +755,7 @@ void ChatForm::hideNetcam()
     }
 
     ContentDialog* current = contentDialogManager.current();
-    if (current) {
+    if (current != nullptr) {
         current->onVideoHide();
     }
 

--- a/src/widget/form/conferenceform.cpp
+++ b/src/widget/form/conferenceform.cpp
@@ -168,7 +168,7 @@ void ConferenceForm::onAttachClicked()
 void ConferenceForm::updateUserNames()
 {
     QLayoutItem* child;
-    while ((child = namesListLayout->takeAt(0))) {
+    while ((child = namesListLayout->takeAt(0)) != nullptr) {
         child->widget()->hide();
         delete child->widget();
         delete child;
@@ -262,7 +262,7 @@ void ConferenceForm::peerAudioPlaying(ToxPk peerPk)
     peerLabels[peerPk]->style()->unpolish(peerLabels[peerPk]);
     peerLabels[peerPk]->style()->polish(peerLabels[peerPk]);
     // TODO(sudden6): check if this can ever be false, cause [] default constructs
-    if (!peerAudioTimers[peerPk]) {
+    if (peerAudioTimers[peerPk] == nullptr) {
         peerAudioTimers[peerPk] = new QTimer(this);
         peerAudioTimers[peerPk]->setSingleShot(true);
         connect(peerAudioTimers[peerPk], &QTimer::timeout, this, [this, peerPk] {
@@ -288,7 +288,7 @@ void ConferenceForm::dragEnterEvent(QDragEnterEvent* ev)
     }
     const ToxPk toxPk{ev->mimeData()->data("toxPk")};
     Friend* frnd = friendList.findFriend(toxPk);
-    if (frnd)
+    if (frnd != nullptr)
         ev->acceptProposedAction();
 }
 
@@ -299,7 +299,7 @@ void ConferenceForm::dropEvent(QDropEvent* ev)
     }
     const ToxPk toxPk{ev->mimeData()->data("toxPk")};
     Friend* frnd = friendList.findFriend(toxPk);
-    if (!frnd)
+    if (frnd == nullptr)
         return;
 
     const int friendId = frnd->getId();
@@ -353,7 +353,7 @@ void ConferenceForm::onCallClicked()
 void ConferenceForm::keyPressEvent(QKeyEvent* ev)
 {
     // Push to talk (CTRL+P)
-    if (ev->key() == Qt::Key_P && (ev->modifiers() & Qt::ControlModifier) && inCall) {
+    if (ev->key() == Qt::Key_P && ((ev->modifiers() & Qt::ControlModifier) != 0u) && inCall) {
         onMicMuteToggle();
     }
 
@@ -366,7 +366,7 @@ void ConferenceForm::keyPressEvent(QKeyEvent* ev)
 void ConferenceForm::keyReleaseEvent(QKeyEvent* ev)
 {
     // Push to talk (CTRL+P)
-    if (ev->key() == Qt::Key_P && (ev->modifiers() & Qt::ControlModifier) && inCall) {
+    if (ev->key() == Qt::Key_P && ((ev->modifiers() & Qt::ControlModifier) != 0u) && inCall) {
         onMicMuteToggle();
     }
 

--- a/src/widget/form/conferenceinviteform.cpp
+++ b/src/widget/form/conferenceinviteform.cpp
@@ -153,7 +153,7 @@ void ConferenceInviteForm::deleteInviteWidget(const ConferenceInvite& inviteInfo
 void ConferenceInviteForm::retranslateUi()
 {
     headLabel->setText(tr("Conferences"));
-    if (createButton) {
+    if (createButton != nullptr) {
         createButton->setText(tr("Create new conference"));
     }
     inviteBox->setTitle(tr("Conference invites"));

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -80,7 +80,7 @@ QString fontToCss(const QFont& font, const QString& name)
 QString GenericChatForm::resolveToxPk(const ToxPk& pk)
 {
     Friend* f = friendList.findFriend(pk);
-    if (f) {
+    if (f != nullptr) {
         return f->getDisplayedName();
     }
 
@@ -420,7 +420,7 @@ void GenericChatForm::onChatContextMenuRequested(QPoint pos)
     // If we right-clicked on a link, give the option to copy it
     bool clickedOnLink = false;
     Text* clickedText = qobject_cast<Text*>(chatWidget->getContentFromGlobalPos(pos));
-    if (clickedText) {
+    if (clickedText != nullptr) {
         const QPointF scenePos = chatWidget->mapToScene(chatWidget->mapFromGlobal(pos));
         const QString linkTarget = clickedText->getLinkAt(scenePos);
         if (!linkTarget.isEmpty()) {
@@ -464,7 +464,7 @@ void GenericChatForm::onEmoteButtonClicked()
     widget.installEventFilter(this);
 
     QWidget* sender = qobject_cast<QWidget*>(QObject::sender());
-    if (sender) {
+    if (sender != nullptr) {
         const QPoint pos =
             -QPoint(widget.sizeHint().width() / 2, widget.sizeHint().height()) - QPoint(0, 10);
         widget.exec(sender->mapToGlobal(pos));
@@ -475,7 +475,7 @@ void GenericChatForm::onEmoteInsertRequested(QString str)
 {
     // insert the emoticon
     QWidget* sender = qobject_cast<QWidget*>(QObject::sender());
-    if (sender)
+    if (sender != nullptr)
         msgEdit->insertPlainText(str);
 
     msgEdit->setFocus(); // refocus so that we can continue typing
@@ -521,7 +521,7 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr& chatLine) const
     if (chatLine) {
         Timestamp* const timestamp = qobject_cast<Timestamp*>(chatLine->getContent(2));
 
-        if (timestamp) {
+        if (timestamp != nullptr) {
             return timestamp->getTime();
         }
         return {};
@@ -574,7 +574,7 @@ void GenericChatForm::resizeEvent(QResizeEvent* event)
 bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
 {
     EmoticonsWidget* ev = qobject_cast<EmoticonsWidget*>(object);
-    if (ev && event->type() == QEvent::KeyPress) {
+    if ((ev != nullptr) && event->type() == QEvent::KeyPress) {
         QKeyEvent* key = static_cast<QKeyEvent*>(event);
         msgEdit->sendKeyEvent(key);
         msgEdit->setFocus();
@@ -585,7 +585,7 @@ bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
         return false;
 
     auto wObject = qobject_cast<QWidget*>(object);
-    if (!wObject || !wObject->isEnabled())
+    if ((wObject == nullptr) || !wObject->isEnabled())
         return false;
 
     switch (event->type()) {
@@ -663,7 +663,7 @@ void GenericChatForm::searchFormShow()
 void GenericChatForm::onLoadHistory()
 {
     LoadHistoryDialog dlg(&chatLog);
-    if (dlg.exec()) {
+    if (dlg.exec() != 0) {
         chatWidget->jumpToDate(dlg.getFromDate().date());
     }
 }

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -157,7 +157,7 @@ void SearchSettingsForm::onChoiceDate()
     LoadHistoryDialog dlg;
     dlg.setTitle(tr("Select Date Dialog"));
     dlg.setInfoLabel(tr("Select a date"));
-    if (dlg.exec()) {
+    if (dlg.exec() != 0) {
         startDate = dlg.getFromDate().date();
         updateStartDateLabel();
     }

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -127,7 +127,7 @@ void AdvancedForm::on_btnCopyDebug_clicked()
     }
 
     QClipboard* clipboard = QApplication::clipboard();
-    if (clipboard) {
+    if (clipboard != nullptr) {
         QString debugtext;
         if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
             QTextStream in(&file);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -107,7 +107,7 @@ void AVForm::hideEvent(QHideEvent* event)
     audioSink.reset();
     audioSrc.reset();
 
-    if (camVideoSurface) {
+    if (camVideoSurface != nullptr) {
         camVideoSurface->setSource(nullptr);
         killVideoSurface();
     }
@@ -297,7 +297,7 @@ void AVForm::fillCameraModesComboBox()
         qDebug("width: %d, height: %d, fps: %f, pixel format: %s", mode.width, mode.height,
                static_cast<double>(mode.fps), pixelFormat.c_str());
 
-        if (mode.height && mode.width) {
+        if ((mode.height != 0) && (mode.width != 0)) {
             str += QString("%1p").arg(mode.height);
         } else {
             str += tr("Default resolution");
@@ -341,7 +341,7 @@ void AVForm::fillScreenModesComboBox()
                static_cast<double>(mode.fps), pixelFormat.c_str());
 
         QString name;
-        if (mode.width && mode.height)
+        if ((mode.width != 0) && (mode.height != 0))
             name = tr("Screen %1").arg(i + 1);
         else
             name = tr("Select region");
@@ -602,7 +602,7 @@ void AVForm::on_audioThresholdSlider_valueChanged(int sliderSteps)
 }
 void AVForm::createVideoSurface()
 {
-    if (camVideoSurface)
+    if (camVideoSurface != nullptr)
         return;
 
     camVideoSurface = new VideoSurface(QPixmap(), CamFrame);
@@ -614,7 +614,7 @@ void AVForm::createVideoSurface()
 
 void AVForm::killVideoSurface()
 {
-    if (!camVideoSurface)
+    if (camVideoSurface == nullptr)
         return;
 
     QLayoutItem* child;

--- a/src/widget/form/settings/genericsettings.cpp
+++ b/src/widget/form/settings/genericsettings.cpp
@@ -64,8 +64,8 @@ void GenericForm::eventsInit()
 bool GenericForm::eventFilter(QObject* o, QEvent* e)
 {
     if ((e->type() == QEvent::Wheel)
-        && (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o)
-            || qobject_cast<QCheckBox*>(o))) {
+        && ((qobject_cast<QComboBox*>(o) != nullptr) || (qobject_cast<QAbstractSpinBox*>(o) != nullptr)
+            || (qobject_cast<QCheckBox*>(o) != nullptr))) {
         e->ignore();
         return true;
     }

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -388,10 +388,10 @@ void UserInterfaceForm::on_txtChatFontSize_valueChanged(int px)
 
 void UserInterfaceForm::on_useNameColors_stateChanged(int value)
 {
-    settings.setEnableConferencesColor(value);
+    settings.setEnableConferencesColor(value != 0);
 }
 
 void UserInterfaceForm::on_notifyHide_stateChanged(int value)
 {
-    settings.setNotifyHide(value);
+    settings.setNotifyHide(value != 0);
 }

--- a/src/widget/form/settings/verticalonlyscroller.cpp
+++ b/src/widget/form/settings/verticalonlyscroller.cpp
@@ -16,13 +16,13 @@ VerticalOnlyScroller::VerticalOnlyScroller(QWidget* parent)
 void VerticalOnlyScroller::resizeEvent(QResizeEvent* event)
 {
     QScrollArea::resizeEvent(event);
-    if (widget())
+    if (widget() != nullptr)
         widget()->setMaximumWidth(event->size().width());
 }
 
 void VerticalOnlyScroller::showEvent(QShowEvent* event)
 {
     QScrollArea::showEvent(event);
-    if (widget())
+    if (widget() != nullptr)
         widget()->setMaximumWidth(size().width());
 }

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -438,7 +438,7 @@ void FriendListWidget::onConferencePositionChanged(bool top)
 
 void FriendListWidget::cycleChats(GenericChatroomWidget* activeChatroomWidget, bool forward)
 {
-    if (!activeChatroomWidget) {
+    if (activeChatroomWidget == nullptr) {
         return;
     }
 
@@ -446,7 +446,7 @@ void FriendListWidget::cycleChats(GenericChatroomWidget* activeChatroomWidget, b
     FriendWidget* friendWidget = qobject_cast<FriendWidget*>(activeChatroomWidget);
 
     if (mode == SortingMode::Activity) {
-        if (!friendWidget) {
+        if (friendWidget == nullptr) {
             return;
         }
 
@@ -518,7 +518,7 @@ void FriendListWidget::dragEnterEvent(QDragEnterEvent* event)
     }
     const ToxPk toxPk(event->mimeData()->data("toxPk"));
     Friend* frnd = friendList.findFriend(toxPk);
-    if (frnd)
+    if (frnd != nullptr)
         event->acceptProposedAction();
 }
 
@@ -527,14 +527,14 @@ void FriendListWidget::dropEvent(QDropEvent* event)
     // Check, that the element is dropped from qTox
     QObject* o = event->source();
     FriendWidget* widget = qobject_cast<FriendWidget*>(o);
-    if (!widget)
+    if (widget == nullptr)
         return;
 
     // Check, that the user has a friend with the same ToxPk
     assert(event->mimeData()->hasFormat("toxPk"));
     const ToxPk toxPk{event->mimeData()->data("toxPk")};
     Friend* f = friendList.findFriend(toxPk);
-    if (!f)
+    if (f == nullptr)
         return;
 
     // Save CircleWidget before changing the Id
@@ -543,7 +543,7 @@ void FriendListWidget::dropEvent(QDropEvent* event)
 
     moveWidget(widget, f->getStatus(), true);
 
-    if (circleWidget)
+    if (circleWidget != nullptr)
         circleWidget->updateStatus();
 }
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -191,7 +191,7 @@ getCircleAndFriendList(const Friend* frnd, FriendWidget* fw, Settings& settings)
     const auto pk = frnd->getPublicKey();
     const auto circleId = settings.getFriendCircleID(pk);
     auto circleWidget = CircleWidget::getFromID(circleId);
-    auto w = circleWidget ? static_cast<QWidget*>(circleWidget) : static_cast<QWidget*>(fw);
+    auto w = circleWidget != nullptr ? static_cast<QWidget*>(circleWidget) : static_cast<QWidget*>(fw);
     auto friendList = qobject_cast<FriendListWidget*>(w->parentWidget());
     return std::make_tuple(circleWidget, friendList);
 }
@@ -248,7 +248,7 @@ void FriendWidget::moveToCircle(int newCircleId)
     auto oldCircleWidget = CircleWidget::getFromID(oldCircleId);
     auto newCircleWidget = CircleWidget::getFromID(newCircleId);
 
-    if (newCircleWidget) {
+    if (newCircleWidget != nullptr) {
         newCircleWidget->addFriendWidget(this, frnd->getStatus());
         newCircleWidget->setExpanded(true);
         s.savePersonal();
@@ -256,7 +256,7 @@ void FriendWidget::moveToCircle(int newCircleId)
         s.setFriendCircleID(pk, newCircleId);
     }
 
-    if (oldCircleWidget) {
+    if (oldCircleWidget != nullptr) {
         oldCircleWidget->updateStatus();
     }
 }
@@ -315,7 +315,7 @@ void FriendWidget::updateStatusLight()
         const Settings& s = settings;
         const uint32_t circleId = s.getFriendCircleID(frnd->getPublicKey());
         CircleWidget* circleWidget = CircleWidget::getFromID(circleId);
-        if (circleWidget) {
+        if (circleWidget != nullptr) {
             circleWidget->setExpanded(true);
         }
 

--- a/src/widget/qrwidget.cpp
+++ b/src/widget/qrwidget.cpp
@@ -89,7 +89,7 @@ void QRWidget::paintImage()
             for (int x = 0; x < s; ++x) {
                 const int xx = yy + x;
                 const unsigned char b = qr->data[xx];
-                if (b & 0x01) {
+                if ((b & 0x01) != 0) {
                     const double rx1 = x * scale;
                     const double ry1 = y * scale;
                     const QRectF r(rx1, ry1, scale, scale);

--- a/src/widget/searchform.cpp
+++ b/src/widget/searchform.cpp
@@ -306,7 +306,7 @@ void LineEdit::keyPressEvent(QKeyEvent* event)
     const int key = event->key();
 
     if ((key == Qt::Key_Enter || key == Qt::Key_Return)) {
-        if ((event->modifiers() & Qt::ShiftModifier)) {
+        if ((event->modifiers() & Qt::ShiftModifier) != 0u) {
             emit clickShiftEnter();
         } else {
             emit clickEnter();

--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -325,7 +325,7 @@ void Style::repolish(QWidget* w)
 
     for (QObject* o : w->children()) {
         QWidget* c = qobject_cast<QWidget*>(o);
-        if (c) {
+        if (c != nullptr) {
             c->style()->unpolish(c);
             c->style()->polish(c);
         }

--- a/src/widget/tool/adjustingscrollarea.cpp
+++ b/src/widget/tool/adjustingscrollarea.cpp
@@ -29,7 +29,7 @@ void AdjustingScrollArea::resizeEvent(QResizeEvent* ev)
 
 QSize AdjustingScrollArea::sizeHint() const
 {
-    if (widget()) {
+    if (widget() != nullptr) {
         const int scrollbarWidth = verticalScrollBar()->isVisible() ? verticalScrollBar()->width() : 0;
         return widget()->sizeHint() + QSize(scrollbarWidth, 0);
     }

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -102,7 +102,7 @@ CallConfirmWidget::CallConfirmWidget(Settings& settings, Style& style, const QWi
  */
 void CallConfirmWidget::reposition()
 {
-    if (parentWidget())
+    if (parentWidget() != nullptr)
         parentWidget()->removeEventFilter(this);
 
     setParent(anchor->window());
@@ -155,7 +155,7 @@ void CallConfirmWidget::showEvent(QShowEvent* event)
 void CallConfirmWidget::hideEvent(QHideEvent* event)
 {
     std::ignore = event;
-    if (parentWidget())
+    if (parentWidget() != nullptr)
         parentWidget()->removeEventFilter(this);
 
     setParent(nullptr);

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -39,7 +39,7 @@ void ChatTextEdit::keyPressEvent(QKeyEvent* event)
         return;
     }
     if (key == Qt::Key_Tab) {
-        if (event->modifiers())
+        if (event->modifiers() != 0u)
             event->ignore();
         else {
             emit tabPressed();
@@ -79,12 +79,12 @@ bool ChatTextEdit::pasteIfImage(QKeyEvent* event)
 {
     std::ignore = event;
     const QClipboard* const clipboard = QApplication::clipboard();
-    if (!clipboard) {
+    if (clipboard == nullptr) {
         return false;
     }
 
     const QMimeData* const mimeData = clipboard->mimeData();
-    if (!mimeData || !mimeData->hasImage()) {
+    if ((mimeData == nullptr) || !mimeData->hasImage()) {
         return false;
     }
 

--- a/src/widget/tool/movablewidget.cpp
+++ b/src/widget/tool/movablewidget.cpp
@@ -86,8 +86,8 @@ void MovableWidget::setRatio(float r)
 
 void MovableWidget::mousePressEvent(QMouseEvent* event)
 {
-    if (event->buttons() & Qt::LeftButton) {
-        if (!(mode & Resize))
+    if ((event->buttons() & Qt::LeftButton) != 0u) {
+        if ((mode & Resize) == 0)
             mode |= Moving;
 
         lastPoint = event->globalPosition().toPoint();
@@ -96,7 +96,7 @@ void MovableWidget::mousePressEvent(QMouseEvent* event)
 
 void MovableWidget::mouseMoveEvent(QMouseEvent* event)
 {
-    if (mode & Moving) {
+    if ((mode & Moving) != 0) {
         QPoint moveTo = pos() - (lastPoint - event->globalPosition().toPoint());
         checkBoundary(moveTo);
 
@@ -127,7 +127,7 @@ void MovableWidget::mouseMoveEvent(QMouseEvent* event)
                 mode &= ~ResizeDown;
         }
 
-        if (mode & Resize) {
+        if ((mode & Resize) != 0) {
             const Modes ResizeUpRight = ResizeUp | ResizeRight;
             const Modes ResizeUpLeft = ResizeUp | ResizeLeft;
             const Modes ResizeDownRight = ResizeDown | ResizeRight;
@@ -137,18 +137,18 @@ void MovableWidget::mouseMoveEvent(QMouseEvent* event)
                 setCursor(Qt::SizeBDiagCursor);
             else if ((mode & ResizeUpLeft) == ResizeUpLeft || (mode & ResizeDownRight) == ResizeDownRight)
                 setCursor(Qt::SizeFDiagCursor);
-            else if (mode & (ResizeLeft | ResizeRight))
+            else if ((mode & (ResizeLeft | ResizeRight)) != 0)
                 setCursor(Qt::SizeHorCursor);
             else
                 setCursor(Qt::SizeVerCursor);
 
-            if (event->buttons() & Qt::LeftButton) {
+            if ((event->buttons() & Qt::LeftButton) != 0u) {
                 QPoint lastPosition = pos();
                 const QPoint displacement = lastPoint - event->globalPosition().toPoint();
                 QSize lastSize = size();
 
 
-                if (mode & ResizeUp) {
+                if ((mode & ResizeUp) != 0) {
                     lastSize.setHeight(height() + displacement.y());
 
                     if (lastSize.height() > maximumHeight())
@@ -158,7 +158,7 @@ void MovableWidget::mouseMoveEvent(QMouseEvent* event)
                         lastPosition.setY(y() - displacement.y());
                 }
 
-                if (mode & ResizeLeft) {
+                if ((mode & ResizeLeft) != 0) {
                     lastSize.setWidth(width() + displacement.x());
                     if (lastSize.width() > maximumWidth())
                         lastPosition.setX(x() - displacement.x() + (lastSize.width() - maximumWidth()));
@@ -166,10 +166,10 @@ void MovableWidget::mouseMoveEvent(QMouseEvent* event)
                         lastPosition.setX(x() - displacement.x());
                 }
 
-                if (mode & ResizeRight)
+                if ((mode & ResizeRight) != 0)
                     lastSize.setWidth(width() - displacement.x());
 
-                if (mode & ResizeDown)
+                if ((mode & ResizeDown) != 0)
                     lastSize.setHeight(height() - displacement.y());
 
                 if (lastSize.height() > maximumHeight())
@@ -178,11 +178,11 @@ void MovableWidget::mouseMoveEvent(QMouseEvent* event)
                 if (lastSize.width() > maximumWidth())
                     lastSize.setWidth(maximumWidth());
 
-                if (mode & (ResizeLeft | ResizeRight)) {
-                    if (mode & (ResizeUp | ResizeDown)) {
+                if ((mode & (ResizeLeft | ResizeRight)) != 0) {
+                    if ((mode & (ResizeUp | ResizeDown)) != 0) {
                         const int height = lastSize.width() / getRatio();
 
-                        if (!(mode & ResizeDown))
+                        if ((mode & ResizeDown) == 0)
                             lastPosition.setY(lastPosition.y() - (height - lastSize.height()));
 
                         resize(lastSize.width(), height);
@@ -226,7 +226,7 @@ void MovableWidget::mouseDoubleClickEvent(QMouseEvent* event)
     if (!(event->buttons() & Qt::LeftButton))
         return;
 
-    if (!graphicsEffect()) {
+    if (graphicsEffect() == nullptr) {
         QGraphicsOpacityEffect* opacityEffect = new QGraphicsOpacityEffect(this);
         opacityEffect->setOpacity(0.5);
         setGraphicsEffect(opacityEffect);

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -228,7 +228,7 @@ void ScreenshotGrabber::hideVisibleWindows()
 void ScreenshotGrabber::restoreHiddenWindows()
 {
     foreach (QWidget* w, mHiddenWindows) {
-        if (w)
+        if (w != nullptr)
             w->setVisible(true);
     }
 

--- a/src/widget/translator.cpp
+++ b/src/widget/translator.cpp
@@ -26,10 +26,10 @@ void Translator::translate(const QString& localeName)
 {
     const QMutexLocker<QMutex> locker{&lock};
 
-    if (!core_translator)
+    if (core_translator == nullptr)
         core_translator = new QTranslator();
 
-    if (!app_translator)
+    if (app_translator == nullptr)
         app_translator = new QTranslator();
 
     // Remove old translations

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -472,7 +472,7 @@ void Widget::init()
     ui->settingsButton->setCheckable(true);
     ui->debugButton->setCheckable(true);
 
-    if (contentLayout) {
+    if (contentLayout != nullptr) {
         onAddClicked();
     }
 
@@ -532,7 +532,7 @@ bool Widget::eventFilter(QObject* obj, QEvent* event)
 
     case QEvent::WindowStateChange:
         ce = static_cast<QWindowStateChangeEvent*>(event);
-        if (state.testFlag(Qt::WindowMinimized) && obj) {
+        if (state.testFlag(Qt::WindowMinimized) && (obj != nullptr)) {
             wasMaximized = ce->oldState().testFlag(Qt::WindowMaximized);
         }
 
@@ -825,12 +825,12 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
         QSize size;
         QPoint pos;
 
-        if (contentLayout) {
+        if (contentLayout != nullptr) {
             pos = mapToGlobal(ui->mainSplitter->widget(1)->pos());
             size = ui->mainSplitter->widget(1)->size();
         }
 
-        if (contentLayout) {
+        if (contentLayout != nullptr) {
             contentLayout->clear();
             contentLayout->parentWidget()->setParent(nullptr); // Remove from splitter.
             contentLayout->parentWidget()->hide();
@@ -845,7 +845,7 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
             showNormal();
             resize(width, height());
 
-            if (settingsWidget) {
+            if (settingsWidget != nullptr) {
                 ContentLayout* contentLayout_ = createContentDialog((DialogType::SettingDialog));
                 contentLayout_->parentWidget()->resize(size);
                 contentLayout_->parentWidget()->move(pos);
@@ -1110,7 +1110,7 @@ void Widget::dispatchFile(ToxFile file)
 {
     const auto& friendId = friendList->id2Key(file.friendId);
     Friend* f = friendList->findFriend(friendId);
-    if (!f) {
+    if (f == nullptr) {
         return;
     }
 
@@ -1262,7 +1262,7 @@ void Widget::onCoreFriendStatusChanged(uint32_t friendId, Status::Status status)
 {
     const auto& friendPk = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendPk);
-    if (!f) {
+    if (f == nullptr) {
         return;
     }
 
@@ -1294,7 +1294,7 @@ void Widget::onFriendStatusMessageChanged(uint32_t friendId, const QString& mess
 {
     const auto& friendPk = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendPk);
-    if (!f) {
+    if (f == nullptr) {
         return;
     }
 
@@ -1328,7 +1328,7 @@ void Widget::onFriendUsernameChanged(uint32_t friendId, const QString& username)
 {
     const auto& friendPk = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendPk);
-    if (!f) {
+    if (f == nullptr) {
         return;
     }
 
@@ -1362,7 +1362,7 @@ void Widget::openDialog(GenericChatroomWidget* widget, bool newWindow)
     const Friend* frnd = widget->getFriend();
     const Conference* conference = widget->getConference();
     bool chatFormIsSet;
-    if (frnd) {
+    if (frnd != nullptr) {
         form = chatForms[frnd->getPublicKey()];
         contentDialogManager->focusChat(frnd->getPersistentId());
         chatFormIsSet = contentDialogManager->chatWidgetExists(frnd->getPersistentId());
@@ -1389,7 +1389,7 @@ void Widget::openDialog(GenericChatroomWidget* widget, bool newWindow)
 
         dialog->show();
 
-        if (frnd) {
+        if (frnd != nullptr) {
             addFriendDialog(frnd, dialog);
         } else {
             addConferenceDialog(conference, dialog);
@@ -1399,7 +1399,7 @@ void Widget::openDialog(GenericChatroomWidget* widget, bool newWindow)
         dialog->activateWindow();
     } else {
         hideMainForms(widget);
-        if (frnd) {
+        if (frnd != nullptr) {
             chatForms[frnd->getPublicKey()]->show(contentLayout);
         } else {
             conferenceForms[conference->getPersistentId()]->show(contentLayout);
@@ -1413,7 +1413,7 @@ void Widget::onFriendMessageReceived(uint32_t friendNumber, const QString& messa
 {
     const auto& friendId = friendList->id2Key(friendNumber);
     Friend* f = friendList->findFriend(friendId);
-    if (!f) {
+    if (f == nullptr) {
         return;
     }
 
@@ -1424,7 +1424,7 @@ void Widget::onReceiptReceived(uint32_t friendId, ReceiptNum receipt)
 {
     const auto& friendKey = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendKey);
-    if (!f) {
+    if (f == nullptr) {
         return;
     }
 
@@ -1438,7 +1438,7 @@ void Widget::addFriendDialog(const Friend* frnd, ContentDialog* dialog)
     const bool isSeparate = settings.getSeparateWindow();
     FriendWidget* widget = friendWidgets[friendPk];
     const bool isCurrent = activeChatroomWidget == widget;
-    if (!contentDialog && !isSeparate && isCurrent) {
+    if ((contentDialog == nullptr) && !isSeparate && isCurrent) {
         onAddClicked();
     }
 
@@ -1491,7 +1491,7 @@ void Widget::addConferenceDialog(const Conference* conference, ContentDialog* di
     Q_ASSERT(conferenceWidgets.contains(conferenceId));
     ConferenceWidget* widget = conferenceWidgets[conferenceId];
     const bool isCurrentWindow = activeChatroomWidget == widget;
-    if (!conferenceDialog && !separated && isCurrentWindow) {
+    if ((conferenceDialog == nullptr) && !separated && isCurrentWindow) {
         onAddClicked();
     }
 
@@ -1545,7 +1545,7 @@ bool Widget::newFriendMessageAlert(const ToxPk& friendId, const QString& text, b
                 contentDialog = createContentDialog();
             } else {
                 contentDialog = contentDialogManager->current();
-                if (!contentDialog) {
+                if (contentDialog == nullptr) {
                     contentDialog = createContentDialog();
                 }
             }
@@ -1762,7 +1762,7 @@ void Widget::removeFriend(Friend* f, bool fake)
     delete chatForm;
 
     delete f;
-    if (contentLayout && contentLayout->mainHead->layout()->isEmpty()) {
+    if ((contentLayout != nullptr) && contentLayout->mainHead->layout()->isEmpty()) {
         onAddClicked();
     }
 }
@@ -2085,7 +2085,7 @@ void Widget::removeConference(Conference* c, bool fake)
     conferenceAlertConnections.remove(conferenceId);
 
     delete c;
-    if (contentLayout && contentLayout->mainHead->layout()->isEmpty()) {
+    if ((contentLayout != nullptr) && contentLayout->mainHead->layout()->isEmpty()) {
         onAddClicked();
     }
 }
@@ -2100,7 +2100,7 @@ Conference* Widget::createConference(uint32_t conferencenumber, const Conference
     assert(core != nullptr);
 
     Conference* c = conferenceList->findConference(conferenceId);
-    if (c) {
+    if (c != nullptr) {
         qWarning() << "Conference already exists";
         return c;
     }
@@ -2181,7 +2181,7 @@ void Widget::onEmptyConferenceCreated(uint32_t conferencenumber, const Conferenc
                                       const QString& title)
 {
     Conference* conference = createConference(conferencenumber, conferenceId);
-    if (!conference) {
+    if (conference == nullptr) {
         return;
     }
     if (title.isEmpty()) {
@@ -2220,7 +2220,7 @@ bool Widget::event(QEvent* e)
         ui->friendList->updateVisualTracking();
         break;
     case QEvent::WindowActivate:
-        if (activeChatroomWidget) {
+        if (activeChatroomWidget != nullptr) {
             activeChatroomWidget->resetEventFlags();
             activeChatroomWidget->updateStatusLight();
             setWindowTitle(activeChatroomWidget->getTitle());
@@ -2252,7 +2252,7 @@ void Widget::onUserAwayCheck()
     const uint32_t autoAwayTime = settings.getAutoAwayTime() * 60 * 1000;
     const bool online = static_cast<Status::Status>(ui->statusButton->property("status").toInt())
                         == Status::Status::Online;
-    const bool away = autoAwayTime && Platform::getIdleTime() >= autoAwayTime;
+    const bool away = (autoAwayTime != 0u) && Platform::getIdleTime() >= autoAwayTime;
 
     if (online && away) {
         qDebug() << "auto away activated at" << QTime::currentTime().toString();
@@ -2269,7 +2269,7 @@ void Widget::onUserAwayCheck()
 void Widget::onEventIconTick()
 {
     if (eventFlag) {
-        eventIcon ^= true;
+        eventIcon ^= 1;
         updateIcons();
     }
 }
@@ -2277,7 +2277,7 @@ void Widget::onEventIconTick()
 void Widget::onTryCreateTrayIcon()
 {
     static int32_t tries = 15;
-    if (!icon && tries--) {
+    if (!icon && ((tries--) != 0)) {
         if (QSystemTrayIcon::isSystemTrayAvailable()) {
             icon = std::make_unique<QSystemTrayIcon>(this);
             updateIcons();
@@ -2361,7 +2361,7 @@ void Widget::onFriendTypingChanged(uint32_t friendNumber, bool isTyping)
 {
     const auto& friendId = friendList->id2Key(friendNumber);
     Friend* f = friendList->findFriend(friendId);
-    if (!f) {
+    if (f == nullptr) {
         return;
     }
 
@@ -2592,7 +2592,7 @@ void Widget::friendRequestsUpdate()
     if (unreadFriendRequests == 0) {
         delete friendRequestsButton;
         friendRequestsButton = nullptr;
-    } else if (!friendRequestsButton) {
+    } else if (friendRequestsButton == nullptr) {
         friendRequestsButton = new QPushButton(this);
         friendRequestsButton->setObjectName("green");
         ui->statusLayout->insertWidget(2, friendRequestsButton);
@@ -2603,7 +2603,7 @@ void Widget::friendRequestsUpdate()
         });
     }
 
-    if (friendRequestsButton) {
+    if (friendRequestsButton != nullptr) {
         friendRequestsButton->setText(tr("%n new friend request(s)", "", unreadFriendRequests));
     }
 }
@@ -2613,7 +2613,7 @@ void Widget::conferenceInvitesUpdate()
     if (unreadConferenceInvites == 0) {
         delete conferenceInvitesButton;
         conferenceInvitesButton = nullptr;
-    } else if (!conferenceInvitesButton) {
+    } else if (conferenceInvitesButton == nullptr) {
         conferenceInvitesButton = new QPushButton(this);
         conferenceInvitesButton->setObjectName("green");
         ui->statusLayout->insertWidget(2, conferenceInvitesButton);
@@ -2621,7 +2621,7 @@ void Widget::conferenceInvitesUpdate()
         connect(conferenceInvitesButton, &QPushButton::released, this, &Widget::onConferenceClicked);
     }
 
-    if (conferenceInvitesButton) {
+    if (conferenceInvitesButton != nullptr) {
         conferenceInvitesButton->setText(tr("%n new conference invite(s)", "", unreadConferenceInvites));
     }
 }
@@ -2669,7 +2669,7 @@ void Widget::retranslateUi()
     actionQuit->setText(tr("Exit", "Tray action menu to exit Tox"));
     actionShow->setText(tr("Show", "Tray action menu to show qTox window"));
 
-    if (!settings.getSeparateWindow() && (settingsWidget && settingsWidget->isShown())) {
+    if (!settings.getSeparateWindow() && ((settingsWidget != nullptr) && settingsWidget->isShown())) {
         setWindowTitle(fromDialogType(DialogType::SettingDialog));
     }
 
@@ -2696,7 +2696,7 @@ void Widget::retranslateUi()
 
 void Widget::focusChatInput()
 {
-    if (activeChatroomWidget) {
+    if (activeChatroomWidget != nullptr) {
         if (const Friend* f = activeChatroomWidget->getFriend()) {
             chatForms[f->getPublicKey()]->focusInput();
         } else if (Conference* c = activeChatroomWidget->getConference()) {

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -147,7 +147,7 @@ public:
                               "user with long nickname two"};
 
         for (int i = 0; i < testNames.size(); ++i) {
-            int unsortedIndex = i % 2 ? i - 1 : testNames.size() - i - 1; // Mixes positions
+            int unsortedIndex = (i % 2) != 0 ? i - 1 : testNames.size() - i - 1; // Mixes positions
             int sortedByActivityIndex = testNames.size() - i - 1;
             unsortedAllFriends.append(testNames[unsortedIndex]);
             sortedByNameOfflineFriends.append(testNames[i]);
@@ -171,7 +171,7 @@ public:
                               "user with long nickname two online"};
 
         for (int i = 0; i < testNames.size(); ++i) {
-            int unsortedIndex = i % 2 ? i - 1 : testNames.size() - i - 1;
+            int unsortedIndex = (i % 2) != 0 ? i - 1 : testNames.size() - i - 1;
             int sortedByActivityIndex = testNames.size() - i - 1;
             unsortedAllFriends.append(testNames[unsortedIndex]);
             sortedByNameOnlineFriends.append(testNames[i]);


### PR DESCRIPTION
```sh
run-clang-tidy -p _build -fix \
  $(find . -name "*.h" -or -name "*.cpp" -or -name "*.c" | grep -v "/_build/") \
  -checks="-*,readability-implicit-bool-conversion"`
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/77)
<!-- Reviewable:end -->
