### PR TITLE
fix: Don't show unicode replacement boxes on unsupported languages.

### DIFF
--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -19,7 +19,7 @@ class GeneralForm : public GenericForm
 {
     Q_OBJECT
 public:
-    GeneralForm(SettingsWidget* parent, Settings& settings, Style& style);
+    GeneralForm(Settings& settings, Style& style);
     ~GeneralForm();
     QString getFormName() final
     {
@@ -49,7 +49,6 @@ private:
     void retranslateUi();
 
 private:
-    Ui::GeneralSettings* bodyUI;
-    SettingsWidget* parent;
+    const std::unique_ptr<Ui::GeneralSettings> bodyUI;
     Settings& settings;
 };

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -45,7 +45,7 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, C
     settingsWidgets->setTabPosition(QTabWidget::North);
     bodyLayout->addWidget(settingsWidgets.get());
 
-    std::unique_ptr<GeneralForm> gfrm(new GeneralForm(this, settings, style));
+    std::unique_ptr<GeneralForm> gfrm(new GeneralForm(settings, style));
     connect(gfrm.get(), &GeneralForm::updateIcons, parent, &Widget::updateIcons);
 
     std::unique_ptr<UserInterfaceForm> uifrm(new UserInterfaceForm(smileyPack, settings, style, this));

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -1083,6 +1083,10 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translation>عام</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -1087,6 +1087,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Выбраць каталог для аўтаматычна прынятых файлаў</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -1085,6 +1085,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Изберете папка за автоматично приемане</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -1082,6 +1082,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -1085,6 +1085,10 @@ takže můžete soubor uložit i v systému Windows.</translation>
         <source>General</source>
         <translation>Obecné</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -1085,6 +1085,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -1091,6 +1091,10 @@ um sie in Windows speichern zu können.</translation>
         <comment>popup title</comment>
         <translation>Speicherort für empfangenen Dateien wählen</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -1079,6 +1079,10 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translation>Γενικά</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -1075,6 +1075,10 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -1085,6 +1085,10 @@ para que puedas guardar el archivo en windows.</translation>
         <comment>popup title</comment>
         <translation>Elige un directorio para transferencias automáticas</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -1085,6 +1085,10 @@ ja sa saad seda faili nüüd Windowsis salvestada.</translation>
         <source>General</source>
         <translation>Üldine</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -1085,6 +1085,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>یک پوشه برای دریافت فایلها به شکل خودکار انتخاب کنید</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -1084,6 +1084,10 @@ joten voit tallentaa tiedoston Windowsissa.</translation>
         <comment>popup title</comment>
         <translation>Valitse hakemisto automaattisesti hyväksyttäville tiedostoille</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -1084,6 +1084,10 @@ afin que vous puissiez enregistrer le fichier sur windows.</translation>
         <comment>popup title</comment>
         <translation>Sélectionner un répertoire d&apos;acceptation automatique</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -1086,6 +1086,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Elixa un cartafol para aceptados automáticamente</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -1082,6 +1082,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -1080,6 +1080,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Odaberi direktorij za automatsko prihvaćanje</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -1078,6 +1078,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Válasszon egy mappát az automatikus elfogadáshoz</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -1082,6 +1082,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -1084,6 +1084,10 @@ in modo da poter salvare il file su Windows.</translation>
         <comment>popup title</comment>
         <translation>Scegli dove salvare i file accettati automaticamente</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -1078,6 +1078,10 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translation>一般</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -1082,6 +1082,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -1085,6 +1085,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished">자동받기 폴더 선택</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -1085,6 +1085,10 @@ tad dabar galite įrašyti failą Windows sistemoje.</translation>
         <comment>popup title</comment>
         <translation>Pasirinkite priimamų failų katalogą</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -1092,6 +1092,10 @@ lai varētu saglabāt failus Windows operētājsistēmā.</translation>
         <comment>popup title</comment>
         <translation>Izvēlieties automātiskās pieņemšanas mapi</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -1087,6 +1087,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Изберете папка за автоматско прифаќање</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -1079,6 +1079,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Kies een map om automatisch aanvaarde bestanden op te slaan</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -1086,6 +1086,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Kies een map voor automatisch aanvaarde bestanden in op te slaan</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -1086,6 +1086,10 @@ slik at du kan lagre filen på Windows.</translation>
         <comment>popup title</comment>
         <translation>Velg en mappe for auto-aksepterte filer</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -1096,6 +1096,10 @@ więc możesz zapisać ten plik na systemie Windows.</translation>
         <translatorcomment>better translation?</translatorcomment>
         <translation>Wybierz domyślną ścieżkę dla plików</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -1084,6 +1084,10 @@ de forma que possa guardar o ficheiro no Windows.</translation>
         <comment>popup title</comment>
         <translation>Escolher uma pasta para onde aceitar ficheiros automaticamente</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -1091,6 +1091,10 @@ de forma que você possa salvar o arquivo no Windows.</translation>
         <comment>popup title</comment>
         <translation>Escolher um diretório para aceitar arquivos automaticamente</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -1092,6 +1092,10 @@ astfel încât să puteți salva fișierul pe Windows.</translation>
         <comment>popup title</comment>
         <translation>Alegeți un director de acceptare automată</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -1088,6 +1088,10 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translation>Общие</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -1082,6 +1082,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -1092,6 +1092,10 @@ so you can save the file on Windows.</translation>
         <comment>popup title</comment>
         <translation>Zvoľte priečinok pre automatické prijímanie</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -1081,6 +1081,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Izberi mapo za avtomatsko sprejemanje datotek</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -1082,6 +1082,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -1087,6 +1087,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Изаберите фасциклу за самостални пријем</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -1088,6 +1088,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Izaberite fasciklu za automatski prijem</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -1085,6 +1085,10 @@ så att du kan spara filen i Windows.</translation>
         <comment>popup title</comment>
         <translation>Välj en acceptera-automatiskt-katalog</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -1082,6 +1082,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -1087,6 +1087,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished">தன்னிச்சையேற்புக்கான கோப்பகத்தைத் தேர்வு செய்க</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -1087,6 +1087,10 @@ geçersiz karakterler _ olarak değiştirildi.</translation>
         <source>General</source>
         <translation>Genel</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -1086,6 +1086,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>قۇبۇل قىلىش مۇندەرىجىسى تاللاڭ</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -1080,6 +1080,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Оберіть теку, для автоматичного отримання файлів</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -1090,6 +1090,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -1090,6 +1090,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>Chọn một thư mục tự động chấp nhận</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1083,6 +1083,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation>选择默认接收目录</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -1085,6 +1085,10 @@ so you can save the file on Windows.</source>
         <comment>popup title</comment>
         <translation type="unfinished">選擇自動接受目錄</translation>
     </message>
+    <message>
+        <source>%1 (no fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSettings</name>


### PR DESCRIPTION
Instead, show the language in English and say "(no fonts)".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/97)
<!-- Reviewable:end -->
