### PR TITLE
cleanup: Add spdx license header to our only ObjC++ file.

### DIFF
--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -1,24 +1,11 @@
-/*
-    Copyright © 2014 Thilo Borgmann <thilo.borgmann@mail.de>
-    Copyright © 2015-2019 by The qTox Project Contributors
-
-    This file is part of qTox, a Qt-based graphical interface for Tox.
-
-    qTox is libre software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    qTox is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
-*/
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2014 Thilo Borgmann <thilo.borgmann@mail.de>
+ * Copyright © 2015-2019 by The qTox Project Contributors
+ * Copyright © 2024 The TokTok team.
+ */
 
 #include "avfoundation.h"
+
 #include <QDebug>
 #include <QMutex>
 #include <QObject>
@@ -28,7 +15,6 @@
 QVector<QPair<QString, QString> > avfoundation::getDeviceList()
 {
     QVector<QPair<QString, QString> > result;
-    qDebug() << "!!!!!!!!!!!!!!!!!!!!!! Getting the device list from AVFoundation. !!!!!!!!!!!!!!!!!!!!!!";
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
     const AVAuthorizationStatus authStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
@@ -71,8 +57,6 @@ QVector<QPair<QString, QString> > avfoundation::getDeviceList()
         }
     }
 
-    qDebug() << "XXX: got devices from avfoundation" << devices;
-    qDebug() << "XXX: got devices from avfoundation" << result;
     return result;
 }
 


### PR DESCRIPTION
I missed this one when changing C++ files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/124)
<!-- Reviewable:end -->
