### PR TITLE
cleanup: Pass moved-from objects by value instead of const ref.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: "-*
 , modernize-loop-convert
 , modernize-make-shared
 , modernize-make-unique
+, modernize-pass-by-value
 , modernize-return-braced-init-list
 , modernize-use-bool-literals
 , modernize-use-emplace

--- a/src/chatlog/chatlinestorage.cpp
+++ b/src/chatlog/chatlinestorage.cpp
@@ -10,7 +10,7 @@
 ChatLineStorage::iterator ChatLineStorage::insertChatMessage(ChatLogIdx idx, QDateTime timestamp,
                                                              ChatLine::Ptr line)
 {
-    if (idxInfoMap.find(idx) != idxInfoMap.end()) {
+    if (idxInfoMap.contains(idx)) {
         qWarning() << "Index is already rendered, not updating";
         return lines.end();
     }
@@ -200,9 +200,9 @@ void ChatLineStorage::decrementLinePosAfter(IdxInfoMap_t::iterator inputIt)
 
 bool ChatLineStorage::shouldRemovePreviousLine(iterator prevIt, iterator it)
 {
-    return prevIt != lines.end() &&                  // Previous iterator is valid
-           dateMap.find(*prevIt) != dateMap.end() && // Previous iterator is a date line
-           (it == lines.end() ||                     // Previous iterator is the last line
-            dateMap.find(*it) != dateMap.end()       // Adjacent date lines
+    return prevIt != lines.end() &&     // Previous iterator is valid
+           dateMap.contains(*prevIt) && // Previous iterator is a date line
+           (it == lines.end() ||        // Previous iterator is the last line
+            dateMap.contains(*it)       // Adjacent date lines
            );
 }

--- a/src/chatlog/chatlinestorage.h
+++ b/src/chatlog/chatlinestorage.h
@@ -73,7 +73,7 @@ public:
 
     bool contains(ChatLogIdx idx) const
     {
-        return idxInfoMap.find(idx) != idxInfoMap.end();
+        return idxInfoMap.contains(idx);
     }
 
     bool contains(QDateTime timestamp) const;

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -16,11 +16,12 @@
 #include <QPalette>
 #include <QTextBlock>
 #include <QTextFragment>
+#include <utility>
 
 Text::Text(DocumentCache& documentCache_, Settings& settings_, Style& style_, const QColor& custom,
-           const QString& txt, const QFont& font, bool enableElide, const QString& rawText_,
+           const QString& txt, const QFont& font, bool enableElide, QString rawText_,
            const TextType& type)
-    : rawText(rawText_)
+    : rawText(std::move(rawText_))
     , elide(enableElide)
     , defFont(font)
     , textType(type)

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -28,7 +28,7 @@ public:
 
     Text(DocumentCache& documentCache, Settings& settings, Style& style, const QColor& custom,
          const QString& txt = "", const QFont& font = QFont(), bool enableElide = false,
-         const QString& rawText = QString(), const TextType& type = NORMAL);
+         QString rawText = QString(), const TextType& type = NORMAL);
     Text(DocumentCache& documentCache, Settings& settings, Style& style, const QString& txt = "",
          const QFont& font = QFont(), bool enableElide = false, const QString& rawText = QString(),
          const TextType& type = NORMAL);

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -188,7 +188,7 @@ void CoreAV::process()
 bool CoreAV::isCallStarted(const Friend* f) const
 {
     QReadLocker locker{&callsLock};
-    return f && (calls.find(f->getId()) != calls.end());
+    return f && calls.contains(f->getId());
 }
 
 /**
@@ -199,7 +199,7 @@ bool CoreAV::isCallStarted(const Friend* f) const
 bool CoreAV::isCallStarted(const Conference* c) const
 {
     QReadLocker locker{&callsLock};
-    return c && (conferenceCalls.find(c->getId()) != conferenceCalls.end());
+    return c && conferenceCalls.contains(c->getId());
 }
 
 /**

--- a/src/core/toxfile.cpp
+++ b/src/core/toxfile.cpp
@@ -7,6 +7,7 @@
 #include <QFile>
 #include <QRegularExpression>
 #include <tox/tox.h>
+#include <utility>
 
 #define TOX_HEX_ID_LENGTH 2 * TOX_ADDRESS_SIZE
 
@@ -38,7 +39,7 @@ ToxFile::ToxFile(uint32_t fileNum_, uint32_t friendId_, QString fileName_, QStri
     : fileKind{TOX_FILE_KIND_DATA}
     , fileNum(fileNum_)
     , friendId(friendId_)
-    , fileName{fileName_}
+    , fileName{std::move(fileName_)}
     , filePath{filePath_}
     , file{new QFile(filePath_)}
     , status{INITIALIZING}

--- a/src/core/toxoptions.cpp
+++ b/src/core/toxoptions.cpp
@@ -13,6 +13,7 @@
 
 #include <QByteArray>
 #include <QDebug>
+#include <utility>
 
 /**
  * @brief The ToxOptions class wraps the Tox_Options struct and the matching
@@ -20,9 +21,9 @@
  *        are correctly deleted.
  */
 
-ToxOptions::ToxOptions(Tox_Options* options_, const QByteArray& proxyAddrData_)
+ToxOptions::ToxOptions(Tox_Options* options_, QByteArray proxyAddrData_)
     : options(options_)
-    , proxyAddrData(proxyAddrData_)
+    , proxyAddrData(std::move(proxyAddrData_))
 {
 }
 

--- a/src/core/toxoptions.h
+++ b/src/core/toxoptions.h
@@ -25,7 +25,7 @@ public:
     void setIPv6Enabled(bool enabled);
 
 private:
-    ToxOptions(Tox_Options* options_, const QByteArray& proxyAddrData_);
+    ToxOptions(Tox_Options* options_, QByteArray proxyAddrData_);
 
 private:
     Tox_Options* options = nullptr;

--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -29,12 +29,10 @@ ToxPk::ToxPk()
  * @param rawId The bytes to construct the ToxPk from. The length must be exactly
  *              ToxPk::size, else the ToxPk will be empty.
  */
-ToxPk::ToxPk(const QByteArray& rawId)
-    : ChatId([&rawId]() {
-        assert(rawId.length() == size);
-        return rawId;
-    }())
+ToxPk::ToxPk(QByteArray rawId)
+    : ChatId(std::move(rawId))
 {
+    assert(rawId.length() == size);
 }
 
 /**
@@ -43,7 +41,7 @@ ToxPk::ToxPk(const QByteArray& rawId)
  * ToxPk::size from the specified buffer.
  */
 ToxPk::ToxPk(const uint8_t* rawId)
-    : ChatId(QByteArray(reinterpret_cast<const char*>(rawId), size))
+    : ToxPk(QByteArray(reinterpret_cast<const char*>(rawId), size))
 {
 }
 
@@ -55,12 +53,12 @@ ToxPk::ToxPk(const uint8_t* rawId)
  * @param pk Tox Pk string to convert to ToxPk object
  */
 ToxPk::ToxPk(const QString& pk)
-    : ChatId([&pk]() {
-        if (pk.length() == numHexChars) {
-            return QByteArray::fromHex(pk.toLatin1());
+    : ToxPk([&pk]() {
+        if (pk.length() != numHexChars) {
+            assert(!"ToxPk constructed with invalid length string");
+            return QByteArray(); // invalid pk string
         }
-        assert(!"ToxPk constructed with invalid length string");
-        return QByteArray(); // invalid pk string
+        return QByteArray::fromHex(pk.toLatin1());
     }())
 {
 }

--- a/src/core/toxpk.h
+++ b/src/core/toxpk.h
@@ -15,7 +15,7 @@ public:
     static constexpr int size = 32;
     static constexpr int numHexChars = 64;
     ToxPk();
-    explicit ToxPk(const QByteArray& rawId);
+    explicit ToxPk(QByteArray rawId);
     explicit ToxPk(const uint8_t* rawId);
     explicit ToxPk(const QString& pk);
     int getSize() const override;

--- a/src/core/toxstring.cpp
+++ b/src/core/toxstring.cpp
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <climits>
+#include <utility>
 
 /**
  * @class ToxString
@@ -31,8 +32,8 @@ ToxString::ToxString(const QString& text)
  * @brief Creates a ToxString from bytes in a QByteArray.
  * @param text Input text.
  */
-ToxString::ToxString(const QByteArray& text)
-    : string(text)
+ToxString::ToxString(QByteArray text)
+    : string(std::move(text))
 {
 }
 

--- a/src/core/toxstring.h
+++ b/src/core/toxstring.h
@@ -14,7 +14,7 @@ class ToxString
 {
 public:
     explicit ToxString(const QString& text);
-    explicit ToxString(const QByteArray& text);
+    explicit ToxString(QByteArray text);
     ToxString(const uint8_t* text, size_t length);
 
     const uint8_t* data() const;

--- a/src/model/chatlogitem.cpp
+++ b/src/model/chatlogitem.cpp
@@ -8,6 +8,7 @@
 #include "src/model/friend.h"
 
 #include <cassert>
+#include <utility>
 
 namespace {
 
@@ -44,10 +45,10 @@ ChatLogItem::ChatLogItem(SystemMessage systemMessage)
 {
 }
 
-ChatLogItem::ChatLogItem(ToxPk sender_, const QString& displayName_, ContentType contentType_,
+ChatLogItem::ChatLogItem(ToxPk sender_, QString displayName_, ContentType contentType_,
                          ContentPtr content_)
     : sender(std::move(sender_))
-    , displayName(displayName_)
+    , displayName(std::move(displayName_))
     , contentType(contentType_)
     , content(std::move(content_))
 {

--- a/src/model/chatlogitem.h
+++ b/src/model/chatlogitem.h
@@ -54,7 +54,7 @@ public:
     const QString& getDisplayName() const;
 
 private:
-    ChatLogItem(ToxPk sender, const QString& displayName_, ContentType contentType, ContentPtr content);
+    ChatLogItem(ToxPk sender, QString displayName_, ContentType contentType, ContentPtr content);
 
     ToxPk sender;
     QString displayName;

--- a/src/model/conference.cpp
+++ b/src/model/conference.cpp
@@ -13,19 +13,19 @@
 #include <cassert>
 
 #include <QDebug>
+#include <utility>
 
 namespace {
 const int MAX_CONFERENCE_TITLE_LENGTH = 128;
 } // namespace
 
-Conference::Conference(int conferenceId_, const ConferenceId persistentConferenceId,
-                       const QString& name, bool isAvConference, const QString& selfName_,
-                       ICoreConferenceQuery& conferenceQuery_, ICoreIdHandler& idHandler_,
-                       FriendList& friendList_)
+Conference::Conference(int conferenceId_, const ConferenceId persistentConferenceId, QString name,
+                       bool isAvConference, QString selfName_, ICoreConferenceQuery& conferenceQuery_,
+                       ICoreIdHandler& idHandler_, FriendList& friendList_)
     : conferenceQuery(conferenceQuery_)
     , idHandler(idHandler_)
-    , selfName{selfName_}
-    , title{name}
+    , selfName{std::move(selfName_)}
+    , title{std::move(name)}
     , toxConferenceNum(conferenceId_)
     , conferenceId{persistentConferenceId}
     , avConference{isAvConference}

--- a/src/model/conference.h
+++ b/src/model/conference.h
@@ -23,8 +23,8 @@ class Conference : public Chat
 {
     Q_OBJECT
 public:
-    Conference(int conferenceId_, const ConferenceId persistentConferenceId, const QString& name,
-               bool isAvConference, const QString& selfName_, ICoreConferenceQuery& conferenceQuery_,
+    Conference(int conferenceId_, const ConferenceId persistentConferenceId, QString name,
+               bool isAvConference, QString selfName_, ICoreConferenceQuery& conferenceQuery_,
                ICoreIdHandler& idHandler_, FriendList& friendList);
     bool isAvConference() const;
     uint32_t getId() const override;

--- a/src/model/conferenceinvite.cpp
+++ b/src/model/conferenceinvite.cpp
@@ -5,16 +5,18 @@
 
 #include "conferenceinvite.h"
 
+#include <utility>
+
 /**
  * @class ConferenceInvite
  *
  * @brief This class contains information needed to create a conference invite
  */
 
-ConferenceInvite::ConferenceInvite(uint32_t friendId_, uint8_t inviteType, const QByteArray& data)
+ConferenceInvite::ConferenceInvite(uint32_t friendId_, uint8_t inviteType, QByteArray data)
     : friendId{friendId_}
     , type{inviteType}
-    , invite{data}
+    , invite{std::move(data)}
     , date{QDateTime::currentDateTime()}
 {
 }

--- a/src/model/conferenceinvite.h
+++ b/src/model/conferenceinvite.h
@@ -13,7 +13,7 @@ class ConferenceInvite
 {
 public:
     ConferenceInvite() = default;
-    ConferenceInvite(uint32_t friendId_, uint8_t inviteType, const QByteArray& data);
+    ConferenceInvite(uint32_t friendId_, uint8_t inviteType, QByteArray data);
     bool operator==(const ConferenceInvite& other) const;
 
     uint32_t getFriendId() const;

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -12,18 +12,17 @@
 #include <QDebug>
 
 #include <cassert>
-#include <memory>
+#include <utility>
 
-Friend::Friend(uint32_t friendId_, const ToxPk& friendPk_, const QString& userAlias_,
-               const QString& userName_)
-    : userName{userName_}
-    , userAlias{userAlias_}
-    , friendPk{friendPk_}
+Friend::Friend(uint32_t friendId_, ToxPk friendPk_, QString userAlias_, QString userName_)
+    : userName{std::move(userName_)}
+    , userAlias{std::move(userAlias_)}
+    , friendPk{std::move(friendPk_)}
     , friendId{friendId_}
     , hasNewEvents{false}
     , friendStatus{Status::Status::Offline}
 {
-    if (userName_.isEmpty()) {
+    if (userName.isEmpty()) {
         userName = friendPk.toString();
     }
 }

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -16,8 +16,7 @@ class Friend : public Chat
 {
     Q_OBJECT
 public:
-    Friend(uint32_t friendId_, const ToxPk& friendPk_, const QString& userAlias_ = {},
-           const QString& userName_ = {});
+    Friend(uint32_t friendId_, ToxPk friendPk_, QString userAlias_ = {}, QString userName_ = {});
     Friend(const Friend& other) = delete;
     Friend& operator=(const Friend& other) = delete;
 

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -12,6 +12,7 @@
 #include <QVector>
 
 #include <functional>
+#include <utility>
 #include <vector>
 
 struct sqlite3_stmt;
@@ -48,7 +49,7 @@ public:
         Query(QString query_, QVector<QByteArray> blobs_ = {},
               const std::function<void(RowId)>& insertCallback_ = {})
             : query{query_.toUtf8()}
-            , blobs{blobs_}
+            , blobs{std::move(blobs_)}
             , insertCallback{insertCallback_}
         {
         }
@@ -65,7 +66,7 @@ public:
         Query(QString query_, QVector<QByteArray> blobs_,
               const std::function<void(const QVector<QVariant>&)>& rowCallback_)
             : query{query_.toUtf8()}
-            , blobs{blobs_}
+            , blobs{std::move(blobs_)}
             , rowCallback{rowCallback_}
         {
         }

--- a/src/persistence/db/rawdatabaseimpl.cpp
+++ b/src/persistence/db/rawdatabaseimpl.cpp
@@ -13,6 +13,7 @@
 #include <QFile>
 #include <QMetaObject>
 #include <QMutexLocker>
+#include <utility>
 
 /**
  * @brief Tries to open a database.
@@ -20,11 +21,11 @@
  * @param password If empty, the database will be opened unencrypted.
  * Otherwise we will use toxencryptsave to derive a key and encrypt the database.
  */
-RawDatabaseImpl::RawDatabaseImpl(const QString& path_, const QString& password, const QByteArray& salt)
+RawDatabaseImpl::RawDatabaseImpl(QString path_, const QString& password, QByteArray salt)
     : workerThread{new QThread}
-    , path{path_}
-    , currentSalt{salt} // we need the salt later if a new password should be set
-    , currentHexKey{deriveKey(password, salt)}
+    , path{std::move(path_)}
+    , currentSalt{std::move(salt)} // we need the salt later if a new password should be set
+    , currentHexKey{deriveKey(password, currentSalt)}
 {
     workerThread->setObjectName("qTox Database");
     moveToThread(workerThread.get());

--- a/src/persistence/db/rawdatabaseimpl.h
+++ b/src/persistence/db/rawdatabaseimpl.h
@@ -70,7 +70,7 @@ public:
         p4_0 // SQLCipher 4.0 default encryption params
     };
 
-    RawDatabaseImpl(const QString& path_, const QString& password, const QByteArray& salt);
+    RawDatabaseImpl(QString path_, const QString& password, QByteArray salt);
     ~RawDatabaseImpl() override;
     bool isOpen() override;
 

--- a/src/persistence/db/upgrades/dbupgrader.cpp
+++ b/src/persistence/db/upgrades/dbupgrader.cpp
@@ -13,6 +13,7 @@
 #include <QDebug>
 #include <QString>
 #include <QTranslator>
+#include <utility>
 
 namespace {
 constexpr int SCHEMA_VERSION = 11;
@@ -61,7 +62,7 @@ struct DuplicateAlias
 {
     DuplicateAlias(RowId goodAliasRow_, std::vector<RowId> badAliasRows_)
         : goodAliasRow{goodAliasRow_}
-        , badAliasRows{badAliasRows_}
+        , badAliasRows{std::move(badAliasRows_)}
     {
     }
     DuplicateAlias() = default;

--- a/src/persistence/db/upgrades/dbupgrader.h
+++ b/src/persistence/db/upgrades/dbupgrader.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "src/persistence/db/rawdatabase.h"
 
@@ -32,7 +33,7 @@ struct BadEntry
 {
     BadEntry(int64_t row_, QString toxId_)
         : row{row_}
-        , toxId{toxId_}
+        , toxId{std::move(toxId_)}
     {
     }
     RowId row;

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -5,6 +5,7 @@
 
 #include <QDebug>
 #include <cassert>
+#include <utility>
 
 #include <tox/tox.h>
 
@@ -180,7 +181,7 @@ FileDbInsertionData::FileDbInsertionData()
  */
 History::History(std::shared_ptr<RawDatabase> db_, Settings& settings_,
                  IMessageBoxManager& messageBoxManager)
-    : db(db_)
+    : db(std::move(db_))
     , settings(settings_)
 {
     if (!isValid()) {

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstdint>
 #include <tox/toxencryptsave.h>
+#include <utility>
 
 #include "src/core/toxfile.h"
 #include "src/core/toxpk.h"
@@ -131,9 +132,9 @@ public:
         HistMessage(RowId id_, MessageState state_, QDateTime timestamp_,
                     std::unique_ptr<ChatId> chat_, QString dispName_, ToxPk sender_, QString message)
             : chat{std::move(chat_)}
-            , sender{sender_}
-            , dispName{dispName_}
-            , timestamp{timestamp_}
+            , sender{std::move(sender_)}
+            , dispName{std::move(dispName_)}
+            , timestamp{std::move(timestamp_)}
             , id{id_}
             , state{state_}
             , content(std::move(message))
@@ -143,9 +144,9 @@ public:
         HistMessage(RowId id_, MessageState state_, QDateTime timestamp_,
                     std::unique_ptr<ChatId> chat_, QString dispName_, ToxPk sender_, ToxFile file)
             : chat{std::move(chat_)}
-            , sender{sender_}
-            , dispName{dispName_}
-            , timestamp{timestamp_}
+            , sender{std::move(sender_)}
+            , dispName{std::move(dispName_)}
+            , timestamp{std::move(timestamp_)}
             , id{id_}
             , state{state_}
             , content(std::move(file))
@@ -155,7 +156,7 @@ public:
         HistMessage(RowId id_, QDateTime timestamp_, std::unique_ptr<ChatId> chat_,
                     SystemMessage systemMessage)
             : chat{std::move(chat_)}
-            , timestamp{timestamp_}
+            , timestamp{std::move(timestamp_)}
             , id{id_}
             , state(MessageState::complete)
             , content(std::move(systemMessage))

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <memory>
 #include <sodium.h>
+#include <utility>
 
 #include "profile.h"
 #include "profilelocker.h"
@@ -277,9 +278,8 @@ void Profile::initCore(const QByteArray& toxSave, Settings& s, bool isNewProfile
     avatarBroadcaster = std::make_unique<AvatarBroadcaster>(*core);
 }
 
-Profile::Profile(const QString& name_, std::unique_ptr<ToxEncrypt> passkey_, Paths& paths_,
-                 Settings& settings_)
-    : name{name_}
+Profile::Profile(QString name_, std::unique_ptr<ToxEncrypt> passkey_, Paths& paths_, Settings& settings_)
+    : name{std::move(name_)}
     , passkey{std::move(passkey_)}
     , isRemoved{false}
     , encrypted{passkey != nullptr}

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -96,8 +96,7 @@ private slots:
                                uint64_t filesize);
 
 private:
-    Profile(const QString& name_, std::unique_ptr<ToxEncrypt> passkey_, Paths& paths_,
-            Settings& settings_);
+    Profile(QString name_, std::unique_ptr<ToxEncrypt> passkey_, Paths& paths_, Settings& settings_);
     static QStringList getFilesByExt(QString extension, Paths& paths);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -25,6 +25,7 @@
 #include <QNetworkProxy>
 #include <QObject>
 #include <QPixmap>
+#include <utility>
 
 class Profile;
 class QCommandLineParser;
@@ -685,7 +686,7 @@ private:
     {
         friendProp() = delete;
         friendProp(QString addr_)
-            : addr(addr_)
+            : addr(std::move(addr_))
         {
         }
         QString alias = "";

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -14,6 +14,7 @@
 #include <QSaveFile>
 #include <cassert>
 #include <memory>
+#include <utility>
 
 /**
  * @class SettingsSerializer
@@ -84,7 +85,7 @@ QDataStream& readStream(QDataStream& dataStream, QByteArray& data)
 } // namespace
 
 SettingsSerializer::SettingsSerializer(QString filePath_, const ToxEncrypt* passKey_)
-    : path{filePath_}
+    : path{std::move(filePath_)}
     , passKey{passKey_}
     , group{-1}
     , array{-1}

--- a/src/persistence/settingsserializer.h
+++ b/src/persistence/settingsserializer.h
@@ -11,6 +11,7 @@
 #include <QSettings>
 #include <QString>
 #include <QVector>
+#include <utility>
 
 class SettingsSerializer
 {
@@ -56,8 +57,8 @@ private:
             : group{group_}
             , array{array_}
             , arrayIndex{arrayIndex_}
-            , key{key_}
-            , value{value_}
+            , key{std::move(key_)}
+            , value{std::move(value_)}
         {
         }
         qint64 group;

--- a/src/persistence/smileypack.cpp
+++ b/src/persistence/smileypack.cpp
@@ -323,7 +323,7 @@ QList<QStringList> SmileyPack::getEmoticons() const
 std::shared_ptr<QIcon> SmileyPack::getAsIcon(const QString& emoticon) const
 {
     QMutexLocker<QMutex> locker(&loadingMutex);
-    if (cachedIcon.find(emoticon) != cachedIcon.end()) {
+    if (cachedIcon.contains(emoticon)) {
         return cachedIcon[emoticon];
     }
 

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -203,7 +203,7 @@ QVector<QPair<QString, QString>> v4l2::getDeviceList()
 
 QString v4l2::getPixelFormatString(uint32_t pixel_format)
 {
-    if (pixFmtToName.find(pixel_format) == pixFmtToName.end()) {
+    if (!pixFmtToName.contains(pixel_format)) {
         qWarning() << "Pixel format not found";
         return QStringLiteral("invalid");
     }
@@ -212,10 +212,10 @@ QString v4l2::getPixelFormatString(uint32_t pixel_format)
 
 bool v4l2::betterPixelFormat(uint32_t a, uint32_t b)
 {
-    if (pixFmtToQuality.find(a) == pixFmtToQuality.end()) {
+    if (!pixFmtToQuality.contains(a)) {
         return false;
     }
-    if (pixFmtToQuality.find(b) == pixFmtToQuality.end()) {
+    if (!pixFmtToQuality.contains(b)) {
         return true;
     }
     return pixFmtToQuality.at(a) > pixFmtToQuality.at(b);

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -23,6 +23,7 @@ extern "C"
 #include <QMutexLocker>
 #include <QScreen>
 #include <QVector>
+#include <utility>
 
 // no longer needed when avformat version < 59 is no longer supported
 using AvFindInputFormatRet = decltype(av_find_input_format(""));
@@ -104,8 +105,8 @@ struct AVFormatContextDeleter
 QHash<QString, CameraDevice*> CameraDevice::openDevices;
 QMutex CameraDevice::openDeviceLock, CameraDevice::iformatLock;
 
-CameraDevice::CameraDevice(const QString& devName_, AVFormatContext* context_)
-    : devName{devName_}
+CameraDevice::CameraDevice(QString devName_, AVFormatContext* context_)
+    : devName{std::move(devName_)}
     , context{context_}
     , refcount{1}
 {

--- a/src/video/cameradevice.h
+++ b/src/video/cameradevice.h
@@ -37,7 +37,7 @@ public:
     static bool isScreen(const QString& devName);
 
 private:
-    CameraDevice(const QString& devName_, AVFormatContext* context_);
+    CameraDevice(QString devName_, AVFormatContext* context_);
     static CameraDevice* open(QString devName, AVDictionary** options);
     static bool getDefaultInputFormat();
     static QVector<QPair<QString, QString>> getRawDeviceListGeneric();

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -22,6 +22,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QScreen>
+#include <utility>
 
 namespace {
 const auto BTN_STATE_NONE = QVariant("none");
@@ -35,7 +36,7 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, Settings& s
                        Style& style_, Profile& profile, QWidget* parent)
     : QWidget(parent)
     , selfFrame{nullptr}
-    , friendPk{friendPk_}
+    , friendPk{std::move(friendPk_)}
     , e(false)
     , cameraSource{cameraSource_}
     , settings{settings_}

--- a/src/video/videosurface.cpp
+++ b/src/video/videosurface.cpp
@@ -15,6 +15,7 @@
 #include <QDebug>
 #include <QLabel>
 #include <QPainter>
+#include <utility>
 
 namespace {
 float getSizeRatio(const QSize size)
@@ -27,12 +28,12 @@ float getSizeRatio(const QSize size)
  * @var std::atomic_bool VideoSurface::frameLock
  * @brief Fast lock for lastFrame.
  */
-VideoSurface::VideoSurface(const QPixmap& avatar_, QWidget* parent, bool expanding_)
+VideoSurface::VideoSurface(QPixmap avatar_, QWidget* parent, bool expanding_)
     : QWidget{parent}
     , source{nullptr}
     , frameLock{false}
     , hasSubscribed{0}
-    , avatar{avatar_}
+    , avatar{std::move(avatar_)}
     , ratio{1.0f}
     , expanding{expanding_}
 {

--- a/src/video/videosurface.h
+++ b/src/video/videosurface.h
@@ -15,7 +15,7 @@ class VideoSurface : public QWidget
     Q_OBJECT
 
 public:
-    VideoSurface(const QPixmap& avatar_, QWidget* parent = nullptr, bool expanding_ = false);
+    VideoSurface(QPixmap avatar_, QWidget* parent = nullptr, bool expanding_ = false);
     VideoSurface(const QPixmap& avatar_, VideoSource* source_, QWidget* parent = nullptr);
     ~VideoSurface() override;
 

--- a/src/widget/form/conferenceinvitewidget.cpp
+++ b/src/widget/form/conferenceinvitewidget.cpp
@@ -13,6 +13,7 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QSignalMapper>
+#include <utility>
 
 /**
  * @class ConferenceInviteWidget
@@ -21,14 +22,14 @@
  * and provides buttons to accept/reject it
  */
 
-ConferenceInviteWidget::ConferenceInviteWidget(QWidget* parent, const ConferenceInvite& invite,
+ConferenceInviteWidget::ConferenceInviteWidget(QWidget* parent, ConferenceInvite invite,
                                                Settings& settings_, Core& core_)
     : QWidget(parent)
     , acceptButton(new QPushButton(this))
     , rejectButton(new QPushButton(this))
     , inviteMessageLabel(new CroppingLabel(this))
     , widgetLayout(new QHBoxLayout(this))
-    , inviteInfo(invite)
+    , inviteInfo(std::move(invite))
     , settings{settings_}
     , core{core_}
 {

--- a/src/widget/form/conferenceinvitewidget.h
+++ b/src/widget/form/conferenceinvitewidget.h
@@ -20,8 +20,7 @@ class ConferenceInviteWidget : public QWidget
 {
     Q_OBJECT
 public:
-    ConferenceInviteWidget(QWidget* parent, const ConferenceInvite& invite, Settings& settings,
-                           Core& core);
+    ConferenceInviteWidget(QWidget* parent, ConferenceInvite invite, Settings& settings, Core& core);
     void retranslateUi();
     const ConferenceInvite getInviteInfo() const;
 

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -19,6 +19,7 @@
 #include <QDesktopServices>
 #include <QPushButton>
 #include <QTimer>
+#include <utility>
 
 // index of UI in the QStackedWidget
 enum class updateIndex
@@ -43,7 +44,7 @@ AboutForm::AboutForm(UpdateCheck& updateCheck_, QString contactInfo_, Style& sty
     , bodyUI(new Ui::AboutSettings)
     , progressTimer(new QTimer(this))
     , updateCheck(updateCheck_)
-    , contactInfo{contactInfo_}
+    , contactInfo{std::move(contactInfo_)}
     , style{style_}
 {
     bodyUI->setupUi(this);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -240,7 +240,7 @@ void AVForm::selectBestModes(QVector<VideoMode>& allVideoModes)
             if (mode.norm(idealMode) > idealMode.tolerance())
                 continue;
 
-            if (bestModeIndices.find(res) == bestModeIndices.end()) {
+            if (!bestModeIndices.contains(res)) {
                 bestModeIndices[res] = i;
                 continue;
             }

--- a/src/widget/form/settings/genericsettings.cpp
+++ b/src/widget/form/settings/genericsettings.cpp
@@ -10,6 +10,7 @@
 #include <QComboBox>
 #include <QEvent>
 #include <QSpinBox>
+#include <utility>
 
 /**
  * @class GenericForm
@@ -18,9 +19,9 @@
  * It provides correct behaviour of controls for settings forms.
  */
 
-GenericForm::GenericForm(const QPixmap& icon, Style& style, QWidget* parent)
+GenericForm::GenericForm(QPixmap icon, Style& style, QWidget* parent)
     : QWidget(parent)
-    , formIcon(icon)
+    , formIcon(std::move(icon))
 {
     connect(&style, &Style::themeReload, this, &GenericForm::reloadTheme);
 }

--- a/src/widget/form/settings/genericsettings.h
+++ b/src/widget/form/settings/genericsettings.h
@@ -13,7 +13,7 @@ class GenericForm : public QWidget
 {
     Q_OBJECT
 public:
-    GenericForm(const QPixmap& icon, Style& style, QWidget* parent = nullptr);
+    GenericForm(QPixmap icon, Style& style, QWidget* parent = nullptr);
     ~GenericForm() override = default;
 
     virtual QString getFormName() = 0;

--- a/src/widget/form/tabcompleter.h
+++ b/src/widget/form/tabcompleter.h
@@ -10,6 +10,7 @@
 #include "src/widget/tool/chattextedit.h"
 #include <QMap>
 #include <QString>
+#include <utility>
 
 class TabCompleter : public QObject
 {
@@ -24,8 +25,8 @@ public slots:
 private:
     struct SortableString
     {
-        explicit SortableString(const QString& n)
-            : contents{n}
+        explicit SortableString(QString n)
+            : contents{std::move(n)}
         {
         }
         bool operator<(const SortableString& other) const;

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -34,6 +34,7 @@
 #include <QMimeData>
 
 #include <cassert>
+#include <utility>
 
 /**
  * @class FriendWidget
@@ -46,7 +47,7 @@ FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom_, bool compa
                            Settings& settings_, Style& style_,
                            IMessageBoxManager& messageBoxManager_, Profile& profile_)
     : GenericChatroomWidget(compact_, settings_, style_)
-    , chatroom{chatroom_}
+    , chatroom{std::move(chatroom_)}
     , isDefaultAvatar{true}
     , settings{settings_}
     , style{style_}

--- a/src/widget/maskablepixmapwidget.cpp
+++ b/src/widget/maskablepixmapwidget.cpp
@@ -6,6 +6,7 @@
 #include "maskablepixmapwidget.h"
 #include <QPainter>
 #include <QStyle>
+#include <utility>
 
 /**
  * @var QPixmap* MaskablePixmapWidget::renderTarget
@@ -15,7 +16,7 @@
 MaskablePixmapWidget::MaskablePixmapWidget(QWidget* parent, QSize size, QString maskName_)
     : QLabel("", parent)
     , renderTarget(nullptr)
-    , maskName(maskName_)
+    , maskName(std::move(maskName_))
     , clickable(false)
 {
     setSize(size);

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -19,7 +19,7 @@ NotificationScrollArea::NotificationScrollArea(QWidget* parent)
 
 void NotificationScrollArea::trackWidget(Settings& settings, Style& style, GenericChatroomWidget* widget)
 {
-    if (trackedWidgets.find(widget) != trackedWidgets.end())
+    if (trackedWidgets.contains(widget))
         return;
 
     Visibility visibility = widgetVisible(widget);

--- a/test/chatlog/chatlinestorage_test.cpp
+++ b/test/chatlog/chatlinestorage_test.cpp
@@ -5,6 +5,7 @@
 
 #include "src/chatlog/chatlinestorage.h"
 #include <QTest>
+#include <utility>
 
 namespace {
 class IdxChatLine : public ChatLine
@@ -30,7 +31,7 @@ class TimestampChatLine : public ChatLine
 public:
     explicit TimestampChatLine(QDateTime dateTime)
         : ChatLine()
-        , timestamp(dateTime)
+        , timestamp(std::move(dateTime))
     {
     }
 

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -8,6 +8,7 @@
 #include <QSignalSpy>
 #include <QTest>
 #include <memory>
+#include <utility>
 
 class MockFriend : public IFriendListItem
 {
@@ -19,9 +20,9 @@ public:
     {
     }
 
-    MockFriend(const QString& nameStr, bool onlineRes, const QDateTime& lastAct)
-        : name(nameStr)
-        , lastActivity(lastAct)
+    MockFriend(QString nameStr, bool onlineRes, QDateTime lastAct)
+        : name(std::move(nameStr))
+        , lastActivity(std::move(lastAct))
         , online(onlineRes)
     {
     }
@@ -80,8 +81,8 @@ public:
     {
     }
 
-    MockConference(const QString& nameStr)
-        : name(nameStr)
+    MockConference(QString nameStr)
+        : name(std::move(nameStr))
     {
     }
 

--- a/test/model/friendmessagedispatcher_test.cpp
+++ b/test/model/friendmessagedispatcher_test.cpp
@@ -147,7 +147,7 @@ void TestFriendMessageDispatcher::testSignals()
 
     // We should have received some message ids in our callbacks
     QVERIFY(sentIds.first == sentIds.second);
-    QVERIFY(outgoingMessages.find(sentIds.first) != outgoingMessages.end());
+    QVERIFY(outgoingMessages.contains(sentIds.first));
     QVERIFY(startReceiptNum.get() != endReceiptNum.get());
     QVERIFY(outgoingMessages.size() == 1);
 


### PR DESCRIPTION
```sh
run-clang-tidy -p _build -fix \
  $(find . -name "*.h" -or -name "*.cpp" -or -name "*.c" | grep -v "/_build/") \
  -checks="-*,modernize-pass-by-value"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/80)
<!-- Reviewable:end -->
