### PR TITLE
cleanup: Make member functions `const` where possible.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: "-*
 , modernize-use-override
 , readability-container-*
 , readability-else-after-return
+, readability-make-member-function-const
 , readability-named-parameter
 , readability-inconsistent-declaration-parameter-name
 "

--- a/src/model/debug/debugobjecttreemodel.cpp
+++ b/src/model/debug/debugobjecttreemodel.cpp
@@ -52,7 +52,7 @@ public:
         qFatal("Parent tree item does not contain this item");
     }
 
-    TreeItem* parentItem()
+    TreeItem* parentItem() const
     {
         return parent;
     }

--- a/src/model/friendlist/friendlistmanager.cpp
+++ b/src/model/friendlist/friendlistmanager.cpp
@@ -176,7 +176,7 @@ void FriendListManager::removeAll(IFriendListItem* item)
     }
 }
 
-bool FriendListManager::cmpByName(const IFriendListItemPtr& a, const IFriendListItemPtr& b)
+bool FriendListManager::cmpByName(const IFriendListItemPtr& a, const IFriendListItemPtr& b) const
 {
     if (a->isConference() && !b->isConference()) {
         if (conferencesOnTop) {

--- a/src/model/friendlist/friendlistmanager.h
+++ b/src/model/friendlist/friendlistmanager.h
@@ -52,7 +52,7 @@ private:
     } filterParams;
 
     void removeAll(IFriendListItem* item);
-    bool cmpByName(const IFriendListItemPtr& itemA, const IFriendListItemPtr& itemB);
+    bool cmpByName(const IFriendListItemPtr& itemA, const IFriendListItemPtr& itemB) const;
     bool cmpByActivity(const IFriendListItemPtr& itemA, const IFriendListItemPtr& itemB);
 
     bool byName = true;

--- a/src/video/scopedavdictionary.cpp
+++ b/src/video/scopedavdictionary.cpp
@@ -12,7 +12,7 @@ extern "C"
 
 void ScopedAVDictionary::Setter::operator=(const char* value)
 {
-    av_dict_set(dict, key, value, 0);
+    av_dict_set(dict_, key_, value, 0);
 }
 
 void ScopedAVDictionary::Setter::operator=(const QString& value)
@@ -22,7 +22,7 @@ void ScopedAVDictionary::Setter::operator=(const QString& value)
 
 void ScopedAVDictionary::Setter::operator=(std::int64_t value)
 {
-    av_dict_set_int(dict, key, value, 0);
+    av_dict_set_int(dict_, key_, value, 0);
 }
 
 ScopedAVDictionary::~ScopedAVDictionary()

--- a/src/video/scopedavdictionary.h
+++ b/src/video/scopedavdictionary.h
@@ -15,10 +15,17 @@ class ScopedAVDictionary
 {
     AVDictionary* options = nullptr;
 
-    struct Setter
+    class Setter
     {
-        AVDictionary** dict;
-        const char* key;
+        AVDictionary** dict_;
+        const char* key_;
+
+    public:
+        Setter(AVDictionary** dict, const char* key)
+            : dict_(dict)
+            , key_(key)
+        {
+        }
 
         void operator=(const char* value);
         void operator=(const QString& value);

--- a/src/widget/contentlayout.cpp
+++ b/src/widget/contentlayout.cpp
@@ -65,7 +65,7 @@ void ContentLayout::reloadTheme()
 #endif
 }
 
-void ContentLayout::clear()
+void ContentLayout::clear() const
 {
     QLayoutItem* item;
     while ((item = mainHead->layout()->takeAt(0)) != nullptr) {

--- a/src/widget/contentlayout.h
+++ b/src/widget/contentlayout.h
@@ -18,7 +18,7 @@ public:
     explicit ContentLayout(Settings& settings, Style& style, QWidget* parent);
     ~ContentLayout() override;
 
-    void clear();
+    void clear() const;
 
     QFrame mainHLine;
     QHBoxLayout mainHLineLayout;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -567,7 +567,7 @@ void ChatForm::onScreenshotClicked()
     QTimer::singleShot(SCREENSHOT_GRABBER_OPENING_DELAY, this, &ChatForm::hideFileMenu);
 }
 
-void ChatForm::doScreenshot()
+void ChatForm::doScreenshot() const
 {
     // note: grabber is self-managed and will destroy itself when done
     ScreenshotGrabber* grabber = new ScreenshotGrabber;

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -97,7 +97,7 @@ private slots:
     void previewImage(const QPixmap& pixmap);
     void cancelImagePreview();
     void sendImageFromPreview();
-    void doScreenshot();
+    void doScreenshot() const;
     void onCopyStatusMessage();
 
     void callUpdateFriendActivity();

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -145,7 +145,7 @@ void AVForm::open(const QString& devName, const VideoMode& mode)
     camera.setupDevice(devName, mode);
 }
 
-void AVForm::trackNewScreenGeometry(QScreen* qScreen)
+void AVForm::trackNewScreenGeometry(QScreen* qScreen) const
 {
     connect(qScreen, &QScreen::geometryChanged, this, &AVForm::rescanDevices);
 }
@@ -628,13 +628,13 @@ void AVForm::retranslateUi()
     Ui::AVForm::retranslateUi(this);
 }
 
-int AVForm::getStepsFromValue(qreal val, qreal valMin, qreal valMax)
+int AVForm::getStepsFromValue(qreal val, qreal valMin, qreal valMax) const
 {
     const float norm = (val - valMin) / (valMax - valMin);
     return norm * totalSliderSteps;
 }
 
-qreal AVForm::getValueFromSteps(int steps, qreal valMin, qreal valMax)
+qreal AVForm::getValueFromSteps(int steps, qreal valMin, qreal valMax) const
 {
     return (static_cast<qreal>(steps) / totalSliderSteps) * (valMax - valMin) + valMin;
 }

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -77,9 +77,9 @@ private:
     void hideEvent(QHideEvent* event) final;
     void showEvent(QShowEvent* event) final;
     void open(const QString& devName, const VideoMode& mode);
-    int getStepsFromValue(qreal val, qreal valMin, qreal valMax);
-    qreal getValueFromSteps(int steps, qreal valMin, qreal valMax);
-    void trackNewScreenGeometry(QScreen* qScreen);
+    int getStepsFromValue(qreal val, qreal valMin, qreal valMax) const;
+    qreal getValueFromSteps(int steps, qreal valMin, qreal valMax) const;
+    void trackNewScreenGeometry(QScreen* qScreen) const;
 
 private:
     IAudioControl& audio;

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -106,7 +106,7 @@ void GenericChatroomWidget::compactChange(bool _compact)
     }
 }
 
-bool GenericChatroomWidget::isActive()
+bool GenericChatroomWidget::isActive() const
 {
     return active;
 }

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -42,7 +42,7 @@ public slots:
 
     bool eventFilter(QObject* object, QEvent* event) final;
 
-    bool isActive();
+    bool isActive() const;
 
     void setName(const QString& name);
     void setStatusMsg(const QString& status);

--- a/src/widget/searchtypes.h
+++ b/src/widget/searchtypes.h
@@ -40,12 +40,12 @@ struct ParameterSearch
     QDate date;
     bool isUpdate{false};
 
-    bool operator==(const ParameterSearch& other)
+    bool operator==(const ParameterSearch& other) const
     {
         return filter == other.filter && period == other.period && date == other.date;
     }
 
-    bool operator!=(const ParameterSearch& other)
+    bool operator!=(const ParameterSearch& other) const
     {
         return !(*this == other);
     }

--- a/src/widget/tool/removechatdialog.h
+++ b/src/widget/tool/removechatdialog.h
@@ -17,12 +17,12 @@ class RemoveChatDialog : public QDialog
 public:
     explicit RemoveChatDialog(QWidget* parent, const Chat& contact);
 
-    inline bool removeHistory()
+    bool removeHistory() const
     {
         return ui.removeHistory->isChecked();
     }
 
-    inline bool accepted()
+    bool accepted() const
     {
         return _accepted;
     }

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -203,7 +203,7 @@ void ScreenshotGrabber::reject()
     deleteLater();
 }
 
