### PR TITLE
cleanup: Remove redundant base initialisers.

### DIFF
--- a/src/core/chatid.cpp
+++ b/src/core/chatid.cpp
@@ -12,10 +12,7 @@
 /**
  * @brief The default constructor. Creates an empty id.
  */
-ChatId::ChatId()
-    : id()
-{
-}
+ChatId::ChatId() {}
 ChatId::~ChatId() = default;
 
 /**

--- a/src/core/groupid.cpp
+++ b/src/core/groupid.cpp
@@ -18,10 +18,7 @@
 /**
  * @brief The default constructor. Creates an empty Tox group ID.
  */
-GroupId::GroupId()
-    : ChatId()
-{
-}
+GroupId::GroupId() {}
 
 /**
  * @brief Constructs a GroupId from bytes.

--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -36,10 +36,7 @@ const QRegularExpression
 /**
  * @brief The default constructor. Creates an empty Tox ID.
  */
-ToxId::ToxId()
-    : toxId()
-{
-}
+ToxId::ToxId() {}
 
 /**
  * @brief The copy constructor.

--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -19,10 +19,7 @@
 /**
  * @brief The default constructor. Creates an empty Tox key.
  */
-ToxPk::ToxPk()
-    : ChatId()
-{
-}
+ToxPk::ToxPk() {}
 
 /**
  * @brief Constructs a ToxPk from bytes.

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -81,8 +81,6 @@ CameraSource::CameraSource(Settings& settings_)
     : deviceThread{new QThread}
     , deviceName{"none"}
     , device{nullptr}
-    , mode(VideoMode())
-    // clang-format off
     , cctx{nullptr}
 #if LIBAVCODEC_VERSION_INT < 3747941
     , cctxOrig{nullptr}
@@ -105,8 +103,6 @@ CameraSource::CameraSource(Settings& settings_)
 #endif
     avdevice_register_all();
 }
-
-// clang-format on
 
 /**
  * @brief Setup default device

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -46,7 +46,6 @@ ContentDialog::ContentDialog(const Core& core, Settings& settings_, Style& style
     , splitter{new QSplitter(this)}
     , friendLayout{new FriendListLayout(this)}
     , activeChatroomWidget(nullptr)
-    , videoSurfaceSize(QSize())
     , videoCount(0)
     , settings{settings_}
     , style{style_}

--- a/src/widget/contentlayout.cpp
+++ b/src/widget/contentlayout.cpp
@@ -10,8 +10,7 @@
 #include <QStyleFactory>
 
 ContentLayout::ContentLayout(Settings& settings_, Style& style_)
-    : QVBoxLayout()
-    , settings{settings_}
+    : settings{settings_}
     , style{style_}
 {
     init();

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -413,8 +413,7 @@ View::~View() = default;
 
 FilesForm::FilesForm(CoreFile& coreFile, Settings& settings, Style& style,
                      IMessageBoxManager& messageBoxManager_, FriendList& friendList)
-    : QObject()
-    , messageBoxManager{messageBoxManager_}
+    : messageBoxManager{messageBoxManager_}
 {
     head = new QWidget();
     QFont bold;

--- a/src/widget/friendlistlayout.cpp
+++ b/src/widget/friendlistlayout.cpp
@@ -12,7 +12,7 @@
 #include <cassert>
 
 FriendListLayout::FriendListLayout()
-    : QVBoxLayout()
+
 {
     init();
 }

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -37,8 +37,7 @@
  */
 
 CallConfirmWidget::CallConfirmWidget(Settings& settings, Style& style, const QWidget* anchor_)
-    : QWidget()
-    , anchor(anchor_)
+    : anchor(anchor_)
     , rectW{120}
     , rectH{85}
     , spikeW{30}

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -21,8 +21,7 @@
 #include "src/widget/widget.h"
 
 ScreenshotGrabber::ScreenshotGrabber()
-    : QObject()
-    , mKeysBlocked(false)
+    : mKeysBlocked(false)
     , scene(nullptr)
     , mQToxVisible(true)
 {

--- a/test/chatlog/chatlinestorage_test.cpp
+++ b/test/chatlog/chatlinestorage_test.cpp
@@ -11,8 +11,7 @@ class IdxChatLine : public ChatLine
 {
 public:
     explicit IdxChatLine(ChatLogIdx idx_)
-        : ChatLine()
-        , idx(idx_)
+        : idx(idx_)
     {
     }
 
@@ -29,8 +28,7 @@ class TimestampChatLine : public ChatLine
 {
 public:
     explicit TimestampChatLine(QDateTime dateTime)
-        : ChatLine()
-        , timestamp(dateTime)
+        : timestamp(dateTime)
     {
     }
 


### PR DESCRIPTION
Also some unnecessary member initialisers.

```sh
run-clang-tidy -p _build -fix \
  $(find . -name "*.h" -or -name "*.cpp" -or -name "*.c" | grep -v "/_build/") \
  -checks="-*,readability-redundant-member-init"
```