### PR TITLE
chore: Use separate cache keys for the jobs using ccache.

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -301,6 +301,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Fetch build scripts
         run: git clone --depth=1 https://github.com/TokTok/dockerfiles ".ci-scripts/dockerfiles"
       - name: Homebrew dependencies to build dependencies
@@ -358,6 +360,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Fetch build scripts
         run: git clone --depth=1 https://github.com/TokTok/dockerfiles ".ci-scripts/dockerfiles"
       - name: Homebrew


### PR DESCRIPTION
They overwrite each other without this, causing one job to never have a cache and always missing every cache lookup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/107)
<!-- Reviewable:end -->
