### PR TITLE
cleanup: Use `= default` instead of `{}` for default ctors.

### DIFF
--- a/.ci-scripts/build-qtox-linux.sh
+++ b/.ci-scripts/build-qtox-linux.sh
@@ -115,7 +115,7 @@ fi
 cmake --build "$BUILD_DIR"
 
 if [ ! -z "${TIDY+x}" ]; then
-  run-clang-tidy -p "$BUILD_DIR" -header-filter=.* src/ audio/src/ audio/include test/src/ \
+  run-clang-tidy -quiet -fix -format -p "$BUILD_DIR" -header-filter=.* src/ audio/src/ audio/include test/src/ \
     test/include util/src/ util/include/
 else
   ctest -j"$(nproc)" --test-dir "$BUILD_DIR" --output-on-failure

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,9 @@
 Checks: "-*
 , modernize-use-bool-literals
 , modernize-use-emplace
+, modernize-use-equals-*
+, modernize-use-nullptr
+, modernize-use-override
 , readability-named-parameter
 , readability-inconsistent-declaration-parameter-name
 "

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -131,7 +131,7 @@ jobs:
           path: ".cache/ccache"
           key: ${{ github.job }}-ccache
       - name: Run build
-        run: docker compose run --rm fedora .ci-scripts/build-qtox-linux.sh --build-type Release --full --tidy
+        run: docker compose run --rm fedora .ci-scripts/build-qtox-linux.sh --build-type Release --full --tidy || (git diff --exit-code && false)
 
   ################################################################################################
   # Build and test jobs (PR)

--- a/audio/include/audio/iaudiocontrol.h
+++ b/audio/include/audio/iaudiocontrol.h
@@ -87,7 +87,7 @@ class IAudioControl : public QObject
     Q_OBJECT
 
 public:
-    virtual ~IAudioControl() = default;
+    ~IAudioControl() override = default;
     virtual void setOutputVolume(qreal volume) = 0;
     virtual qreal maxOutputVolume() const = 0;
     virtual qreal minOutputVolume() const = 0;

--- a/audio/include/audio/iaudiosource.h
+++ b/audio/include/audio/iaudiosource.h
@@ -19,7 +19,7 @@ class IAudioSource : public QObject
 {
     Q_OBJECT
 public:
-    virtual ~IAudioSource() = default;
+    ~IAudioSource() override = default;
 
     virtual operator bool() const = 0;
 

--- a/audio/src/backend/alsink.h
+++ b/audio/src/backend/alsink.h
@@ -22,7 +22,7 @@ public:
     AlSink& operator=(const AlSink&) = delete;
     AlSink(AlSink&& other) = delete;
     AlSink& operator=(AlSink&& other) = delete;
-    ~AlSink();
+    ~AlSink() override;
 
     void playAudioBuffer(const int16_t* data, int samples, unsigned channels,
                          int sampleRate) const override;

--- a/audio/src/backend/alsource.h
+++ b/audio/src/backend/alsource.h
@@ -19,9 +19,9 @@ public:
     AlSource& operator=(const AlSource&) = delete;
     AlSource(AlSource&& other) = delete;
     AlSource& operator=(AlSource&& other) = delete;
-    ~AlSource();
+    ~AlSource() override;
 
-    operator bool() const;
+    operator bool() const override;
 
     void kill();
 

--- a/audio/src/backend/openal.h
+++ b/audio/src/backend/openal.h
@@ -38,42 +38,42 @@ class OpenAL : public IAudioControl
 
 public:
     explicit OpenAL(IAudioSettings& _settings);
-    virtual ~OpenAL();
+    ~OpenAL() override;
 
-    qreal maxOutputVolume() const
+    qreal maxOutputVolume() const override
     {
         return 1;
     }
-    qreal minOutputVolume() const
+    qreal minOutputVolume() const override
     {
         return 0;
     }
-    void setOutputVolume(qreal volume);
+    void setOutputVolume(qreal volume) override;
 
-    qreal minInputGain() const;
-    qreal maxInputGain() const;
+    qreal minInputGain() const override;
+    qreal maxInputGain() const override;
 
-    qreal inputGain() const;
-    void setInputGain(qreal dB);
+    qreal inputGain() const override;
+    void setInputGain(qreal dB) override;
 
-    qreal minInputThreshold() const;
-    qreal maxInputThreshold() const;
+    qreal minInputThreshold() const override;
+    qreal maxInputThreshold() const override;
 
-    qreal getInputThreshold() const;
-    void setInputThreshold(qreal normalizedThreshold);
+    qreal getInputThreshold() const override;
+    void setInputThreshold(qreal normalizedThreshold) override;
 
-    void reinitInput(const QString& inDevDesc);
-    bool reinitOutput(const QString& outDevDesc);
+    void reinitInput(const QString& inDevDesc) override;
+    bool reinitOutput(const QString& outDevDesc) override;
 
-    bool isOutputReady() const;
+    bool isOutputReady() const override;
 
-    QStringList outDeviceNames();
-    QStringList inDeviceNames();
+    QStringList outDeviceNames() override;
+    QStringList inDeviceNames() override;
 
-    std::unique_ptr<IAudioSink> makeSink();
+    std::unique_ptr<IAudioSink> makeSink() override;
     void destroySink(AlSink& sink);
 
-    std::unique_ptr<IAudioSource> makeSource();
+    std::unique_ptr<IAudioSource> makeSource() override;
     void destroySource(AlSource& source);
 
     void startLoop(uint sourceId);

--- a/src/appmanager.h
+++ b/src/appmanager.h
@@ -24,7 +24,7 @@ class AppManager : public QObject
 
 public:
     AppManager(int& argc, char** argv);
-    ~AppManager();
+    ~AppManager() override;
     int run();
 
 private:

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -9,7 +9,7 @@
 #include <QDebug>
 #include <QGraphicsScene>
 
-ChatLine::ChatLine() {}
+ChatLine::ChatLine() = default;
 
 ChatLine::~ChatLine()
 {

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -31,7 +31,7 @@ struct ColumnFormat
         Right,
     };
 
-    ColumnFormat() {}
+    ColumnFormat() = default;
     ColumnFormat(qreal s, Policy p, Align hAlign_ = Left)
         : size(s)
         , policy(p)

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -39,8 +39,8 @@ public:
 
     virtual qreal getAscent() const;
 
-    virtual QRectF boundingRect() const = 0;
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) = 0;
+    QRectF boundingRect() const override = 0;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override = 0;
 
     virtual void visibilityChanged(bool visible);
     virtual void reloadTheme();

