### PR TITLE
cleanup: Reduce nesting of `else` clauses after `return`.

### DIFF
--- a/.ci-scripts/build-qtox-linux.sh
+++ b/.ci-scripts/build-qtox-linux.sh
@@ -115,8 +115,14 @@ fi
 cmake --build "$BUILD_DIR"
 
 if [ ! -z "${TIDY+x}" ]; then
-  run-clang-tidy -quiet -fix -format -p "$BUILD_DIR" -header-filter=.* src/ audio/src/ audio/include test/src/ \
-    test/include util/src/ util/include/
+  run-clang-tidy -quiet -fix -format -p "$BUILD_DIR" \
+    audio/include \
+    audio/src/ \
+    src/ \
+    test/include \
+    test/src/ \
+    util/include/ \
+    util/src/
 else
   ctest -j"$(nproc)" --test-dir "$BUILD_DIR" --output-on-failure
 fi

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,10 @@ Checks: "-*
 , modernize-use-nullptr
 , modernize-use-override
 , readability-container-*
+, readability-else-after-return
 , readability-named-parameter
 , readability-inconsistent-declaration-parameter-name
 "
 WarningsAsErrors: "*"
+ExcludeHeaderFilterRegex: "/usr/.*"
+HeaderFilterRegex: ".*"

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -136,9 +136,8 @@ ChatLogIdx firstItemAfterDate(QDate date, const IChatLog& chatLog)
     auto idxs = chatLog.getDateIdxs(date, 1);
     if (!idxs.empty()) {
         return idxs[0].idx;
-    } else {
-        return chatLog.getNextIdx();
     }
