### PR TITLE
chore: Add version check for toxcore.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -37,9 +37,11 @@ add_dependency(
 
 include(CMakeParseArguments)
 
+set(TOXCORE_MINIMUM_VERSION "0.2.20")
+
 function(search_dependency pkg)
   set(options OPTIONAL STATIC_PACKAGE)
-  set(oneValueArgs PACKAGE LIBRARY FRAMEWORK HEADER)
+  set(oneValueArgs PACKAGE LIBRARY FRAMEWORK HEADER MINIMUM_VERSION)
   set(multiValueArgs)
   cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -59,6 +61,10 @@ function(search_dependency pkg)
     if(${pkg}_LIBRARIES)
       set(${pkg}_FOUND TRUE)
     endif()
+  endif()
+
+  if(${pkg} MATCHES "TOXCORE" AND "${TOXCORE_VERSION}" VERSION_LESS "${arg_MINIMUM_VERSION}")
+    message(FATAL_ERROR "Minimum ${arg_PACKAGE} version is: ${arg_MINIMUM_VERSION}")
   endif()
 
   # Last, search for the library itself globally.
@@ -135,15 +141,15 @@ endif()
 
 # Try to find cmake toxcore libraries
 if(WIN32 OR ANDROID)
-  search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL STATIC_PACKAGE)
+  search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL STATIC_PACKAGE MINIMUM_VERSION ${TOXCORE_MINIMUM_VERSION})
 else()
-  search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL)
+  search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL MINIMUM_VERSION ${TOXCORE_MINIMUM_VERSION})
 endif()
 
 # If not found, use automake toxcore libraries
 # We only check for TOXCORE, because the other two are gone in 0.2.0.
 if (NOT TOXCORE_FOUND)
-  search_dependency(TOXCORE         PACKAGE libtoxcore)
+  search_dependency(TOXCORE         PACKAGE libtoxcore MINIMUM_VERSION ${TOXCORE_MINIMUM_VERSION})
   search_dependency(TOXAV           PACKAGE libtoxav)
 endif()
 


### PR DESCRIPTION
Not sure if something like this will be wanted, and not sure if it catches all the platforms and such (also the formatting gets a bit wide-like), but at this time, the build fails as follows with toxcore version less than 0.2.20:

```
FAILED: util/CMakeFiles/util_library.dir/src/toxcoreerrorparser.cpp.o
/usr/bin/x86_64-pc-linux-gnu-g++ -DCMAKE_BUILD -DDESKTOP_NOTIFICATIONS=0 -DGIT_DESCRIBE=\"nightly\" -DGIT_DESCRIBE_EXACT=\"nightly\" -DGIT_VERSION=\"9270753a8686706a33adeecea90eb138d789f466\" -DLOG_TO_FILE=1 -DQTOX_PLATFORM_EXT -DQT_CORE_LIB -DQT_MESSAGELOGCONTEXT=1 -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_RESTRICTED_CAST_FROM_ASCII -DSPELL_CHECKING -I/mnt/lprup/portage-build/portage/net-im/qtox-9999/work/qtox-9999_build/util/util_library_autogen/include -I/mnt/lprup/portage-build/portage/net-im/qtox-9999/work/qtox-9999_build -I/mnt/lprup/portage-build/portage/net-im/qtox-9999/work/qtox-9999 -I/usr/include/libexif -I/usr/include/sqlcipher -I/usr/include/opus -I/usr/include/AL -I/mnt/lprup/portage-build/portage/net-im/qtox-9999/work/qtox-9999/util/include -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/lib64/qt6/mkspecs/linux-g++  -march=znver4 -O2 -fomit-frame-pointer -pipe -mindirect-branch=thunk -std=c++20 -fno-exceptions -fno-rtti -fstack-protector-all -fPIC -fno-common -fstrict-overflow -ftrapv -pedantic-errors -Wall -Wcast-align -Wdouble-promotion -Wextra -Wformat=2 -Wmissing-declarations -Wnon-virtual-dtor -Wnull-dereference -Wold-style-cast -Woverloaded-virtual -Wshadow -Wsign-compare -Wundef -Wduplicated-cond -Wlogical-op -Wdate-time -Wstack-protector -MD -MT util/CMakeFiles/util_library.dir/src/toxcoreerrorparser.cpp.o -MF util/CMakeFiles/util_library.dir/src/toxcoreerrorparser.cpp.o.d -o util/CMakeFiles/util_library.dir/src/toxcoreerrorparser.cpp.o -c /mnt/lprup/portage-build/portage/net-im/qtox-9999/work/qtox-9999/util/src/toxcoreerrorparser.cpp
/mnt/lprup/portage-build/portage/net-im/qtox-9999/work/qtox-9999/util/src/toxcoreerrorparser.cpp: In function ‘bool ToxcoreErrorParser::parseErr(Tox_Err_Conference_Join, const char*, int, const char*)’:
/mnt/lprup/portage-build/portage/net-im/qtox-9999/work/qtox-9999/util/src/toxcoreerrorparser.cpp:154:10: error: ‘TOX_ERR_CONFERENCE_JOIN_NULL’ was not declared in this scope; did you mean ‘TOX_ERR_CONFERENCE_JOIN_OK’?
  154 |     case TOX_ERR_CONFERENCE_JOIN_NULL:
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          TOX_ERR_CONFERENCE_JOIN_OK
ninja: build stopped: subcommand failed.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/147)
<!-- Reviewable:end -->
