### PR TITLE
cleanup: Avoid logging QString as format.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -513,12 +513,12 @@ void Core::onConferenceInvite(Tox* tox, uint32_t friendId, Tox_Conference_Type t
     const ConferenceInvite inviteInfo(friendId, type, data);
     switch (type) {
     case TOX_CONFERENCE_TYPE_TEXT:
-        qDebug() << QString("Text conference invite by %1").arg(friendId);
+        qDebug() << "Text conference invite by" << friendId;
         emit core->conferenceInviteReceived(inviteInfo);
         break;
 
     case TOX_CONFERENCE_TYPE_AV:
-        qDebug() << QString("AV conference invite by %1").arg(friendId);
+        qDebug() << "AV conference invite by" << friendId;
         emit core->conferenceInviteReceived(inviteInfo);
         break;
 
@@ -541,7 +541,7 @@ void Core::onConferencePeerListChange(Tox* tox, uint32_t conferenceId, void* vCo
 {
     std::ignore = tox;
     const auto core = static_cast<Core*>(vCore);
-    qDebug() << QString("Conference %1 peerlist changed").arg(conferenceId);
+    qDebug("Conference %d peerlist changed", conferenceId);
     // no saveRequest, this callback is called on every connection to conference peer, not just on brand new peers
     emit core->conferencePeerlistChanged(conferenceId);
 }
@@ -551,7 +551,7 @@ void Core::onConferencePeerNameChange(Tox* tox, uint32_t conferenceId, uint32_t 
 {
     std::ignore = tox;
     const auto newName = ToxString(name, length).getQString();
-    qDebug() << QString("Conference %1, peer %2, name changed to %3").arg(conferenceId).arg(peerId).arg(newName);
+    qDebug().nospace() << "Conference " << conferenceId << ", peer " << peerId << ", name " << newName;
     auto* core = static_cast<Core*>(vCore);
     auto peerPk = core->getConferencePeerPk(conferenceId, peerId);
     emit core->conferencePeerNameChanged(conferenceId, peerPk, newName);
@@ -1189,7 +1189,7 @@ uint32_t Core::joinConference(const ConferenceInvite& inviteInfo)
     uint32_t conferenceNum{std::numeric_limits<uint32_t>::max()};
     switch (confType) {
     case TOX_CONFERENCE_TYPE_TEXT: {
-        qDebug() << QString("Trying to accept invite for text conference sent by friend %1").arg(friendId);
+        qDebug() << "Trying to accept invite for text conference sent by friend" << friendId;
         Tox_Err_Conference_Join error;
         conferenceNum = tox_conference_join(tox.get(), friendId, cookie, cookieLength, &error);
         if (!PARSE_ERR(error)) {
@@ -1198,7 +1198,7 @@ uint32_t Core::joinConference(const ConferenceInvite& inviteInfo)
         break;
     }
     case TOX_CONFERENCE_TYPE_AV: {
-        qDebug() << QString("Trying to join AV conference invite sent by friend %1").arg(friendId);
+        qDebug() << "Trying to join AV conference invite sent by friend" << friendId;
         conferenceNum = toxav_join_av_groupchat(tox.get(), friendId, cookie, cookieLength,
                                                 CoreAV::conferenceCallCallback, this);
         break;

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -243,7 +243,7 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
     QWriteLocker locker{&callsLock};
     QMutexLocker<QRecursiveMutex> coreLocker{&coreLock};
 
-    qDebug() << QString("Answering call %1").arg(friendNum);
+    qDebug() << "Answering call" << friendNum;
     auto it = calls.find(friendNum);
     assert(it != calls.end());
     Toxav_Err_Answer err;
@@ -267,7 +267,7 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
     QWriteLocker locker{&callsLock};
     QMutexLocker<QRecursiveMutex> coreLocker{&coreLock};
 
-    qDebug() << QString("Starting call with %1").arg(friendNum);
+    qDebug() << "Starting call with" << friendNum;
     auto it = calls.find(friendNum);
     if (it != calls.end()) {
         qWarning() << QString("Can't start call with %1, we're already in this call!").arg(friendNum);
@@ -297,7 +297,7 @@ bool CoreAV::cancelCall(uint32_t friendNum)
     QWriteLocker locker{&callsLock};
     QMutexLocker<QRecursiveMutex> coreLocker{&coreLock};
 
-    qDebug() << QString("Cancelling call with %1").arg(friendNum);
+    qDebug() << "Cancelling call with" << friendNum;
     Toxav_Err_Call_Control err;
     toxav_call_control(toxav.get(), friendNum, TOXAV_CALL_CONTROL_CANCEL, &err);
     if (!PARSE_ERR(err)) {
@@ -548,7 +548,7 @@ void CoreAV::joinConferenceCall(const Conference& conference)
 {
     QWriteLocker locker{&callsLock};
 
-    qDebug() << QString("Joining conference call %1").arg(conference.getId());
+    qDebug() << "Joining conference call" << conference.getId();
 
     // Audio backend must be set before starting a call
     assert(audio != nullptr);
@@ -575,7 +575,7 @@ void CoreAV::leaveConferenceCall(int conferenceNum)
 {
     QWriteLocker locker{&callsLock};
 
-    qDebug() << QString("Leaving conference call %1").arg(conferenceNum);
+    qDebug() << "Leaving conference call" << conferenceNum;
 
     conferenceCalls.erase(conferenceNum);
 }
@@ -744,7 +744,7 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
         PARSE_ERR(err);
         return;
     }
-    qDebug() << QString("Received call invite from %1").arg(friendNum);
+    qDebug() << "Received call invite from" << friendNum;
 
     // We don't get a state callback when answering, so fill the state ourselves in advance
     int state = 0;

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -131,7 +131,7 @@ void CoreFile::sendFile(uint32_t friendId, QString filename, QString filePath, l
         emit fileSendFailed(friendId, fileName.getQString());
         return;
     }
-    qDebug() << QString("sendFile: Created file sender %1 with friend %2").arg(fileNum).arg(friendId);
+    qDebug("sendFile: Created file sender %d with friend %d", fileNum, friendId);
 
     ToxFile file{fileNum,
                  friendId,
@@ -147,7 +147,7 @@ void CoreFile::sendFile(uint32_t friendId, QString filename, QString filePath, l
         return;
     }
     if (!file.open(false)) {
-        qWarning() << QString("sendFile: Can't open file, error: %1").arg(file.file->errorString());
+        qWarning() << "sendFile: Can't open file, error:" << file.file->errorString();
     }
 
     addFile(friendId, fileNum, file);
@@ -326,7 +326,7 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
 
     if (kind == TOX_FILE_KIND_AVATAR) {
         if (!filesize) {
-            qDebug() << QString("Received empty avatar request %1:%2").arg(friendId).arg(fileId);
+            qDebug("Received empty avatar request %d:%d", friendId, fileId);
             // Avatars of size 0 means explicitely no avatar
             Tox_Err_File_Control err;
             tox_file_control(tox, friendId, fileId, TOX_FILE_CONTROL_CANCEL, &err);
@@ -335,10 +335,10 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
             return;
         }
         if (!ToxClientStandards::IsValidAvatarSize(filesize)) {
-            qWarning() << QString("Received avatar request from %1 with size %2.").arg(friendId).arg(filesize)
-                              + QString(
-                                    " The max size allowed for avatars is %3. Cancelling transfer.")
-                                    .arg(ToxClientStandards::MaxAvatarSize);
+            qWarning("Received avatar request from %d with size %lu."
+                     " The max size allowed for avatars is %lu. Cancelling transfer.",
+                     friendId, static_cast<unsigned long>(filesize),
+                     static_cast<unsigned long>(ToxClientStandards::MaxAvatarSize));
             Tox_Err_File_Control err;
             tox_file_control(tox, friendId, fileId, TOX_FILE_CONTROL_CANCEL, &err);
             PARSE_ERR(err);
@@ -358,14 +358,14 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
 #ifdef Q_OS_WIN
     const auto cleanFileName = CoreFile::getCleanFileName(filename.getQString());
     if (cleanFileName != filename.getQString()) {
-        qDebug() << QStringLiteral("Cleaned filename");
+        qDebug() << "Cleaned filename";
         filename = ToxString(cleanFileName);
         emit coreFile->fileNameChanged(friendPk);
     } else {
-        qDebug() << QStringLiteral("filename already clean");
+        qDebug() << "filename already clean";
     }
 #endif
-    qDebug() << QString("Received file request %1:%2 kind %3").arg(friendId).arg(fileId).arg(kind);
+    qDebug("Received file request %d:%d kind %d", friendId, fileId, kind);
 
     ToxFile file{fileId, friendId, filename.getQString(), "", filesize, ToxFile::RECEIVING};
     file.fileKind = kind;
@@ -387,9 +387,7 @@ void CoreFile::handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept
 {
     if (!accept) {
         // If it's an avatar but we already have it cached, cancel
-        qDebug() << QString("Received avatar request %1:%2. Rejected since it is in cache.")
-                        .arg(friendId)
-                        .arg(fileId);
+        qDebug("Received avatar request %d:%d. Rejected since it is in cache.", friendId, fileId);
         Tox_Err_File_Control err;
         tox_file_control(tox, friendId, fileId, TOX_FILE_CONTROL_CANCEL, &err);
         PARSE_ERR(err);
@@ -402,7 +400,7 @@ void CoreFile::handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept
         return;
     }
     // It's an avatar and we don't have it, autoaccept the transfer
-    qDebug() << QString("Received avatar request %1:%2. Accepted.").arg(friendId).arg(fileId);
+    qDebug("Received avatar request %d:%d. Accepted.", friendId, fileId);
 
     ToxFile file{fileId, friendId, "<avatar>", "", filesize, ToxFile::RECEIVING};
     file.fileKind = TOX_FILE_KIND_AVATAR;

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -386,11 +386,11 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
 
     if (parser.isSet("I")) {
         enableIPv6 = IPv6Setting == ON;
-        qDebug() << QString("Setting IPv6 %1.").arg(IPv6Setting);
+        qDebug() << "Setting IPv6 to" << IPv6Setting;
     }
 
     if (parser.isSet("P")) {
-        qDebug() << QString("Setting proxy type to %1.").arg(proxySettings[0]);
+        qDebug() << "Setting proxy type to" << proxySettings[0];
 
         quint16 portNumber = 0;
         QString address = "";
@@ -416,9 +416,9 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
 
 
         proxyAddr = address;
-        qDebug() << QString("Setting proxy address to %1.").arg(address);
+        qDebug() << "Setting proxy address to" << address;
         proxyPort = portNumber;
-        qDebug() << QString("Setting port number to %1.").arg(portNumber);
+        qDebug() << "Setting port number to" << portNumber;
     }
 
     if (parser.isSet("U")) {
@@ -427,7 +427,7 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
             qDebug() << "Cannot use UDP with proxy; disable proxy explicitly with '-P none'.";
         } else {
             forceTCP = shouldForceTCP;
-            qDebug() << QString("Setting UDP %1.").arg(UDPSetting);
+            qDebug() << "Setting UDP" << UDPSetting;
         }
 
         // LANSetting == ON is caught by verifyProxySettings, the OFF check removes needless debug
@@ -447,7 +447,7 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
             qDebug() << "Cannot use LAN discovery without UDP; enable UDP explicitly with '-U on'.";
         } else {
             enableLanDiscovery = shouldEnableLAN;
-            qDebug() << QString("Setting LAN Discovery %1.").arg(LANSetting);
+            qDebug() << "Setting LAN Discovery" << LANSetting;
         }
     }
     return true;


### PR DESCRIPTION
QStrings are quoted by default, making log messages a bit weird.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/122)
<!-- Reviewable:end -->
