### PR TITLE
cleanup: Use `.empty()` instead of `.size() == 0`.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: "-*
 , modernize-use-equals-*
 , modernize-use-nullptr
 , modernize-use-override
+, readability-container-*
 , readability-named-parameter
 , readability-inconsistent-declaration-parameter-name
 "

--- a/audio/src/backend/openal.cpp
+++ b/audio/src/backend/openal.cpp
@@ -426,7 +426,7 @@ bool OpenAL::initInput(const QString& deviceName, uint32_t channels)
 bool OpenAL::initOutput(const QString& deviceName)
 {
     // there should be no sinks when initializing the output
-    assert(sinks.size() == 0);
+    assert(sinks.empty());
 
     outputInitialized = false;
     if (!settings.getAudioOutDevEnabled())

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -147,7 +147,7 @@ void ChatLine::replaceContent(int col, ChatLineContent* lineContent)
 
 void ChatLine::layout(qreal w, QPointF scenePos)
 {
-    if (!content.size())
+    if (content.empty())
         return;
 
     width = w;

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -134,7 +134,7 @@ ChatMessage::SystemMessageType getChatMessageType(const SystemMessage& systemMes
 ChatLogIdx firstItemAfterDate(QDate date, const IChatLog& chatLog)
 {
     auto idxs = chatLog.getDateIdxs(date, 1);
-    if (idxs.size()) {
+    if (!idxs.empty()) {
         return idxs[0].idx;
     } else {
         return chatLog.getNextIdx();
@@ -1181,7 +1181,7 @@ void ChatWidget::onRenderFinished()
     auto renderCompletionFnsLocal = renderCompletionFns;
     renderCompletionFns.clear();
 
-    while (renderCompletionFnsLocal.size()) {
+    while (!renderCompletionFnsLocal.empty()) {
         renderCompletionFnsLocal.back()();
         renderCompletionFnsLocal.pop_back();
     }

--- a/src/core/toxfileprogress.cpp
+++ b/src/core/toxfileprogress.cpp
@@ -84,7 +84,7 @@ double ToxFileProgress::getProgress() const
 
 double ToxFileProgress::getSpeed() const
 {
-    if (samples.size() > 0 && samples[activeSample].bytesSent == filesize) {
+    if (!samples.empty() && samples[activeSample].bytesSent == filesize) {
         return 0.0;
     }
 
@@ -107,7 +107,7 @@ double ToxFileProgress::getSpeed() const
 
 double ToxFileProgress::getTimeLeftSeconds() const
 {
-    if (samples.size() > 0 && samples[activeSample].bytesSent == filesize) {
+    if (!samples.empty() && samples[activeSample].bytesSent == filesize) {
         return 0;
     }
 

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -91,7 +91,7 @@ QString generateContent(const QHash<const Friend*, size_t>& friendNotifications,
             displayNames.push_back(it.key()->getDisplayedName());
         }
 
-        assert(displayNames.size() > 0);
+        assert(!displayNames.empty());
 
         // Lexicographically sort all display names to ensure consistent formatting
         QCollator collator;

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -172,7 +172,7 @@ VideoFrame::~VideoFrame()
 bool VideoFrame::isValid()
 {
     QReadLocker frameLockReadLocker(&frameLock);
-    return frameBuffer.size() > 0;
+    return !frameBuffer.empty();
 }
 
 std::shared_ptr<VideoFrame> VideoFrame::fromAVFrameUntracked(IDType sourceID, AVFrame* sourceFrame,
@@ -194,7 +194,7 @@ std::shared_ptr<VideoFrame> VideoFrame::fromAVFrame(IDType sourceID, AVFrame* so
     // Add frame to tracked reference list
     refsLock.lockForRead();
 
-    if (refsMap.count(sourceID) == 0) {
+    if (!refsMap.contains(sourceID)) {
         // We need to add a new source to our reference map, obtain write lock
         refsLock.unlock();
         refsLock.lockForWrite();
@@ -484,14 +484,14 @@ AVFrame* VideoFrame::retrieveAVFrame(const QSize& dimensions, const int pixelFor
          */
         FrameBufferKey frameKey = getFrameKey(dimensions, pixelFormat, false);
 
-        if (frameBuffer.count(frameKey) > 0) {
+        if (frameBuffer.contains(frameKey)) {
             return frameBuffer[frameKey];
         }
     }
 
     FrameBufferKey frameKey = getFrameKey(dimensions, pixelFormat, true);
 
-    if (frameBuffer.count(frameKey) > 0) {
+    if (frameBuffer.contains(frameKey)) {
         return frameBuffer[frameKey];
     } else {
         return nullptr;
@@ -599,7 +599,7 @@ AVFrame* VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const
     FrameBufferKey frameKey = getFrameKey(dimensions, pixelFormat, frame->linesize[0]);
 
     // We check the presence of the frame in case of double-computation
-    if (frameBuffer.count(frameKey) > 0) {
+    if (frameBuffer.contains(frameKey)) {
         AVFrame* old_ret = frameBuffer[frameKey];
 
         // Free new frame

--- a/test/model/friendmessagedispatcher_test.cpp
+++ b/test/model/friendmessagedispatcher_test.cpp
@@ -215,7 +215,7 @@ void TestFriendMessageDispatcher::testOfflineMessages()
 
     QVERIFY(messageSender->numSentActions == 1);
     QVERIFY(messageSender->numSentMessages == 2);
-    QVERIFY(outgoingMessages.size() == 0);
+    QVERIFY(outgoingMessages.empty());
 }
 
 /**

--- a/test/net/bsu_test.cpp
+++ b/test/net/bsu_test.cpp
@@ -48,13 +48,13 @@ void TestBootstrapNodesUpdater::testOnline()
     spy.wait(10000);          // increase wait time for sporadic CI failures with slow nodes server
     QCOMPARE(spy.count(), 1); // make sure the signal was emitted exactly one time
     QList<DhtServer> result = qvariant_cast<QList<DhtServer>>(spy.at(0).at(0));
-    QVERIFY(result.size() > 0); // some data should be returned
+    QVERIFY(!result.empty()); // some data should be returned
 }
 
 void TestBootstrapNodesUpdater::testLocal()
 {
     QList<DhtServer> defaultNodes = BootstrapNodeUpdater::loadDefaultBootstrapNodes();
-    QVERIFY(defaultNodes.size() > 0);
+    QVERIFY(!defaultNodes.empty());
 }
 
 QTEST_MAIN(TestBootstrapNodesUpdater)


### PR DESCRIPTION
```sh
run-clang-tidy -p _build -fix \
  $(find . -name "*.h" -or -name "*.cpp" -or -name "*.c" | grep -v "/_build/") \
  -checks="-*,readability-container-*"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/78)
<!-- Reviewable:end -->
