### PR TITLE
cleanup: Make filesform.h and toxuri.cpp parseable by Linguist.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,7 @@ set(${PROJECT_NAME}_SOURCES
   src/widget/form/chatform.h
   src/widget/form/filesform.cpp
   src/widget/form/filesform.h
+  src/widget/form/filetransferlist.h
   src/widget/form/genericchatform.cpp
   src/widget/form/genericchatform.h
   src/widget/form/conferenceform.cpp

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -70,6 +70,7 @@ qt_moc(
         "widget/form/conferenceinviteform.h",
         "widget/form/conferenceinvitewidget.h",
         "widget/form/filesform.h",
+        "widget/form/filetransferlist.h",
         "widget/form/genericchatform.h",
         "widget/form/loadhistorydialog.h",
         "widget/form/profileform.h",

--- a/src/net/toxuri.cpp
+++ b/src/net/toxuri.cpp
@@ -3,7 +3,8 @@
  * Copyright © 2024 The TokTok team.
  */
 
-#include "src/net/toxuri.h"
+#include "toxuri.h"
+
 #include "src/core/core.h"
 #include "src/widget/tool/imessageboxmanager.h"
 #include <QByteArray>

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "filesform.h"
+
 #include "src/core/corefile.h"
 #include "src/core/toxfile.h"
 #include "src/friendlist.h"

--- a/src/widget/form/filesform.h
+++ b/src/widget/form/filesform.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "src/core/toxfile.h"
+#include "src/widget/form/filetransferlist.h"
 
 #include <QAbstractTableModel>
 #include <QHash>
@@ -25,82 +26,6 @@ class QFileInfo;
 class QTableView;
 class Settings;
 class Style;
-
-namespace FileTransferList {
-
-enum class Column : int
-{
-    // NOTE: Order defines order in UI
-    fileName,
-    contact,
-    progress,
-    size,
-    speed,
-    status,
-    control,
-    invalid
-};
-
-Column toFileTransferListColumn(int in);
-QString toQString(Column column);
-
-enum class EditorAction : int
-{
-    pause,
-    cancel,
-    invalid,
-};
-
-EditorAction toEditorAction(int in);
-
-class Model : public QAbstractTableModel
-{
-    Q_OBJECT
-public:
-    Model(FriendList& friendList, QObject* parent = nullptr);
-    ~Model() = default;
-
-    void onFileUpdated(const ToxFile& file);
-
-    QVariant headerData(int section, Qt::Orientation orientation,
-                        int role = Qt::DisplayRole) const override;
-    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
-    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
-    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
-
-signals:
-    void togglePause(ToxFile file);
-    void cancel(ToxFile file);
-
-private:
-    QHash<QByteArray /*file id*/, int /*row index*/> idToRow;
-    std::vector<ToxFile> files;
-    FriendList& friendList;
-};
-
-class Delegate : public QStyledItemDelegate
-{
-public:
-    Delegate(Settings& settings, Style& style, QWidget* parent = nullptr);
-    void paint(QPainter* painter, const QStyleOptionViewItem& option,
-               const QModelIndex& index) const override;
-
-    bool editorEvent(QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option,
-                     const QModelIndex& index) override;
-
-private:
-    Settings& settings;
-    Style& style;
-};
-
-class View : public QTableView
-{
-public:
-    View(QAbstractItemModel* model, Settings& settings, Style& style, QWidget* parent = nullptr);
-    ~View();
-};
-} // namespace FileTransferList
 
 class FilesForm : public QObject
 {

--- a/src/widget/form/filetransferlist.h
+++ b/src/widget/form/filetransferlist.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "src/core/toxfile.h"
+
+#include <QAbstractTableModel>
+#include <QStyledItemDelegate>
+#include <QTableView>
+
+class FriendList;
+class Settings;
+class Style;
+
+namespace FileTransferList {
+
+enum class Column : int
+{
+    // NOTE: Order defines order in UI
+    fileName,
+    contact,
+    progress,
+    size,
+    speed,
+    status,
+    control,
+    invalid
+};
+
+Column toFileTransferListColumn(int in);
+QString toQString(Column column);
+
+enum class EditorAction : int
+{
+    pause,
+    cancel,
+    invalid,
+};
+
+EditorAction toEditorAction(int in);
+
+class Model : public QAbstractTableModel
+{
+    Q_OBJECT
+public:
+    Model(FriendList& friendList, QObject* parent = nullptr);
+    ~Model() = default;
+
+    void onFileUpdated(const ToxFile& file);
+
+    QVariant headerData(int section, Qt::Orientation orientation,
+                        int role = Qt::DisplayRole) const override;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
+
+signals:
+    void togglePause(ToxFile file);
+    void cancel(ToxFile file);
+
+private:
+    QHash<QByteArray /*file id*/, int /*row index*/> idToRow;
+    std::vector<ToxFile> files;
+    FriendList& friendList;
+};
+
+class Delegate : public QStyledItemDelegate
+{
+public:
+    Delegate(Settings& settings, Style& style, QWidget* parent = nullptr);
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override;
+
+    bool editorEvent(QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option,
+                     const QModelIndex& index) override;
+
+private:
+    Settings& settings;
+    Style& style;
+};
+
+class View : public QTableView
+{
+public:
+    View(QAbstractItemModel* model, Settings& settings, Style& style, QWidget* parent = nullptr);
+    ~View();
+};
+} // namespace FileTransferList


### PR DESCRIPTION
This fixes some warnings we get from the translation string updater.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/111)
<!-- Reviewable:end -->