+    return chatLog.getNextIdx();
 }
 
 /**
@@ -181,14 +180,13 @@ ChatLogIdx clampedAdd(ChatLogIdx idx, int val, IChatLog& chatLog)
         }
 
         return idx - std::abs(val);
-    } else {
-        auto distToEnd = chatLog.getNextIdx() - idx;
-        if (static_cast<size_t>(val) > distToEnd) {
-            return chatLog.getNextIdx();
-        }
-
-        return idx + val;
     }
+    auto distToEnd = chatLog.getNextIdx() - idx;
+    if (static_cast<size_t>(val) > distToEnd) {
+        return chatLog.getNextIdx();
+    }
+
+    return idx + val;
 }
 
 } // namespace
@@ -654,7 +652,8 @@ QString ChatWidget::getSelectedText() const
 {
     if (selectionMode == SelectionMode::Precise) {
         return selClickedRow->content[selClickedCol]->getSelectedText();
-    } else if (selectionMode == SelectionMode::Multi) {
+    }
+    if (selectionMode == SelectionMode::Multi) {
         // build a nicely formatted message
         QString out;
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1054,10 +1054,9 @@ ConferenceId Core::getConferencePersistentId(uint32_t conferenceNumber) const
     std::vector<uint8_t> idBuff(tox_conference_id_size());
     if (tox_conference_get_id(tox.get(), conferenceNumber, idBuff.data())) {
         return ConferenceId{idBuff.data()};
-    } else {
-        qCritical() << "Failed to get conference ID of conference" << conferenceNumber;
-        return {};
     }
+    qCritical() << "Failed to get conference ID of conference" << conferenceNumber;
+    return {};
 }
 
 /**
@@ -1232,10 +1231,10 @@ int Core::createConference(uint8_t type)
             emit saveRequest();
             emit emptyConferenceCreated(conferenceId, getConferencePersistentId(conferenceId));
             return conferenceId;
-        } else {
-            return std::numeric_limits<uint32_t>::max();
         }
-    } else if (type == TOX_CONFERENCE_TYPE_AV) {
+        return std::numeric_limits<uint32_t>::max();
+    }
+    if (type == TOX_CONFERENCE_TYPE_AV) {
         // unlike tox_conference_new, toxav_add_av_groupchat does not have an error enum, so -1
         // conference number is our only indication of an error
         int conferenceId = toxav_add_av_groupchat(tox.get(), CoreAV::conferenceCallCallback, this);
@@ -1246,10 +1245,9 @@ int Core::createConference(uint8_t type)
             qCritical() << "Unknown error creating AV conference";
         }
         return conferenceId;
-    } else {
-        qWarning() << "createConference: Unknown type" << type;
-        return -1;
     }
+    qWarning() << "createConference: Unknown type" << type;
+    return -1;
 }
 
 /**

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -252,14 +252,13 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
     if (toxav_answer(toxav.get(), friendNum, audioSettings.getAudioBitrate(), videoBitrate, &err)) {
         it->second->setActive(true);
         return true;
-    } else {
-        qWarning() << "Failed to answer call with error" << err;
-        Toxav_Err_Call_Control controlErr;
-        toxav_call_control(toxav.get(), friendNum, TOXAV_CALL_CONTROL_CANCEL, &controlErr);
-        PARSE_ERR(controlErr);
-        calls.erase(it);
-        return false;
     }
+    qWarning() << "Failed to answer call with error" << err;
+    Toxav_Err_Call_Control controlErr;
+    toxav_call_control(toxav.get(), friendNum, TOXAV_CALL_CONTROL_CANCEL, &controlErr);
+    PARSE_ERR(controlErr);
+    calls.erase(it);
+    return false;
 }
 
 bool CoreAV::startCall(uint32_t friendNum, bool video)

--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -174,9 +174,8 @@ ToxPk ToxId::getPublicKey() const
     const auto pkBytes = toxId.left(ToxPk::size);
     if (pkBytes.isEmpty()) {
         return ToxPk{};
-    } else {
-        return ToxPk{pkBytes};
     }
+    return ToxPk{pkBytes};
 }
 
 /**

--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -58,10 +58,9 @@ ToxPk::ToxPk(const QString& pk)
     : ChatId([&pk]() {
         if (pk.length() == numHexChars) {
             return QByteArray::fromHex(pk.toLatin1());
-        } else {
-            assert(!"ToxPk constructed with invalid length string");
-            return QByteArray(); // invalid pk string
         }
+        assert(!"ToxPk constructed with invalid length string");
+        return QByteArray(); // invalid pk string
     }())
 {
 }

--- a/src/friendlist.cpp
+++ b/src/friendlist.cpp
@@ -69,9 +69,9 @@ QString FriendList::decideNickname(const ToxPk& friendPk, const QString& origNam
     Friend* f = FriendList::findFriend(friendPk);
     if (f != nullptr) {
         return f->getDisplayedName();
-    } else if (!origName.isEmpty()) {
-        return origName;
-    } else {
-        return friendPk.toString();
     }
+    if (!origName.isEmpty()) {
+        return origName;
+    }
+    return friendPk.toString();
 }

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -181,10 +181,10 @@ bool IPC::isCurrentOwner()
         const bool isOwner = isCurrentOwnerNoLock();
         globalMemory.unlock();
         return isOwner;
-    } else {
-        qWarning() << "isCurrentOwner failed to lock, returning false";
-        return false;
     }
+    qWarning() << "isCurrentOwner failed to lock, returning false";
+    return false;
+
 #endif
 }
 

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -161,9 +161,8 @@ ChatLogIdx ChatHistory::getFirstIdx() const
 {
     if (canUseHistory()) {
         return ChatLogIdx(0);
-    } else {
-        return sessionChatLog.getFirstIdx();
     }
+    return sessionChatLog.getFirstIdx();
 }
 
 ChatLogIdx ChatHistory::getNextIdx() const
@@ -189,9 +188,8 @@ std::vector<IChatLog::DateChatLogIdxPair> ChatHistory::getDateIdxs(const QDate& 
 
         // Do not re-search in the session chat log. If we have history the query to the history should have been sufficient
         return ret;
-    } else {
-        return sessionChatLog.getDateIdxs(startDate, maxDates);
     }
+    return sessionChatLog.getDateIdxs(startDate, maxDates);
 }
 
 void ChatHistory::addSystemMessage(const SystemMessage& message)

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -40,9 +40,8 @@ QString generateSingleChatTitle(const QHash<T, size_t> numNotifications, T conta
         return QObject::tr("%1 message(s) from %2")
             .arg(numNotifications[contact])
             .arg(contact->getDisplayedName());
-    } else {
-        return contact->getDisplayedName();
     }
+    return contact->getDisplayedName();
 }
 
 QString generateTitle(const QHash<const Friend*, size_t>& friendNotifications,
@@ -52,9 +51,8 @@ QString generateTitle(const QHash<const Friend*, size_t>& friendNotifications,
     if (numChats > 1) {
         return generateMultiChatTitle(numChats,
                                       getNumMessages(friendNotifications, conferenceNotifications));
-    } else {
-        return generateSingleChatTitle(friendNotifications, f);
     }
+    return generateSingleChatTitle(friendNotifications, f);
 }
 
 QString generateTitle(const QHash<const Friend*, size_t>& friendNotifications,
@@ -65,9 +63,8 @@ QString generateTitle(const QHash<const Friend*, size_t>& friendNotifications,
     if (numChats > 1) {
         return generateMultiChatTitle(numChats,
                                       getNumMessages(friendNotifications, conferenceNotifications));
-    } else {
-        return generateSingleChatTitle(conferenceNotifications, c);
     }
+    return generateSingleChatTitle(conferenceNotifications, c);
 }
 
 QString generateContent(const QHash<const Friend*, size_t>& friendNotifications,
@@ -107,15 +104,15 @@ QString generateContent(const QHash<const Friend*, size_t>& friendNotifications,
         }
 
         return ret;
-    } else if (conferenceNotifications.size() == 1) {
+    }
+    if (conferenceNotifications.size() == 1) {
         auto it = conferenceNotifications.begin();
         if (it == conferenceNotifications.end()) {
             qFatal("Concurrency error: conference notifications got cleared while reading");
         }
         return it.key()->getPeerList()[sender] + ": " + lastMessage;
-    } else {
-        return lastMessage;
     }
+    return lastMessage;
 }
 
 QPixmap getSenderAvatar(Profile* profile, const ToxPk& sender)

--- a/src/model/status.cpp
+++ b/src/model/status.cpp
@@ -56,9 +56,8 @@ QString getIconPath(Status status, bool event)
     const QString statusSuffix = getAssetSuffix(status);
     if (status == Status::Blocked) {
         return ":/img/status/" + statusSuffix + ".svg";
-    } else {
-        return ":/img/status/" + statusSuffix + eventSuffix + ".svg";
     }
+    return ":/img/status/" + statusSuffix + eventSuffix + ".svg";
 }
 
 bool isOnline(Status status)

--- a/src/net/bootstrapnodeupdater.cpp
+++ b/src/net/bootstrapnodeupdater.cpp
@@ -219,9 +219,8 @@ QList<DhtServer> BootstrapNodeUpdater::getBootstrapNodes() const
     auto userFilePath = paths.getUserNodesFilePath();
     if (QFile::exists(userFilePath)) {
         return loadNodesFile(userFilePath);
-    } else {
-        return loadNodesFile(builtinNodesFile);
     }
+    return loadNodesFile(builtinNodesFile);
 }
 
 void BootstrapNodeUpdater::requestBootstrapNodes()

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -286,9 +286,9 @@ void Nexus::setProfile(Profile* p)
         emit profileLoadFailed();
         // Warnings are issued during respective createNew/load calls
         return;
-    } else {
-        emit profileLoaded();
     }
+    emit profileLoaded();
+
 
     emit currentProfileChanged(p);
 }

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -188,13 +188,11 @@ bool RawDatabase::openEncryptedDatabaseAtLatestSupportedVersion(const QString& h
             qInfo() << "Opened database with SQLCipher" << toString(highestSupportedVersion)
                     << "parameters";
             return true;
-        } else {
-            return updateSavedCipherParameters(hexKey, highestSupportedVersion);
         }
-    } else {
-        qCritical() << "Failed to set latest supported SQLCipher params!";
-        return false;
+        return updateSavedCipherParameters(hexKey, highestSupportedVersion);
     }
+    qCritical() << "Failed to set latest supported SQLCipher params!";
+    return false;
 }
 
 bool RawDatabase::testUsable()
@@ -891,17 +889,18 @@ QVariant RawDatabase::extractData(sqlite3_stmt* stmt, int col)
     int type = sqlite3_column_type(stmt, col);
     if (type == SQLITE_INTEGER) {
         return sqlite3_column_int64(stmt, col);
-    } else if (type == SQLITE_TEXT) {
+    }
+    if (type == SQLITE_TEXT) {
         const char* str = reinterpret_cast<const char*>(sqlite3_column_text(stmt, col));
         int len = sqlite3_column_bytes(stmt, col);
         return QString::fromUtf8(str, len);
-    } else if (type == SQLITE_NULL) {
-        return QVariant{};
-    } else {
-        const char* data = reinterpret_cast<const char*>(sqlite3_column_blob(stmt, col));
-        int len = sqlite3_column_bytes(stmt, col);
-        return QByteArray(data, len);
     }
+    if (type == SQLITE_NULL) {
+        return QVariant{};
+    }
+    const char* data = reinterpret_cast<const char*>(sqlite3_column_blob(stmt, col));
+    int len = sqlite3_column_bytes(stmt, col);
+    return QByteArray(data, len);
 }
 
 /**

--- a/src/persistence/db/upgrades/dbupgrader.cpp
+++ b/src/persistence/db/upgrades/dbupgrader.cpp
@@ -87,9 +87,8 @@ DuplicateAlias getDuplicateAliasRows(RawDatabase& db, RowId goodPeerRow, RowId b
 
     if (hasGoodEntry) {
         return {goodAliasRow, badAliasRows};
-    } else {
-        return {};
     }
+    return {};
 }
 
 void mergeAndDeleteAlias(QVector<RawDatabase::Query>& upgradeQueries, RowId goodAlias,
@@ -231,7 +230,8 @@ bool DbUpgrader::dbSchemaUpgrade(std::shared_ptr<RawDatabase>& db, IMessageBoxMa
                              << "). Please upgrade qTox";
         // We don't know what future versions have done, we have to disable db access until we re-upgrade
         return false;
-    } else if (databaseSchemaVersion == SCHEMA_VERSION) {
+    }
+    if (databaseSchemaVersion == SCHEMA_VERSION) {
         // No work to do
         return true;
     }

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -429,16 +429,15 @@ RawDatabase::Query History::generateFileFinished(RowId id, bool success, const Q
                 .arg(id.get()),
             QVector<QByteArray>{filePath.toUtf8(), fileHash},
         };
-    } else {
-        return {
-            QStringLiteral( //
-                "UPDATE file_transfers "
-                "SET file_state = %1 "
-                "WHERE id = %2")
-                .arg(file_state)
-                .arg(id.get()),
-        };
     }
+    return {
+        QStringLiteral( //
+            "UPDATE file_transfers "
+            "SET file_state = %1 "
+            "WHERE id = %2")
+            .arg(file_state)
+            .arg(id.get()),
+    };
 }
 
 void History::addNewFileMessage(const ChatId& chatId, const QByteArray& fileId,

--- a/src/persistence/profilelocker.cpp
+++ b/src/persistence/profilelocker.cpp
@@ -133,6 +133,5 @@ QString ProfileLocker::getCurLockName()
 {
     if (lockfile)
         return curLockName;
-    else
-        return {};
+    return {};
 }

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -119,12 +119,11 @@ int SettingsSerializer::beginReadArray(const QString& prefix)
         array = static_cast<int>(index - std::begin(arrays));
         arrayIndex = -1;
         return index->size;
-    } else {
-        array = arrays.size();
-        arrays.push_back({group, 0, prefix, {}});
-        arrayIndex = -1;
-        return 0;
     }
+    array = arrays.size();
+    arrays.push_back({group, 0, prefix, {}});
+    arrayIndex = -1;
+    return 0;
 }
 
 void SettingsSerializer::beginWriteArray(const QString& prefix, int size)
@@ -174,8 +173,7 @@ QVariant SettingsSerializer::value(const QString& key, const QVariant& defaultVa
     const Value* v = findValue(key);
     if (v)
         return v->value;
-    else
-        return defaultValue;
+    return defaultValue;
 }
 
 const SettingsSerializer::Value* SettingsSerializer::findValue(const QString& key) const
@@ -409,8 +407,7 @@ void SettingsSerializer::readIni()
             if (g.isEmpty()) {
                 if (gstack.isEmpty())
                     break;
-                else
-                    s.endGroup();
+                s.endGroup();
             } else {
                 s.beginGroup(g);
                 break;

--- a/src/platform/autorun_xdg.cpp
+++ b/src/platform/autorun_xdg.cpp
@@ -36,9 +36,8 @@ QString currentBinPath()
 
     if (env.contains(appImageEnvKey)) {
         return env.value(appImageEnvKey);
-    } else {
-        return QApplication::applicationFilePath();
     }
+    return QApplication::applicationFilePath();
 }
 
 inline QString profileRunCommand(const Settings& settings)
@@ -62,8 +61,8 @@ bool Platform::setAutorun(const Settings& settings, bool on)
         desktop.write("\n");
         desktop.close();
         return true;
-    } else
-        return desktop.remove();
+    }
+    return desktop.remove();
 }
 
 bool Platform::getAutorun(const Settings& settings)

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -493,9 +493,8 @@ AVFrame* VideoFrame::retrieveAVFrame(const QSize& dimensions, const int pixelFor
 
     if (frameBuffer.contains(frameKey)) {
         return frameBuffer[frameKey];
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 /**
@@ -610,11 +609,10 @@ AVFrame* VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const
         av_frame_free(&frame);
 
         return old_ret;
-    } else {
-        frameBuffer[frameKey] = frame;
-
-        return frame;
     }
+    frameBuffer[frameKey] = frame;
+
+    return frame;
 }
 
 /**

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -162,7 +162,8 @@ bool CategoryWidget::cycleChats(bool forward)
             setExpanded(true);
             emitChatroomWidget(listLayout->getLayoutOnline(), 0);
             return true;
-        } else if (!listLayout->getLayoutOffline()->isEmpty()) {
+        }
+        if (!listLayout->getLayoutOffline()->isEmpty()) {
             setExpanded(true);
             emitChatroomWidget(listLayout->getLayoutOffline(), 0);
             return true;
@@ -173,7 +174,8 @@ bool CategoryWidget::cycleChats(bool forward)
             emitChatroomWidget(listLayout->getLayoutOffline(),
                                listLayout->getLayoutOffline()->count() - 1);
             return true;
-        } else if (!listLayout->getLayoutOnline()->isEmpty()) {
+        }
+        if (!listLayout->getLayoutOnline()->isEmpty()) {
             setExpanded(true);
             emitChatroomWidget(listLayout->getLayoutOnline(),
                                listLayout->getLayoutOnline()->count() - 1);
@@ -210,7 +212,8 @@ bool CategoryWidget::cycleChats(FriendWidget* activeChatroomWidget, bool forward
 
             index = currentLayout->count() - 1;
             continue;
-        } else if (index >= currentLayout->count()) {
+        }
+        if (index >= currentLayout->count()) {
             if (currentLayout == listLayout->getLayoutOnline())
                 currentLayout = listLayout->getLayoutOffline();
             else

--- a/src/widget/conferencewidget.cpp
+++ b/src/widget/conferencewidget.cpp
@@ -167,9 +167,8 @@ QString ConferenceWidget::getStatusString() const
 {
     if (chatroom->hasNewMessage()) {
         return tr("New message");
-    } else {
-        return tr("Online");
     }
+    return tr("Online");
 }
 
 void ConferenceWidget::editName()

--- a/src/widget/flowlayout.cpp
+++ b/src/widget/flowlayout.cpp
@@ -42,18 +42,16 @@ int FlowLayout::horizontalSpacing() const
 {
     if (m_hSpace >= 0) {
         return m_hSpace;
-    } else {
-        return smartSpacing(QStyle::PM_LayoutHorizontalSpacing);
     }
+    return smartSpacing(QStyle::PM_LayoutHorizontalSpacing);
 }
 
 int FlowLayout::verticalSpacing() const
 {
     if (m_vSpace >= 0) {
         return m_vSpace;
-    } else {
-        return smartSpacing(QStyle::PM_LayoutVerticalSpacing);
     }
+    return smartSpacing(QStyle::PM_LayoutVerticalSpacing);
 }
 //! [4]
 
@@ -167,11 +165,11 @@ int FlowLayout::smartSpacing(QStyle::PixelMetric pm) const
     QObject* parent = this->parent();
     if (!parent) {
         return -1;
-    } else if (parent->isWidgetType()) {
+    }
+    if (parent->isWidgetType()) {
         QWidget* pw = static_cast<QWidget*>(parent);
         return pw->style()->pixelMetric(pm, nullptr, pw);
-    } else {
-        return static_cast<QLayout*>(parent)->spacing();
     }
+    return static_cast<QLayout*>(parent)->spacing();
 }
 //! [12]

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -524,9 +524,8 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr& chatLine) const
 
         if (timestamp) {
             return timestamp->getTime();
-        } else {
-            return {};
         }
+        return {};
     }
 
     return {};

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -465,7 +465,8 @@ void FriendListWidget::cycleChats(GenericChatroomWidget* activeChatroomWidget, b
             if (index < 0) {
                 index = LAST_TIME;
                 continue;
-            } else if (index > LAST_TIME) {
+            }
+            if (index > LAST_TIME) {
                 index = 0;
                 continue;
             }

--- a/src/widget/imagepreviewwidget.cpp
+++ b/src/widget/imagepreviewwidget.cpp
@@ -60,7 +60,8 @@ QPixmap scaleCropIntoSquare(const QPixmap& source, const int targetSize)
     // Only one dimension will be bigger after Qt::KeepAspectRatioByExpanding
     if (result.width() > targetSize) {
         return result.copy((result.width() - targetSize) / 2, 0, targetSize, targetSize);
-    } else if (result.height() > targetSize) {
+    }
+    if (result.height() > targetSize) {
         return result.copy(0, (result.height() - targetSize) / 2, targetSize, targetSize);
     }
 
@@ -79,9 +80,8 @@ QString getToolTipDisplayingImage(const QPixmap& image)
         if (image.width() > maxPreviewWidth || image.height() > maxPreviewHeight) {
             return image.scaled(maxPreviewWidth, maxPreviewHeight, Qt::KeepAspectRatio,
                                 Qt::SmoothTransformation);
-        } else {
-            return image;
         }
+        return image;
     }();
 
     QByteArray imageData;

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -167,7 +167,7 @@ NotificationScrollArea::Visibility NotificationScrollArea::widgetVisible(QWidget
 
     if (y < 0)
         return Above;
-    else if (y + widget->height() - 1 > viewport()->height())
+    if (y + widget->height() - 1 > viewport()->height())
         return Below;
 
     return Visible;

--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -195,18 +195,16 @@ const QString Style::getImagePath(const QString& filename, int themeColor)
     if (QFileInfo::exists(fullPath)) {
         existingImagesCache << fullPath;
         return fullPath;
-    } else {
-        qWarning() << "Failed to open file (using defaults):" << fullPath;
-
-        fullPath = getThemePath(themeColor) % filename;
-
-        if (QFileInfo::exists(fullPath)) {
-            return fullPath;
-        } else {
-            qWarning() << "Failed to open default file:" << fullPath;
-            return {};
-        }
     }
+    qWarning() << "Failed to open file (using defaults):" << fullPath;
+
+    fullPath = getThemePath(themeColor) % filename;
+
+    if (QFileInfo::exists(fullPath)) {
+        return fullPath;
+    }
+    qWarning() << "Failed to open default file:" << fullPath;
+    return {};
 }
 
 QColor Style::getColor(ColorPalette entry)

--- a/src/widget/tool/messageboxmanager.cpp
+++ b/src/widget/tool/messageboxmanager.cpp
@@ -77,14 +77,13 @@ bool MessageBoxManager::askQuestion(const QString& title, const QString& msg, bo
 {
     if (QThread::currentThread() == qApp->thread()) {
         return _askQuestion(title, msg, defaultAns, warning, yesno);
-    } else {
-        bool ret;
-        QMetaObject::invokeMethod(this, "_askQuestion", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret), Q_ARG(const QString&, title),
-                                  Q_ARG(const QString&, msg), Q_ARG(bool, defaultAns),
-                                  Q_ARG(bool, warning), Q_ARG(bool, yesno));
-        return ret;
     }
+    bool ret;
+    QMetaObject::invokeMethod(this, "_askQuestion", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(bool, ret), Q_ARG(const QString&, title),
+                              Q_ARG(const QString&, msg), Q_ARG(bool, defaultAns),
+                              Q_ARG(bool, warning), Q_ARG(bool, yesno));
+    return ret;
 }
 
 /**
@@ -104,14 +103,13 @@ bool MessageBoxManager::askQuestion(const QString& title, const QString& msg, co
 {
     if (QThread::currentThread() == qApp->thread()) {
         return _askQuestion(title, msg, button1, button2, defaultAns, warning);
-    } else {
-        bool ret;
-        QMetaObject::invokeMethod(this, "_askQuestion", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret), Q_ARG(const QString&, title),
-                                  Q_ARG(const QString&, msg), Q_ARG(bool, defaultAns),
-                                  Q_ARG(bool, warning));
-        return ret;
     }
+    bool ret;
+    QMetaObject::invokeMethod(this, "_askQuestion", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(bool, ret), Q_ARG(const QString&, title),
+                              Q_ARG(const QString&, msg), Q_ARG(bool, defaultAns),
+                              Q_ARG(bool, warning));
+    return ret;
 }
 
 void MessageBoxManager::confirmExecutableOpen(const QFileInfo& file)

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2542,11 +2542,11 @@ Widget::FilterCriteria Widget::getFilterCriteria() const
 
     if (checked == filterOnlineAction)
         return FilterCriteria::Online;
-    else if (checked == filterOfflineAction)
+    if (checked == filterOfflineAction)
         return FilterCriteria::Offline;
-    else if (checked == filterFriendsAction)
+    if (checked == filterFriendsAction)
         return FilterCriteria::Friends;
-    else if (checked == filterGroupsAction)
+    if (checked == filterGroupsAction)
         return FilterCriteria::Conferences;
 
     return FilterCriteria::All;


### PR DESCRIPTION
```sh
run-clang-tidy -p _build -fix $(find . -name "*.h" -or -name "*.cpp" \
-or -name "*.c" | grep -v "/_build/") \
-checks="-*,readability-else-after-return"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/86)
<!-- Reviewable:end -->
