### PR TITLE
cleanup: Fix typo "groupOnlyNotfiyWhenMentioned"

### DIFF
--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -64,8 +64,8 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
 
     bodyUI->notify->setChecked(settings.getNotify());
     // Note: UI is boolean inversed from settings to maintain setting file backwards compatibility
-    bodyUI->groupOnlyNotfiyWhenMentioned->setChecked(!settings.getGroupAlwaysNotify());
-    bodyUI->groupOnlyNotfiyWhenMentioned->setEnabled(settings.getNotify());
+    bodyUI->groupOnlyNotifyWhenMentioned->setChecked(!settings.getGroupAlwaysNotify());
+    bodyUI->groupOnlyNotifyWhenMentioned->setEnabled(settings.getNotify());
     bodyUI->notifySound->setChecked(settings.getNotifySound());
     bodyUI->notifyHide->setChecked(settings.getNotifyHide());
     bodyUI->notifySound->setEnabled(settings.getNotify());
@@ -262,7 +262,7 @@ void UserInterfaceForm::on_notify_stateChanged()
 {
     const bool notify = bodyUI->notify->isChecked();
     settings.setNotify(notify);
-    bodyUI->groupOnlyNotfiyWhenMentioned->setEnabled(notify);
+    bodyUI->groupOnlyNotifyWhenMentioned->setEnabled(notify);
     bodyUI->notifySound->setEnabled(notify);
     bodyUI->busySound->setEnabled(notify && bodyUI->notifySound->isChecked());
     bodyUI->desktopNotify->setEnabled(notify);
@@ -291,10 +291,10 @@ void UserInterfaceForm::on_showWindow_stateChanged()
     settings.setShowWindow(bodyUI->showWindow->isChecked());
 }
 
-void UserInterfaceForm::on_groupOnlyNotfiyWhenMentioned_stateChanged()
+void UserInterfaceForm::on_groupOnlyNotifyWhenMentioned_stateChanged()
 {
     // Note: UI is boolean inversed from settings to maintain setting file backwards compatibility
-    settings.setGroupAlwaysNotify(!bodyUI->groupOnlyNotfiyWhenMentioned->isChecked());
+    settings.setGroupAlwaysNotify(!bodyUI->groupOnlyNotifyWhenMentioned->isChecked());
 }
 
 void UserInterfaceForm::on_cbCompactLayout_stateChanged()

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -43,7 +43,7 @@ private slots:
     void on_notifyHide_stateChanged(int value);
     void on_busySound_stateChanged();
     void on_showWindow_stateChanged();
-    void on_groupOnlyNotfiyWhenMentioned_stateChanged();
+    void on_groupOnlyNotifyWhenMentioned_stateChanged();
     void on_cbCompactLayout_stateChanged();
     void on_cbSeparateWindow_stateChanged();
     void on_cbDontGroupWindows_stateChanged();

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -184,7 +184,7 @@
              <number>40</number>
             </property>
             <item>
-             <widget class="QCheckBox" name="groupOnlyNotfiyWhenMentioned">
+             <widget class="QCheckBox" name="groupOnlyNotifyWhenMentioned">
               <property name="toolTip">
                <string comment="toolTip for Group chats only notify when mentioned">Only notify about new messages in group chats when mentioned.</string>
               </property>
@@ -615,7 +615,7 @@
   <tabstop>txtChatFontSize</tabstop>
   <tabstop>textStyleComboBox</tabstop>
   <tabstop>notify</tabstop>
-  <tabstop>groupOnlyNotfiyWhenMentioned</tabstop>
+  <tabstop>groupOnlyNotifyWhenMentioned</tabstop>
   <tabstop>notifySound</tabstop>
   <tabstop>busySound</tabstop>
   <tabstop>showWindow</tabstop>


### PR DESCRIPTION
Found this typo while changing "group" to "conference" in #92.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/93)
<!-- Reviewable:end -->
