### PR TITLE
cleanup: Avoid multiple declarations per statement.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: "-*
 , performance-move-const-arg
 , readability-container-*
 , readability-else-after-return
+, readability-isolate-declaration
 , readability-make-member-function-const
 , readability-named-parameter
 , readability-inconsistent-declaration-parameter-name

--- a/audio/src/backend/openal.cpp
+++ b/audio/src/backend/openal.cpp
@@ -536,7 +536,8 @@ void OpenAL::playAudioBuffer(uint sourceId, const int16_t* data, int samples, un
         return;
 
     ALuint bufids[BUFFER_COUNT];
-    ALint processed = 0, queued = 0;
+    ALint processed = 0;
+    ALint queued = 0;
     alGetSourcei(sourceId, AL_BUFFERS_PROCESSED, &processed);
     alGetSourcei(sourceId, AL_BUFFERS_QUEUED, &queued);
     alSourcei(sourceId, AL_LOOPING, AL_FALSE);

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -260,7 +260,8 @@ int AppManager::startGui(QCommandLineParser& parser)
 
     uint32_t ipcDest = 0;
     bool doIpc = ipc->isAttached();
-    QString eventType, firstParam;
+    QString eventType;
+    QString firstParam;
     if (parser.isSet("p")) {
         profileName = parser.value("p");
         if (!Profile::exists(profileName, settings->getPaths())) {

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -60,7 +60,8 @@ unsigned CoreFile::corefileIterationInterval()
        comes to CPU usage – just keep the CPU usage low when there are no file
        transfers, and speed things up when there is an ongoing file transfer.
     */
-    constexpr unsigned fileInterval = 10, idleInterval = 1000;
+    constexpr unsigned fileInterval = 10;
+    constexpr unsigned idleInterval = 1000;
 
     for (const ToxFile& file : fileMap) {
         if (file.status == ToxFile::TRANSMITTING) {

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -408,7 +408,8 @@ QStringList Profile::getFilesByExt(QString extension, Paths& paths)
 const QStringList Profile::getAllProfileNames(Paths& paths)
 {
     profiles.clear();
-    QStringList toxFiles = getFilesByExt("tox", paths), iniFiles = getFilesByExt("ini", paths);
+    QStringList toxFiles = getFilesByExt("tox", paths);
+    QStringList iniFiles = getFilesByExt("ini", paths);
     for (const QString& toxFile : toxFiles) {
         if (!iniFiles.contains(toxFile)) {
             Settings::createPersonal(paths, toxFile);
@@ -892,7 +893,8 @@ QStringList Profile::remove()
  */
 bool Profile::rename(QString newName)
 {
-    QString path = paths.getSettingsDirPath() + name, newPath = paths.getSettingsDirPath() + newName;
+    QString path = paths.getSettingsDirPath() + name;
+    QString newPath = paths.getSettingsDirPath() + newName;
 
     if (!ProfileLocker::lock(newName, paths)) {
         return false;

--- a/src/platform/timer_x11.cpp
+++ b/src/platform/timer_x11.cpp
@@ -24,7 +24,8 @@ uint32_t Platform::getIdleTime()
         return 0;
     }
 
-    int32_t x11event = 0, x11error = 0;
+    int32_t x11event = 0;
+    int32_t x11error = 0;
     static const int32_t hasExtension = XScreenSaverQueryExtension(display, &x11event, &x11error);
     if (hasExtension) {
         XScreenSaverInfo* info = XScreenSaverAllocInfo();

--- a/src/widget/flowlayout.cpp
+++ b/src/widget/flowlayout.cpp
@@ -121,7 +121,10 @@ QSize FlowLayout::minimumSize() const
 //! [9]
 int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
 {
-    int left, top, right, bottom;
+    int left;
+    int top;
+    int right;
+    int bottom;
     getContentsMargins(&left, &top, &right, &bottom);
     const QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
     int x = effectiveRect.x();

--- a/src/widget/genericchatitemlayout.cpp
+++ b/src/widget/genericchatitemlayout.cpp
@@ -93,7 +93,8 @@ QLayout* GenericChatItemLayout::getLayout() const
 int GenericChatItemLayout::indexOfClosestSortedWidget(GenericChatItemWidget* widget) const
 {
     // Binary search: Deferred test of equality.
-    int min = 0, max = layout->count();
+    int min = 0;
+    int max = layout->count();
     while (min < max) {
         const int mid = (max - min) / 2 + min;
         GenericChatItemWidget* atMid =

--- a/src/widget/qrwidget.cpp
+++ b/src/widget/qrwidget.cpp
@@ -90,7 +90,8 @@ void QRWidget::paintImage()
                 const int xx = yy + x;
                 const unsigned char b = qr->data[xx];
                 if (b & 0x01) {
-                    const double rx1 = x * scale, ry1 = y * scale;
+                    const double rx1 = x * scale;
+                    const double ry1 = y * scale;
                     const QRectF r(rx1, ry1, scale, scale);
                     painter.drawRects(&r, 1);
                 }

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -71,7 +71,8 @@ CallConfirmWidget::CallConfirmWidget(Settings& settings, Style& style, const QWi
     callLabel->setText(elidedText);
 
     QDialogButtonBox* buttonBox = new QDialogButtonBox(Qt::Horizontal, this);
-    QPushButton *accept = new QPushButton(this), *reject = new QPushButton(this);
+    QPushButton* accept = new QPushButton(this);
+    QPushButton* reject = new QPushButton(this);
     accept->setFlat(true);
     reject->setFlat(true);
     accept->setStyleSheet("QPushButton{border:none;}");

--- a/src/widget/tool/movablewidget.cpp
+++ b/src/widget/tool/movablewidget.cpp
@@ -237,7 +237,10 @@ void MovableWidget::mouseDoubleClickEvent(QMouseEvent* event)
 
 void MovableWidget::checkBoundary(QPoint& point) const
 {
-    int x1, y1, x2, y2;
+    int x1;
+    int y1;
+    int x2;
+    int y2;
     boundaryRect.getCoords(&x1, &y1, &x2, &y2);
 
     if (point.x() < boundaryRect.left())

--- a/test/model/exiftransform_test.cpp
+++ b/test/model/exiftransform_test.cpp
@@ -22,7 +22,8 @@ enum class Side
 
 QPoint getPosition(Side side)
 {
-    int x, y;
+    int x;
+    int y;
     switch (side) {
     case Side::top: {
         x = 1;


### PR DESCRIPTION
```sh
run-clang-tidy -p _build -fix $(find . -name "*.h" -or -name "*.cpp" \
-or -name "*.c" | grep -v "/_build/") \
-checks="-*,readability-isolate-declaration"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/85)
<!-- Reviewable:end -->
