### PR TITLE
fix: Don't create huge font weights in themes.

### DIFF
--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -64,7 +64,7 @@ QFont appFont(int pixelSize, QFont::Weight weight)
 
 QString qssifyFont(QFont font)
 {
-    return QString("%1 %2px \"%3\"").arg(font.weight() * 8).arg(font.pixelSize()).arg(font.family());
+    return QString("%1 %2px \"%3\"").arg(font.weight()).arg(font.pixelSize()).arg(font.family());
 }
 
 using MainTheme = Style::MainTheme;


### PR DESCRIPTION
This multiplication used to be necessary, but isn't anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/95)
<!-- Reviewable:end -->
