### PR TITLE
chore: Set min sdk version to 24 (Android 7).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,6 +606,11 @@ qt_add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE
 target_link_libraries(
   ${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_static ${CMAKE_REQUIRED_LIBRARIES}
                           ${ALL_LIBRARIES})
+set_target_properties(
+  ${PROJECT_NAME}
+  PROPERTIES QT_ANDROID_TARGET_SDK_VERSION 24
+             QT_ANDROID_MIN_SDK_VERSION 24
+             QT_ANDROID_ABIS arm64-v8a)
 
 include(Testing)
 include(Installation)


### PR DESCRIPTION
See https://github.com/TokTok/qTox/issues/172 by @ljgdasfhk.

This should make the APK work on older Android versions. In the android builder image, we [already select API 23](https://github.com/TokTok/dockerfiles/blob/15f3ca2ebb2715ff09ffb97569c3299836d2f22a/qtox/docker/Dockerfile.android-builder#L41), so this should work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/173)
<!-- Reviewable:end -->
