### PR TITLE
cleanup: Make ToxId move-only.

### DIFF
--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -42,11 +42,11 @@ ToxId::ToxId()
 }
 
 /**
- * @brief The copy constructor.
- * @param other ToxId to copy
+ * @brief The move constructor.
+ * @param other ToxId to move from.
  */
-ToxId::ToxId(const ToxId& other)
-    : toxId(other.toxId)
+ToxId::ToxId(ToxId&& other)
+    : toxId(std::move(other.toxId))
 {
 }
 

--- a/src/core/toxid.h
+++ b/src/core/toxid.h
@@ -23,7 +23,7 @@ public:
     static constexpr int numHexChars = size * 2;
 
     ToxId();
-    ToxId(const ToxId& other);
+    ToxId(ToxId&& other);
     explicit ToxId(const QString& id);
     explicit ToxId(const QByteArray& rawId);
     explicit ToxId(const uint8_t* rawId, int len);
@@ -39,7 +39,6 @@ public:
     static bool isValidToxId(const QString& id);
     static bool isToxId(const QString& id);
     const uint8_t* getBytes() const;
-    QByteArray getToxId() const;
     ToxPk getPublicKey() const;
     QString getNoSpamString() const;
 

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -48,7 +48,7 @@ bool checkIsValidId(const QString& id)
 
 AddFriendForm::AddFriendForm(ToxId ownId_, Settings& settings_, Style& style_,
                              IMessageBoxManager& messageBoxManager_, Core& core_)
-    : ownId{ownId_}
+    : ownId{std::move(ownId_)}
     , settings{settings_}
     , style{style_}
     , messageBoxManager{messageBoxManager_}

--- a/test/core/toxid_test.cpp
+++ b/test/core/toxid_test.cpp
@@ -26,7 +26,6 @@ private slots:
     void equalTest();
     void notEqualTest();
     void clearTest();
-    void copyTest();
     void validationTest();
 };
 
@@ -58,13 +57,6 @@ void TestToxId::clearTest()
     QVERIFY(empty != test);
     test.clear();
     QVERIFY(empty == test);
-}
-
-void TestToxId::copyTest()
-{
-    ToxId src(testToxId);
-    ToxId copy = src;
-    QVERIFY(copy == src);
 }
 
 void TestToxId::validationTest()


### PR DESCRIPTION
We never copy it except in one place where it's a mistake.

Also removed an unimplemented member function declaration from ToxId.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/175)
<!-- Reviewable:end -->
