### PR TITLE
chore: Give Cirrus more CPUs to build qtox.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ bazel-opt_task:
   timeout_in: 10m
   container:
     image: toxchat/toktok-stack:latest-release
-    cpu: 2
+    cpu: 8
     memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo qtox
@@ -11,5 +11,5 @@ bazel-opt_task:
     - cd /src/workspace && bazel
         --max_idle_secs=5
         test -k
-        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        --remote_cache=http://$CIRRUS_HTTP_CACHE_HOST
         //qtox/...


### PR DESCRIPTION
We have 16 in total (8 can be used at the same time). This means that now we can only build 2 qtox PRs at the same time, but hopefully they will finish faster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/100)
<!-- Reviewable:end -->
