### PR TITLE
cleanup: Use raw strings to simplify regexes.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: "-*
 , modernize-make-shared
 , modernize-make-unique
 , modernize-pass-by-value
+, modernize-raw-string-literal
 , modernize-return-braced-init-list
 , modernize-use-bool-literals
 , modernize-use-emplace

--- a/src/model/message.cpp
+++ b/src/model/message.cpp
@@ -44,11 +44,13 @@ QStringList splitMessage(const QString& message, uint64_t maxLength)
 void MessageProcessor::SharedParams::onUserNameSet(const QString& username)
 {
     QString sanitizedName = username;
-    sanitizedName.remove(QRegularExpression("[\\t\\n\\v\\f\\r\\x0000]"));
-    nameMention = QRegularExpression("\\b" + QRegularExpression::escape(username) + "\\b",
-                                     QRegularExpression::CaseInsensitiveOption);
-    sanitizedNameMention = QRegularExpression("\\b" + QRegularExpression::escape(sanitizedName) + "\\b",
-                                              QRegularExpression::CaseInsensitiveOption);
+    sanitizedName.remove(QRegularExpression(QStringLiteral(R"([\t\n\v\f\r\x0000])")));
+    nameMention =
+        QRegularExpression(QStringLiteral(R"(\b%1\b)").arg(QRegularExpression::escape(username)),
+                           QRegularExpression::CaseInsensitiveOption);
+    sanitizedNameMention =
+        QRegularExpression(QStringLiteral(R"(\b%1\b)").arg(QRegularExpression::escape(sanitizedName)),
+                           QRegularExpression::CaseInsensitiveOption);
 }
 
 /**

--- a/src/widget/form/tabcompleter.cpp
+++ b/src/widget/form/tabcompleter.cpp
@@ -48,9 +48,10 @@ void TabCompleter::buildCompletionList()
 
     // split the string on the given RE (not chars, nums or braces/brackets) and take the last
     // section
-    const QString tabAbbrev = msgEdit->toPlainText()
-                                  .left(msgEdit->textCursor().position())
-                                  .section(QRegularExpression(R"([^\w\d\$:@_\[\]{}|`^.\\-])"), -1, -1);
+    const QString tabAbbrev =
+        msgEdit->toPlainText()
+            .left(msgEdit->textCursor().position())
+            .section(QRegularExpression(QStringLiteral(R"([^\w\d\$:@_\[\]{}|`^.\\-])")), -1, -1);
     // that section is then used as the completion regex
     const QRegularExpression regex(QStringLiteral(R"(^[-_\[\]{}|`^.\\]*)")
                                        .append(QRegularExpression::escape(tabAbbrev)),

--- a/src/widget/tool/croppinglabel.cpp
+++ b/src/widget/tool/croppinglabel.cpp
@@ -165,7 +165,7 @@ void CroppingLabel::editingFinished()
 {
     hideTextEdit();
     const QString newText =
-        textEdit->text().trimmed().remove(QRegularExpression("[\\t\\n\\v\\f\\r\\x0000]"));
+        textEdit->text().trimmed().remove(QRegularExpression(QStringLiteral(R"([\t\n\v\f\r\x0000])")));
 
     if (origText != newText)
         emit editFinished(textEdit->text());


### PR DESCRIPTION
clang-tidy: modernize-raw-string-literal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/88)
<!-- Reviewable:end -->