-QPixmap ScreenshotGrabber::grabScreen()
+QPixmap ScreenshotGrabber::grabScreen() const
 {
     QScreen* screen = QGuiApplication::primaryScreen();
     QRect rec = screen->virtualGeometry();

--- a/src/widget/tool/screenshotgrabber.h
+++ b/src/widget/tool/screenshotgrabber.h
@@ -54,7 +54,7 @@ private:
     bool handleKeyPress(QKeyEvent* event);
     void reject();
 
-    QPixmap grabScreen();
+    QPixmap grabScreen() const;
 
     void hideVisibleWindows();
     void restoreHiddenWindows();

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2710,12 +2710,12 @@ void Widget::refreshPeerListsLocal(const QString& username)
     }
 }
 
-void Widget::connectCircleWidget(CircleWidget& circleWidget)
+void Widget::connectCircleWidget(CircleWidget& circleWidget) const
 {
     connect(&circleWidget, &CircleWidget::newContentDialog, this, &Widget::registerContentDialog);
 }
 
-void Widget::connectFriendWidget(FriendWidget& friendWidget)
+void Widget::connectFriendWidget(FriendWidget& friendWidget) const
 {
     connect(&friendWidget, &FriendWidget::updateFriendActivity, this, &Widget::updateFriendActivity);
 }

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -245,8 +245,8 @@ private slots:
     void dispatchFile(ToxFile file);
     void dispatchFileWithBool(ToxFile file, bool pausedOrBroken);
     void dispatchFileSendFailed(uint32_t friendId, const QString& fileName);
-    void connectCircleWidget(CircleWidget& circleWidget);
-    void connectFriendWidget(FriendWidget& friendWidget);
+    void connectCircleWidget(CircleWidget& circleWidget) const;
+    void connectFriendWidget(FriendWidget& friendWidget) const;
     void searchCircle(CircleWidget& circleWidget);
     void updateFriendActivity(const Friend& frnd);
     void registerContentDialog(ContentDialog& contentDialog) const;

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -204,7 +204,7 @@ public:
         return this;
     }
 
-    bool getConferencesOnTop()
+    bool getConferencesOnTop() const
     {
         return conferencesOnTop;
     }

--- a/test/persistence/dbschema_test.cpp
+++ b/test/persistence/dbschema_test.cpp
@@ -100,7 +100,7 @@ public:
     {
         std::ignore = file;
     }
-    int getErrorsShown()
+    int getErrorsShown() const
     {
         return errorsShown;
     }


### PR DESCRIPTION
```sh
run-clang-tidy -p _build -fix \
  $(find . -name "*.h" -or -name "*.cpp" -or -name "*.c" | grep -v "/_build/") \
  -checks="-*,readability-make-member-function-const"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/83)
<!-- Reviewable:end -->
