### PR TITLE
chore: Don't build Qt stuff in bazel cross-compile builds.

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
     hdrs = ["dbutility/include/dbutility/dbutility.h"],
     copts = COPTS,
     strip_include_prefix = "dbutility/include",
+    tags = ["no-cross"],
     deps = [
         "//qtox/src",
         "@qt//:qt_core",


### PR DESCRIPTION
We're not ready for ARM builds of ffmpeg.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/184)
<!-- Reviewable:end -->