--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -39,7 +39,7 @@ public:
     };
 
     ChatMessage(DocumentCache& documentCache, Settings& settings, Style& style);
-    ~ChatMessage();
+    ~ChatMessage() override;
     ChatMessage(const ChatMessage&) = default;
     ChatMessage(ChatMessage&&) = default;
 

--- a/src/chatlog/chatwidget.h
+++ b/src/chatlog/chatwidget.h
@@ -33,7 +33,7 @@ public:
     ChatWidget(IChatLog& chatLog_, const Core& core_, DocumentCache& documentCache,
                SmileyPack& smileyPack, Settings& settings, Style& style,
                IMessageBoxManager& messageBoxManager, QWidget* parent = nullptr);
-    virtual ~ChatWidget();
+    ~ChatWidget() override;
 
     void insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines);
     void clearSelection();

--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -30,7 +30,7 @@ class FileTransferWidget : public QWidget
 public:
     FileTransferWidget(QWidget* parent, CoreFile& _coreFile, ToxFile file, Settings& settings,
                        Style& style, IMessageBoxManager& messageBoxManager);
-    virtual ~FileTransferWidget();
+    ~FileTransferWidget() override;
     bool isActive() const;
     void onFileTransferUpdate(ToxFile file);
 

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -32,7 +32,7 @@ public:
     Text(DocumentCache& documentCache, Settings& settings, Style& style, const QString& txt = "",
          const QFont& font = QFont(), bool enableElide = false, const QString& rawText = QString(),
          const TextType& type = NORMAL);
-    virtual ~Text();
+    ~Text() override;
 
     void setText(const QString& txt);
     void selectText(const QString& txt, const std::pair<int, int>& point);

--- a/src/chatlog/content/timestamp.h
+++ b/src/chatlog/content/timestamp.h
@@ -23,7 +23,7 @@ public:
     QDateTime getTime();
 
 protected:
-    QSizeF idealSize();
+    QSizeF idealSize() override;
 
 private:
     QDateTime time;

--- a/src/chatlog/customtextdocument.h
+++ b/src/chatlog/customtextdocument.h
@@ -21,7 +21,7 @@ public:
     CustomTextDocument(SmileyPack& smileyPack, Settings& settings, QObject* parent = nullptr);
 
 protected:
-    virtual QVariant loadResource(int type, const QUrl& name);
+    QVariant loadResource(int type, const QUrl& name) override;
 
 private:
     QList<std::shared_ptr<QIcon>> emoticonIcons;

--- a/src/chatlog/pixmapcache.h
+++ b/src/chatlog/pixmapcache.h
@@ -15,10 +15,11 @@ public:
     QPixmap get(const QString& filename, QSize size);
     static PixmapCache& getInstance();
 
-protected:
-    PixmapCache() {}
     PixmapCache(PixmapCache&) = delete;
     PixmapCache& operator=(const PixmapCache&) = delete;
+
+protected:
+    PixmapCache() = default;
 
 private:
     QHash<QString, QIcon> cache;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -17,7 +17,6 @@
 #include "toxpk.h"
 
 #include "src/model/status.h"
-#include "util/strongtype.h"
 #include <tox/tox.h>
 
 #include <QMutex>
@@ -25,7 +24,6 @@
 #include <QThread>
 #include <QTimer>
 
-#include <functional>
 #include <memory>
 
 class CoreAV;
@@ -67,7 +65,7 @@ public:
     Tox* getTox() const;
     QRecursiveMutex& getCoreLoopLock() const;
 
-    ~Core();
+    ~Core() override;
 
     static const QString TOX_EXT;
     uint64_t getMaxMessageSize() const;

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -41,7 +41,7 @@ public:
     void setAudio(IAudioControl& newAudio);
     IAudioControl* getAudio();
 
-    ~CoreAV();
+    ~CoreAV() override;
 
     bool isCallStarted(const Friend* f) const;
     bool isCallStarted(const Conference* c) const;

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -30,11 +30,11 @@ class ToxCall : public QObject
     Q_OBJECT
 
 protected:
-    ToxCall() = delete;
     ToxCall(bool VideoEnabled, CoreAV& av, IAudioControl& audio);
-    ~ToxCall();
+    ~ToxCall() override;
 
 public:
+    ToxCall() = delete;
     ToxCall(const ToxCall& other) = delete;
     ToxCall(ToxCall&& other) = delete;
 
@@ -82,7 +82,7 @@ public:
                   CameraSource& cameraSource);
     ToxFriendCall(ToxFriendCall&& other) = delete;
     ToxFriendCall& operator=(ToxFriendCall&& other) = delete;
-    ~ToxFriendCall();
+    ~ToxFriendCall() override;
 
     TOXAV_FRIEND_CALL_STATE getState() const;
     void setState(const TOXAV_FRIEND_CALL_STATE& value);
@@ -109,7 +109,7 @@ public:
     ToxConferenceCall() = delete;
     ToxConferenceCall(const Conference& conference_, CoreAV& av_, IAudioControl& audio_);
     ToxConferenceCall(ToxConferenceCall&& other) = delete;
-    ~ToxConferenceCall();
+    ~ToxConferenceCall() override;
 
     ToxConferenceCall& operator=(ToxConferenceCall&& other) = delete;
     void removePeer(ToxPk peerId);

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -30,7 +30,7 @@ protected:
 
 public:
     explicit IPC(uint32_t profileId_);
