### PR TITLE
cleanup: Use `true`/`false` instead of `0`/`1` for boolean literals.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 Checks: "-*
+, modernize-use-bool-literals
 , modernize-use-emplace
 , readability-named-parameter
 , readability-inconsistent-declaration-parameter-name

--- a/src/core/toxfile.h
+++ b/src/core/toxfile.h
@@ -33,8 +33,8 @@ struct ToxFile
     // current form (can add fields though as db representation is an int)
     enum FileDirection : bool
     {
-        SENDING = 0,
-        RECEIVING = 1,
+        SENDING = false,
+        RECEIVING = true,
     };
 
     ToxFile();

--- a/src/model/conference.cpp
+++ b/src/model/conference.cpp
@@ -34,8 +34,8 @@ Conference::Conference(int conferenceId_, const ConferenceId persistentConferenc
     // in conferences, we only notify on messages containing your name <-- dumb
     // sound notifications should be on all messages, but system popup notification
     // on naming is appropriate
-    hasNewMessages = 0;
-    userWasMentioned = 0;
+    hasNewMessages = false;
+    userWasMentioned = false;
     regeneratePeerList();
 }
 

--- a/src/model/exiftransform.cpp
+++ b/src/model/exiftransform.cpp
@@ -62,24 +62,24 @@ QImage applyTransformation(QImage image, Orientation orientation)
     case Orientation::TopLeft:
         break;
     case Orientation::TopRight:
-        image = image.mirrored(1, 0);
+        image = image.mirrored(true, false);
         break;
     case Orientation::BottomRight:
         exifTransform.rotate(180);
         break;
     case Orientation::BottomLeft:
-        image = image.mirrored(0, 1);
+        image = image.mirrored(false, true);
         break;
     case Orientation::LeftTop:
         exifTransform.rotate(-90);
-        image = image.mirrored(1, 0);
+        image = image.mirrored(true, false);
         break;
     case Orientation::RightTop:
         exifTransform.rotate(90);
         break;
     case Orientation::RightBottom:
         exifTransform.rotate(90);
-        image = image.mirrored(1, 0);
+        image = image.mirrored(true, false);
         break;
     case Orientation::LeftBottom:
         exifTransform.rotate(-90);


### PR DESCRIPTION
clang-tidy: modernize-use-bool-literals

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/91)
<!-- Reviewable:end -->