-    ~IPC();
+    ~IPC() override;
 
     struct IPCEvent
     {

--- a/src/model/chat.cpp
+++ b/src/model/chat.cpp
@@ -7,4 +7,4 @@
 #include "chat.h"
 #include <QVariant>
 
-Chat::~Chat() {}
+Chat::~Chat() = default;

--- a/src/model/chat.h
+++ b/src/model/chat.h
@@ -14,7 +14,7 @@ class Chat : public QObject
 {
     Q_OBJECT
 public:
-    virtual ~Chat() = 0;
+    ~Chat() override;
 
     virtual void setName(const QString& name) = 0;
     virtual QString getDisplayedName() const = 0;

--- a/src/model/debug/debugobjecttreemodel.cpp
+++ b/src/model/debug/debugobjecttreemodel.cpp
@@ -89,7 +89,7 @@ DebugObjectTreeModel::DebugObjectTreeModel(QObject* parent)
     reload();
 }
 
-DebugObjectTreeModel::~DebugObjectTreeModel() {}
+DebugObjectTreeModel::~DebugObjectTreeModel() = default;
 
 void DebugObjectTreeModel::reload()
 {

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -69,7 +69,7 @@ class IChatLog : public QObject
 {
     Q_OBJECT
 public:
-    virtual ~IChatLog() = default;
+    ~IChatLog() override = default;
 
     /**
      * @brief Returns reference to item at idx

--- a/src/model/imessagedispatcher.h
+++ b/src/model/imessagedispatcher.h
@@ -22,7 +22,7 @@ class IMessageDispatcher : public QObject
 {
     Q_OBJECT
 public:
-    virtual ~IMessageDispatcher();
+    ~IMessageDispatcher() override;
 
     /**
      * @brief Sends message to associated chat

--- a/src/model/notificationgenerator.h
+++ b/src/model/notificationgenerator.h
@@ -26,7 +26,7 @@ public:
                           // currently mockable so we allow profile to be nullptr for unit
                           // testing
                           Profile* profile_);
-    virtual ~NotificationGenerator();
+    ~NotificationGenerator() override;
     NotificationGenerator(const NotificationGenerator&) = delete;
     NotificationGenerator& operator=(const NotificationGenerator&) = delete;
     NotificationGenerator(NotificationGenerator&&) = delete;

--- a/src/model/sessionchatlog.h
+++ b/src/model/sessionchatlog.h
@@ -24,7 +24,7 @@ public:
     SessionChatLog(ChatLogIdx initialIdx, const ICoreIdHandler& coreIdHandler_,
                    FriendList& friendList, ConferenceList& conferenceList);
 
-    ~SessionChatLog();
+    ~SessionChatLog() override;
     const ChatLogItem& at(ChatLogIdx idx) const override;
     SearchResult searchForward(SearchPos startPos, const QString& phrase,
                                const ParameterSearch& parameter) const override;

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -38,7 +38,7 @@ class Nexus : public QObject
 public:
     Nexus(Settings& settings, IMessageBoxManager& messageBoxManager, CameraSource& cameraSource,
           IPC& ipc, QObject* parent = nullptr);
-    ~Nexus();
+    ~Nexus() override;
     void start();
     void showMainGUI();
     void setParser(QCommandLineParser* parser_);

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -104,7 +104,7 @@ public:
     };
 
     RawDatabase(const QString& path_, const QString& password, const QByteArray& salt);
-    ~RawDatabase();
+    ~RawDatabase() override;
     bool isOpen();
 
     bool execNow(const QString& statement);

--- a/src/persistence/db/upgrades/dbupgrader.cpp
+++ b/src/persistence/db/upgrades/dbupgrader.cpp
@@ -64,7 +64,7 @@ struct DuplicateAlias
         , badAliasRows{badAliasRows_}
     {
     }
-    DuplicateAlias() {}
+    DuplicateAlias() = default;
     RowId goodAliasRow{-1};
     std::vector<RowId> badAliasRows;
 };

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -202,7 +202,7 @@ public:
 
 public:
     History(std::shared_ptr<RawDatabase> db, Settings& settings, IMessageBoxManager& messageBoxManager);
-    ~History();
+    ~History() override;
 
     bool isValid();
 

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -38,7 +38,7 @@ public:
                                   const QCommandLineParser* parser, CameraSource& cameraSource,
                                   IMessageBoxManager& messageBoxManager);
     void save();
-    ~Profile();
+    ~Profile() override;
 
     Core& getCore() const;
     QString getName() const;

--- a/src/persistence/profilelocker.h
+++ b/src/persistence/profilelocker.h
@@ -13,10 +13,9 @@ class Paths;
 
 class ProfileLocker
 {
-private:
+public:
     ProfileLocker() = delete;
 
-public:
     static bool isLockable(QString profile, Paths& paths);
     static bool lock(QString profile, Paths& paths);
     static void unlock();

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -135,7 +135,7 @@ public:
 
 public:
     explicit Settings(IMessageBoxManager& messageBoxManager);
-    ~Settings();
+    ~Settings() override;
     Settings(Settings& settings) = delete;
     Settings& operator=(const Settings&) = delete;
 

--- a/src/platform/desktop_notifications/desktopnotify.h
+++ b/src/platform/desktop_notifications/desktopnotify.h
@@ -29,7 +29,7 @@ class DesktopNotify : public QObject
 
 public:
     DesktopNotify(INotificationSettings& settings, QObject* parent);
-    ~DesktopNotify();
+    ~DesktopNotify() override;
 
     void setIcon(QSystemTrayIcon* icon);
 

--- a/src/platform/desktop_notifications/desktopnotifybackend.h
+++ b/src/platform/desktop_notifications/desktopnotifybackend.h
@@ -14,7 +14,7 @@ class DesktopNotifyBackend : public QObject
 
 public:
     explicit DesktopNotifyBackend(QObject* parent);
-    ~DesktopNotifyBackend();
+    ~DesktopNotifyBackend() override;
 
     bool showMessage(const QString& title, const QString& message, const QPixmap& pixmap);
 

--- a/src/platform/posixsignalnotifier.h
+++ b/src/platform/posixsignalnotifier.h
@@ -22,7 +22,7 @@ public:
     };
     Q_ENUM(UserSignal)
 
-    ~PosixSignalNotifier();
+    ~PosixSignalNotifier() override;
 
     static void watchSignal(int signum);
     static void watchSignals(std::initializer_list<int> signalSet);

--- a/src/video/camerasource.h
+++ b/src/video/camerasource.h
@@ -24,7 +24,7 @@ class CameraSource : public VideoSource
 
 public:
     explicit CameraSource(Settings& settings);
-    ~CameraSource();
+    ~CameraSource() override;
     void setupDefault();
     bool isNone() const;
 

--- a/src/video/netcamview.h
+++ b/src/video/netcamview.h
@@ -32,7 +32,7 @@ class NetCamView : public QWidget
 public:
     NetCamView(ToxPk friendPk_, CameraSource& cameraSource, Settings& settings, Style& style,
                Profile& profile, QWidget* parent = nullptr);
-    ~NetCamView();
+    ~NetCamView() override;
 
     virtual void show(VideoSource* source, const QString& title);
     virtual void hide();
@@ -42,7 +42,7 @@ public:
     QSize getSurfaceMinSize();
 
 protected:
-    void showEvent(QShowEvent* event);
+    void showEvent(QShowEvent* event) override;
     QVBoxLayout* verLayout;
     VideoSurface* videoSurface;
     QPushButton* enterFullScreenButton = nullptr;
@@ -71,8 +71,8 @@ private:
     void toggleVideoPreview();
     void toggleButtonState(QPushButton* btn);
     void updateButtonState(QPushButton* btn, bool active);
-    void keyPressEvent(QKeyEvent* event);
-    void closeEvent(QCloseEvent* event);
+    void keyPressEvent(QKeyEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
     VideoSurface* selfVideoSurface;
     MovableWidget* selfFrame;
     ToxPk friendPk;

--- a/src/video/videosource.h
+++ b/src/video/videosource.h
@@ -27,7 +27,7 @@ public:
     {
     }
 
-    virtual ~VideoSource() = default;
+    ~VideoSource() override = default;
     /**
      * @brief If subscribe successfully opens the source, it will start emitting frameAvailable
      * signals.

--- a/src/video/videosurface.h
+++ b/src/video/videosurface.h
@@ -17,7 +17,7 @@ class VideoSurface : public QWidget
 public:
     VideoSurface(const QPixmap& avatar_, QWidget* parent = nullptr, bool expanding_ = false);
     VideoSurface(const QPixmap& avatar_, VideoSource* source_, QWidget* parent = nullptr);
-    ~VideoSurface();
+    ~VideoSurface() override;
 
     bool isExpanding() const;
     void setSource(VideoSource* src);

--- a/src/widget/about/aboutfriendform.h
+++ b/src/widget/about/aboutfriendform.h
@@ -27,7 +27,7 @@ class AboutFriendForm : public QDialog
 public:
     AboutFriendForm(std::unique_ptr<IAboutFriend> about, Settings& settings, Style& style,
                     IMessageBoxManager& messageBoxManager, QWidget* parent = nullptr);
-    ~AboutFriendForm();
+    ~AboutFriendForm() override;
 
 private:
     Ui::AboutFriendForm* ui;

--- a/src/widget/chatformheader.h
+++ b/src/widget/chatformheader.h
@@ -47,7 +47,7 @@ public:
     };
 
     ChatFormHeader(Settings& settings, Style& style, QWidget* parent = nullptr);
-    ~ChatFormHeader();
+    ~ChatFormHeader() override;
 
     void setName(const QString& newName);
     void setMode(Mode mode_);

--- a/src/widget/circlewidget.h
+++ b/src/widget/circlewidget.h
@@ -23,7 +23,7 @@ public:
     CircleWidget(const Core& core_, FriendListWidget* parent, int id_, Settings& settings,
                  Style& style, IMessageBoxManager& messageboxManager, FriendList& friendList,
                  ConferenceList& conferenceList, Profile& profile);
-    ~CircleWidget();
+    ~CircleWidget() override;
 
     void editName();
     static CircleWidget* getFromID(int id);

--- a/src/widget/conferencewidget.h
+++ b/src/widget/conferencewidget.h
@@ -22,7 +22,7 @@ class ConferenceWidget final : public GenericChatroomWidget, public IFriendListI
 public:
     ConferenceWidget(std::shared_ptr<ConferenceRoom> chatroom_, bool compact, Settings& settings,
                      Style& style);
-    ~ConferenceWidget();
+    ~ConferenceWidget() override;
     void setAsInactiveChatroom() final;
     void setAsActiveChatroom() final;
     void updateStatusLight() final;

--- a/src/widget/contentdialogmanager.h
+++ b/src/widget/contentdialogmanager.h
@@ -30,8 +30,8 @@ public:
     ContentDialog* getFriendDialog(const ToxPk& friendPk) const;
     ContentDialog* getConferenceDialog(const ConferenceId& conferenceId) const;
 
-    IDialogs* getFriendDialogs(const ToxPk& friendPk) const;
-    IDialogs* getConferenceDialogs(const ConferenceId& conferenceId) const;
+    IDialogs* getFriendDialogs(const ToxPk& friendPk) const override;
+    IDialogs* getConferenceDialogs(const ConferenceId& conferenceId) const override;
 
     FriendWidget* addFriendToDialog(ContentDialog* dialog, std::shared_ptr<FriendChatroom> chatroom,
                                     GenericChatForm* form);

--- a/src/widget/contentlayout.h
+++ b/src/widget/contentlayout.h
@@ -16,7 +16,7 @@ class ContentLayout : public QVBoxLayout
 public:
     ContentLayout(Settings& settings, Style& style);
     explicit ContentLayout(Settings& settings, Style& style, QWidget* parent);
-    ~ContentLayout();
+    ~ContentLayout() override;
 
     void clear();
 

--- a/src/widget/flowlayout.h
+++ b/src/widget/flowlayout.h
@@ -13,7 +13,7 @@ class FlowLayout : public QLayout
 public:
     explicit FlowLayout(QWidget* parent, int margin = -1, int hSpacing = -1, int vSpacing = -1);
     explicit FlowLayout(int margin = -1, int hSpacing = -1, int vSpacing = -1);
-    ~FlowLayout();
+    ~FlowLayout() override;
 
     void addItem(QLayoutItem* item) override;
     int horizontalSpacing() const;

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -38,7 +38,7 @@ public:
                   IMessageBoxManager& messageBoxManager, Core& core);
     AddFriendForm(const AddFriendForm&) = delete;
     AddFriendForm& operator=(const AddFriendForm&) = delete;
-    ~AddFriendForm();
+    ~AddFriendForm() override;
 
     bool isShown() const;
     void show(ContentLayout* contentLayout);

--- a/src/widget/form/conferenceform.h
+++ b/src/widget/form/conferenceform.h
@@ -37,7 +37,7 @@ public:
                    DocumentCache& documentCache, SmileyPack& smileyPack, Style& style,
                    IMessageBoxManager& messageBoxManager, FriendList& friendList,
                    ConferenceList& conferenceList);
-    ~ConferenceForm();
+    ~ConferenceForm() override;
 
     void peerAudioPlaying(ToxPk peerPk);
 

--- a/src/widget/form/conferenceinviteform.h
+++ b/src/widget/form/conferenceinviteform.h
@@ -28,7 +28,7 @@ class ConferenceInviteForm : public QWidget
     Q_OBJECT
 public:
     ConferenceInviteForm(Settings& settings, Core& core);
-    ~ConferenceInviteForm();
+    ~ConferenceInviteForm() override;
 
     void show(ContentLayout* contentLayout);
     bool addConferenceInvite(const ConferenceInvite& inviteInfo);

--- a/src/widget/form/debug/debuglog.h
+++ b/src/widget/form/debug/debuglog.h
@@ -22,7 +22,7 @@ class DebugLogForm final : public GenericForm
     Q_OBJECT
 public:
     DebugLogForm(Paths& paths, Style& style, QWidget* parent);
-    ~DebugLogForm();
+    ~DebugLogForm() override;
     QString getFormName() final
     {
         return tr("Debug Log");

--- a/src/widget/form/debug/debugobjecttree.cpp
+++ b/src/widget/form/debug/debugobjecttree.cpp
@@ -20,4 +20,4 @@ DebugObjectTree::DebugObjectTree(Style& style, QWidget* parent)
     connect(ui_->btnReload, &QPushButton::clicked, model_, &DebugObjectTreeModel::reload);
 }
 
-DebugObjectTree::~DebugObjectTree() {}
+DebugObjectTree::~DebugObjectTree() = default;

--- a/src/widget/form/debug/debugobjecttree.h
+++ b/src/widget/form/debug/debugobjecttree.h
@@ -22,7 +22,7 @@ class DebugObjectTree : public GenericForm
 
 public:
     explicit DebugObjectTree(Style& style, QWidget* parent = nullptr);
-    ~DebugObjectTree();
+    ~DebugObjectTree() override;
 
     QString getFormName() final
     {

--- a/src/widget/form/debugwidget.h
+++ b/src/widget/form/debugwidget.h
@@ -21,7 +21,7 @@ class DebugWidget : public QWidget
     Q_OBJECT
 public:
     DebugWidget(Paths& paths, Style& style, Widget* parent = nullptr);
-    ~DebugWidget();
+    ~DebugWidget() override;
 
     bool isShown() const;
     void show(ContentLayout* contentLayout);

--- a/src/widget/form/filesform.h
+++ b/src/widget/form/filesform.h
@@ -34,7 +34,7 @@ class FilesForm : public QObject
 public:
     FilesForm(CoreFile& coreFile, Settings& settings, Style& style,
               IMessageBoxManager& messageBoxManager, FriendList& friendList);
-    ~FilesForm();
+    ~FilesForm() override;
 
     bool isShown() const;
     void show(ContentLayout* contentLayout);

--- a/src/widget/form/filetransferlist.h
+++ b/src/widget/form/filetransferlist.h
@@ -42,7 +42,7 @@ class Model : public QAbstractTableModel
     Q_OBJECT
 public:
     Model(FriendList& friendList, QObject* parent = nullptr);
-    ~Model() = default;
+    ~Model() override = default;
 
     void onFileUpdated(const ToxFile& file);
 
@@ -82,6 +82,6 @@ class View : public QTableView
 {
 public:
     View(QAbstractItemModel* model, Settings& settings, Style& style, QWidget* parent = nullptr);
-    ~View();
+    ~View() override;
 };
 } // namespace FileTransferList

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -21,7 +21,7 @@ class LoadHistoryDialog : public QDialog
 public:
     explicit LoadHistoryDialog(const IChatLog* chatLog_, QWidget* parent = nullptr);
     explicit LoadHistoryDialog(QWidget* parent = nullptr);
-    ~LoadHistoryDialog();
+    ~LoadHistoryDialog() override;
 
     QDateTime getFromDate();
     void setTitle(const QString& title);

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -44,7 +44,7 @@ class ProfileForm : public QWidget
 public:
     ProfileForm(IProfileInfo* profileInfo_, Settings& settings, Style& style,
                 IMessageBoxManager& messageBoxManager, QWidget* parent = nullptr);
-    ~ProfileForm();
+    ~ProfileForm() override;
     void show(ContentLayout* contentLayout);
     bool isShown() const;
 
@@ -71,7 +71,7 @@ private slots:
 private:
     void retranslateUi();
     void prFileLabelUpdate();
-    bool eventFilter(QObject* object, QEvent* event);
+    bool eventFilter(QObject* object, QEvent* event) override;
     void refreshProfiles();
     static QString getSupportedImageFilter();
 

--- a/src/widget/form/searchsettingsform.h
+++ b/src/widget/form/searchsettingsform.h
@@ -20,7 +20,7 @@ class SearchSettingsForm : public QWidget
 
 public:
     SearchSettingsForm(Settings& settings, Style& style, QWidget* parent = nullptr);
-    ~SearchSettingsForm();
+    ~SearchSettingsForm() override;
 
     ParameterSearch getParameterSearch();
     void reloadTheme();

--- a/src/widget/form/setpassworddialog.h
+++ b/src/widget/form/setpassworddialog.h
@@ -23,7 +23,7 @@ public:
         Tertiary
     };
     explicit SetPasswordDialog(QString body_, QString extraButton, QWidget* parent = nullptr);
-    ~SetPasswordDialog();
+    ~SetPasswordDialog() override;
     QString getPassword();
     static int getPasswordStrength(QString pass);
 

--- a/src/widget/form/settings/aboutform.h
+++ b/src/widget/form/settings/aboutform.h
@@ -25,7 +25,7 @@ class AboutForm : public GenericForm
     Q_OBJECT
 public:
     AboutForm(UpdateCheck& updateCheck_, QString contactInfo_, Style& style_);
-    ~AboutForm();
+    ~AboutForm() override;
     QString getFormName() final
     {
         return tr("About");

--- a/src/widget/form/settings/advancedform.h
+++ b/src/widget/form/settings/advancedform.h
@@ -21,7 +21,7 @@ class AdvancedForm : public GenericForm
     Q_OBJECT
 public:
     AdvancedForm(Settings& settings, Style& style, IMessageBoxManager& messageBoxManager);
-    ~AdvancedForm();
+    ~AdvancedForm() override;
     QString getFormName() final
     {
         return tr("Advanced");

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -20,7 +20,7 @@ class GeneralForm final : public GenericForm
     Q_OBJECT
 public:
     GeneralForm(Settings& settings, Style& style);
-    ~GeneralForm();
+    ~GeneralForm() override;
     QString getFormName() final
     {
         return tr("General");

--- a/src/widget/form/settings/genericsettings.h
+++ b/src/widget/form/settings/genericsettings.h
@@ -14,7 +14,7 @@ class GenericForm : public QWidget
     Q_OBJECT
 public:
     GenericForm(const QPixmap& icon, Style& style, QWidget* parent = nullptr);
-    virtual ~GenericForm() {}
+    ~GenericForm() override = default;
 
     virtual QString getFormName() = 0;
     QPixmap getFormIcon();

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -21,7 +21,7 @@ class PrivacyForm : public GenericForm
     Q_OBJECT
 public:
     PrivacyForm(Core* core_, Settings& settings, Style& style, Profile& profile);
-    ~PrivacyForm();
+    ~PrivacyForm() override;
     QString getFormName() final
     {
         return tr("Privacy");

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -23,7 +23,7 @@ class UserInterfaceForm : public GenericForm
 public:
     UserInterfaceForm(SmileyPack& smileyPack, Settings& settings, Style& style,
                       SettingsWidget* myParent);
-    ~UserInterfaceForm();
+    ~UserInterfaceForm() override;
     QString getFormName() final
     {
         return tr("User Interface");

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -38,7 +38,7 @@ public:
     SettingsWidget(UpdateCheck& updateCheck, IAudioControl& audio, Core* core, SmileyPack& smileyPack,
                    CameraSource& cameraSource, Settings& settings, Style& style,
                    IMessageBoxManager& messageBoxManager, Profile& profile, Widget* parent = nullptr);
-    ~SettingsWidget();
+    ~SettingsWidget() override;
 
     bool isShown() const;
     void show(ContentLayout* contentLayout);

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -39,7 +39,7 @@ public:
     FriendListWidget(const Core& core, Widget* parent, Settings& settings, Style& style,
                      IMessageBoxManager& messageBoxManager, FriendList& friendList,
                      ConferenceList& conferenceList, Profile& profile, bool conferencesOnTop = true);
-    ~FriendListWidget();
+    ~FriendListWidget() override;
     void setMode(SortingMode mode);
     SortingMode getMode() const;
 

--- a/src/widget/imagepreviewwidget.h
+++ b/src/widget/imagepreviewwidget.h
@@ -16,7 +16,7 @@ public:
         : QPushButton(parent)
     {
     }
-    ~ImagePreviewButton();
+    ~ImagePreviewButton() override;
     ImagePreviewButton(const ImagePreviewButton&) = delete;
     ImagePreviewButton& operator=(const ImagePreviewButton&) = delete;
     ImagePreviewButton(ImagePreviewButton&&) = delete;

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -24,7 +24,7 @@ class LoginScreen : public QDialog
 public:
     LoginScreen(Paths& paths, Style& style, int themeColor,
                 const QString& initialProfileName = QString(), QWidget* parent = nullptr);
-    ~LoginScreen();
+    ~LoginScreen() override;
     bool event(QEvent* event) final;
 
 signals:

--- a/src/widget/passwordedit.h
+++ b/src/widget/passwordedit.h
@@ -15,11 +15,11 @@ class PasswordEdit : public QLineEdit
     Q_OBJECT
 public:
     explicit PasswordEdit(QWidget* parent);
-    ~PasswordEdit();
+    ~PasswordEdit() override;
 
 protected:
-    virtual void showEvent(QShowEvent* event);
-    virtual void hideEvent(QHideEvent* event);
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
 
 private:
     class EventHandler : QObject
@@ -28,9 +28,9 @@ private:
         QVector<QAction*> actions;
 
         EventHandler();
-        ~EventHandler();
+        ~EventHandler() override;
         void updateActions();
-        bool eventFilter(QObject* obj, QEvent* event);
+        bool eventFilter(QObject* obj, QEvent* event) override;
     };
 
     void registerHandler();

--- a/src/widget/qrwidget.h
+++ b/src/widget/qrwidget.h
@@ -14,7 +14,7 @@ class QRWidget : public QWidget
 
 public:
     explicit QRWidget(QWidget* parent = nullptr);
-    ~QRWidget();
+    ~QRWidget() override;
     void setQRData(const QString& data_);
     QImage* getImage();
     bool saveImage(QString path);

--- a/src/widget/tool/adjustingscrollarea.h
+++ b/src/widget/tool/adjustingscrollarea.h
@@ -12,7 +12,7 @@ class AdjustingScrollArea : public QScrollArea
     Q_OBJECT
 public:
     explicit AdjustingScrollArea(QWidget* parent = nullptr);
-    virtual ~AdjustingScrollArea() = default;
+    ~AdjustingScrollArea() override = default;
 
 protected:
     void resizeEvent(QResizeEvent* ev) override;

--- a/src/widget/tool/chattextedit.h
+++ b/src/widget/tool/chattextedit.h
@@ -12,7 +12,7 @@ class ChatTextEdit final : public QTextEdit
     Q_OBJECT
 public:
     explicit ChatTextEdit(QWidget* parent = nullptr);
-    ~ChatTextEdit();
+    ~ChatTextEdit() override;
     void setLastMessage(QString lm);
     void sendKeyEvent(QKeyEvent* event);
 

--- a/src/widget/tool/flyoutoverlaywidget.cpp
+++ b/src/widget/tool/flyoutoverlaywidget.cpp
@@ -27,7 +27,7 @@ FlyoutOverlayWidget::FlyoutOverlayWidget(QWidget* parent)
     hide();
 }
 
-FlyoutOverlayWidget::~FlyoutOverlayWidget() {}
+FlyoutOverlayWidget::~FlyoutOverlayWidget() = default;
 
 int FlyoutOverlayWidget::animationDuration() const
 {

--- a/src/widget/tool/flyoutoverlaywidget.h
+++ b/src/widget/tool/flyoutoverlaywidget.h
@@ -16,7 +16,7 @@ class FlyoutOverlayWidget : public QWidget
     Q_PROPERTY(qreal flyoutPercent READ flyoutPercent WRITE setFlyoutPercent)
 public:
     explicit FlyoutOverlayWidget(QWidget* parent = nullptr);
-    ~FlyoutOverlayWidget();
+    ~FlyoutOverlayWidget() override;
 
     int animationDuration() const;
     void setAnimationDuration(int timeMs);

--- a/src/widget/tool/movablewidget.h
+++ b/src/widget/tool/movablewidget.h
@@ -17,10 +17,10 @@ public:
     void setRatio(float r);
 
 protected:
-    void mousePressEvent(QMouseEvent* event);
-    void mouseMoveEvent(QMouseEvent* event);
-    void mouseReleaseEvent(QMouseEvent* event);
-    void mouseDoubleClickEvent(QMouseEvent* event);
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
     void checkBoundary(QPoint& point) const;

--- a/src/widget/tool/screengrabberchooserrectitem.cpp
+++ b/src/widget/tool/screengrabberchooserrectitem.cpp
@@ -41,7 +41,7 @@ ScreenGrabberChooserRectItem::ScreenGrabberChooserRectItem(QGraphicsScene* scene
     hideHandles();
 }
 
-ScreenGrabberChooserRectItem::~ScreenGrabberChooserRectItem() {}
+ScreenGrabberChooserRectItem::~ScreenGrabberChooserRectItem() = default;
 
 QRectF ScreenGrabberChooserRectItem::boundingRect() const
 {

--- a/src/widget/tool/screengrabberchooserrectitem.h
+++ b/src/widget/tool/screengrabberchooserrectitem.h
@@ -12,7 +12,7 @@ class ScreenGrabberChooserRectItem final : public QObject, public QGraphicsItemG
     Q_OBJECT
 public:
     explicit ScreenGrabberChooserRectItem(QGraphicsScene* scene);
-    ~ScreenGrabberChooserRectItem();
+    ~ScreenGrabberChooserRectItem() override;
 
     QRectF boundingRect() const final;
     void beginResize(QPointF mousePos);

--- a/src/widget/tool/screengrabberoverlayitem.cpp
+++ b/src/widget/tool/screengrabberoverlayitem.cpp
@@ -22,7 +22,7 @@ ScreenGrabberOverlayItem::ScreenGrabberOverlayItem(ScreenshotGrabber* grabber)
     setPen(QPen(Qt::NoPen));
 }
 
-ScreenGrabberOverlayItem::~ScreenGrabberOverlayItem() {}
+ScreenGrabberOverlayItem::~ScreenGrabberOverlayItem() = default;
 
 void ScreenGrabberOverlayItem::setChosenRect(QRect rect)
 {

--- a/src/widget/tool/screengrabberoverlayitem.h
+++ b/src/widget/tool/screengrabberoverlayitem.h
@@ -14,7 +14,7 @@ class ScreenGrabberOverlayItem final : public QObject, public QGraphicsRectItem
     Q_OBJECT
 public:
     explicit ScreenGrabberOverlayItem(ScreenshotGrabber* grabber);
-    ~ScreenGrabberOverlayItem();
+    ~ScreenGrabberOverlayItem() override;
 
     void setChosenRect(QRect rect);
 

--- a/src/widget/tool/toolboxgraphicsitem.cpp
+++ b/src/widget/tool/toolboxgraphicsitem.cpp
@@ -18,7 +18,7 @@ ToolBoxGraphicsItem::ToolBoxGraphicsItem()
     setOpacity(activeOpacity);
 }
 
-ToolBoxGraphicsItem::~ToolBoxGraphicsItem() {}
+ToolBoxGraphicsItem::~ToolBoxGraphicsItem() = default;
 
 void ToolBoxGraphicsItem::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {

--- a/src/widget/tool/toolboxgraphicsitem.h
+++ b/src/widget/tool/toolboxgraphicsitem.h
@@ -15,7 +15,7 @@ class ToolBoxGraphicsItem final : public QObject, public QGraphicsItemGroup
     Q_PROPERTY(qreal opacity READ opacity WRITE setOpacity)
 public:
     ToolBoxGraphicsItem();
-    ~ToolBoxGraphicsItem();
+    ~ToolBoxGraphicsItem() override;
 
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) final;
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1860,7 +1860,7 @@ ContentLayout* Widget::createContentDialog(DialogType type) const
             connect(core, &Core::usernameSet, this, &Dialog::retranslateUi);
         }
 
-        ~Dialog()
+        ~Dialog() override
         {
             Translator::unregister(this);
         }

--- a/test/mock/include/mock/mockconferencequery.h
+++ b/test/mock/include/mock/mockconferencequery.h
@@ -14,7 +14,7 @@ class MockConferenceQuery : public ICoreConferenceQuery
 {
 public:
     MockConferenceQuery() = default;
-    virtual ~MockConferenceQuery();
+    ~MockConferenceQuery() override;
     MockConferenceQuery(const MockConferenceQuery&) = default;
     MockConferenceQuery& operator=(const MockConferenceQuery&) = default;
     MockConferenceQuery(MockConferenceQuery&&) = default;
@@ -23,7 +23,7 @@ public:
     ConferenceId getConferencePersistentId(uint32_t conferenceNumber) const override
     {
         std::ignore = conferenceNumber;
-        return ConferenceId(0);
+        return ConferenceId(nullptr);
     }
 
     uint32_t getConferenceNumberPeers(int conferenceId) const override

--- a/test/mock/include/mock/mockcoreidhandler.h
+++ b/test/mock/include/mock/mockcoreidhandler.h
@@ -11,7 +11,7 @@ class MockCoreIdHandler : public ICoreIdHandler
 {
 public:
     MockCoreIdHandler() = default;
-    virtual ~MockCoreIdHandler();
+    ~MockCoreIdHandler() override;
     MockCoreIdHandler(const MockCoreIdHandler&) = default;
     MockCoreIdHandler& operator=(const MockCoreIdHandler&) = default;
     MockCoreIdHandler(MockCoreIdHandler&&) = default;

--- a/test/mock/include/mock/mockcoresettings.h
+++ b/test/mock/include/mock/mockcoresettings.h
@@ -22,7 +22,7 @@ public:
         Q_INIT_RESOURCE(res);
     }
 
-    ~MockSettings();
+    ~MockSettings() override;
 
     bool getEnableIPv6() const override
     {

--- a/test/model/conferencemessagedispatcher_test.cpp
+++ b/test/model/conferencemessagedispatcher_test.cpp
@@ -133,7 +133,7 @@ private:
     std::unique_ptr<FriendList> friendList;
 };
 
-TestConferenceMessageDispatcher::TestConferenceMessageDispatcher() {}
+TestConferenceMessageDispatcher::TestConferenceMessageDispatcher() = default;
 
 /**
  * @brief Test initialization. Resets all members to initial state

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -25,7 +25,7 @@ public:
     {
     }
 
-    ~MockFriend();
+    ~MockFriend() override;
 
     bool isFriend() const override
     {
@@ -84,7 +84,7 @@ public:
     {
     }
 
-    ~MockConference();
+    ~MockConference() override;
 
     bool isFriend() const override
     {

--- a/test/model/friendmessagedispatcher_test.cpp
+++ b/test/model/friendmessagedispatcher_test.cpp
@@ -105,7 +105,7 @@ private:
     std::deque<Message> receivedMessages;
 };
 
-TestFriendMessageDispatcher::TestFriendMessageDispatcher() {}
+TestFriendMessageDispatcher::TestFriendMessageDispatcher() = default;
 
 /**
  * @brief Test initialization. Resets all member variables for a fresh test state

--- a/test/model/messageprocessor_test.cpp
+++ b/test/model/messageprocessor_test.cpp
@@ -25,7 +25,7 @@ class TestMessageProcessor : public QObject
     Q_OBJECT
 
 public:
-    TestMessageProcessor() {}
+    TestMessageProcessor() = default;
 
 private slots:
     void testSelfMention();

--- a/test/model/notificationgenerator_test.cpp
+++ b/test/model/notificationgenerator_test.cpp
@@ -15,75 +15,75 @@
 namespace {
 class MockNotificationSettings : public INotificationSettings
 {
-    virtual bool getNotify() const override
+    bool getNotify() const override
     {
         return true;
     }
 
-    virtual void setNotify(bool newValue) override
+    void setNotify(bool newValue) override
     {
         std::ignore = newValue;
     }
 
-    virtual bool getShowWindow() const override
+    bool getShowWindow() const override
     {
         return true;
     }
-    virtual void setShowWindow(bool newValue) override
+    void setShowWindow(bool newValue) override
     {
         std::ignore = newValue;
     }
 
-    virtual bool getDesktopNotify() const override
+    bool getDesktopNotify() const override
     {
         return true;
     }
-    virtual void setDesktopNotify(bool newValue) override
+    void setDesktopNotify(bool enabled) override
     {
-        std::ignore = newValue;
+        std::ignore = enabled;
     }
 
-    virtual bool getNotifySystemBackend() const override
+    bool getNotifySystemBackend() const override
     {
         return true;
     }
-    virtual void setNotifySystemBackend(bool newValue) override
+    void setNotifySystemBackend(bool newValue) override
     {
         std::ignore = newValue;
     }
 
-    virtual bool getNotifySound() const override
+    bool getNotifySound() const override
     {
         return true;
     }
-    virtual void setNotifySound(bool newValue) override
+    void setNotifySound(bool newValue) override
     {
         std::ignore = newValue;
     }
 
-    virtual bool getNotifyHide() const override
+    bool getNotifyHide() const override
     {
         return notifyHide;
     }
-    virtual void setNotifyHide(bool newValue) override
+    void setNotifyHide(bool newValue) override
     {
         notifyHide = newValue;
     }
 
-    virtual bool getBusySound() const override
+    bool getBusySound() const override
     {
         return true;
     }
-    virtual void setBusySound(bool newValue) override
+    void setBusySound(bool newValue) override
     {
         std::ignore = newValue;
     }
 
-    virtual bool getConferenceAlwaysNotify() const override
+    bool getConferenceAlwaysNotify() const override
     {
         return true;
     }
-    virtual void setConferenceAlwaysNotify(bool newValue) override
+    void setConferenceAlwaysNotify(bool newValue) override
     {
         std::ignore = newValue;
     }
@@ -178,7 +178,7 @@ void TestNotificationGenerator::testNotificationClear()
 
 void TestNotificationGenerator::testConferenceMessage()
 {
-    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery,
+    Conference g(0, ConferenceId(nullptr), "conferenceName", false, "selfName", *conferenceQuery,
                  *coreIdHandler, *friendList);
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
     g.updateUsername(sender, "sender1");
@@ -190,7 +190,7 @@ void TestNotificationGenerator::testConferenceMessage()
 
 void TestNotificationGenerator::testMultipleConferenceMessages()
 {
-    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery,
+    Conference g(0, ConferenceId(nullptr), "conferenceName", false, "selfName", *conferenceQuery,
                  *coreIdHandler, *friendList);
 
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
@@ -361,7 +361,7 @@ void TestNotificationGenerator::testSimpleFileTransfer()
 
 void TestNotificationGenerator::testSimpleConferenceMessage()
 {
-    Conference g(0, ConferenceId(0), "conferenceName", false, "selfName", *conferenceQuery,
+    Conference g(0, ConferenceId(nullptr), "conferenceName", false, "selfName", *conferenceQuery,
                  *coreIdHandler, *friendList);
     auto sender = conferenceQuery->getConferencePeerPk(0, 0);
     g.updateUsername(sender, "sender1");

--- a/test/model/sessionchatlog_test.cpp
+++ b/test/model/sessionchatlog_test.cpp
@@ -47,7 +47,7 @@ class TestSessionChatLog : public QObject
     Q_OBJECT
 
 public:
-    TestSessionChatLog() {}
+    TestSessionChatLog() = default;
 
 private slots:
     void init();

--- a/test/persistence/offlinemsgengine_test.cpp
+++ b/test/persistence/offlinemsgengine_test.cpp
@@ -3,9 +3,6 @@
  * Copyright © 2024-2025 The TokTok team.
  */
 
-#include "src/core/core.h"
-#include "src/model/friend.h"
-#include "src/model/status.h"
 #include "src/persistence/offlinemsgengine.h"
 
 #include <QtTest/QtTest>
@@ -128,7 +125,6 @@ void TestOfflineMsgEngine::testCallback()
     size_t numCallbacks = 0;
     auto callback = [&numCallbacks](bool) { numCallbacks++; };
     Message msg{false, QString(), QDateTime(), {}};
-    ReceiptNum receipt;
 
     offlineMsgEngine.addSentCoreMessage(ReceiptNum(1), Message(), callback);
     offlineMsgEngine.addSentCoreMessage(ReceiptNum(2), Message(), callback);

--- a/util/include/util/strongtype.h
+++ b/util/include/util/strongtype.h
@@ -123,7 +123,7 @@ class NamedType : public Properties<NamedType<T, Tag, Properties...>, T>...
 public:
     using UnderlyingType = T;
 
-    NamedType() {}
+    NamedType() = default;
     explicit NamedType(const T& value)
         : value_(value)
     {


### PR DESCRIPTION
Also remove redundant `virtual` when functions are already marked as `override`. Also use `nullptr` more.

```sh
run-clang-tidy -p _build -fix \
  $(find . -name "*.h" -or -name "*.cpp" -or -name "*.c" | grep -v "/_build/") \
  -checks="-*,modernize-use-equals-*,modernize-use-nullptr,modernize-use-override"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/81)
<!-- Reviewable:end -->
