### PR TITLE
chore: Use the debug version of Qt in Android release builds.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ services:
     image: toxchat/qtox:android-builder.arm64-v8a.debug
     <<: *shared_params
   android_builder.arm64-v8a.release:
-    image: toxchat/qtox:android-builder.arm64-v8a.release
+    image: toxchat/qtox:android-builder.arm64-v8a.debug
+    # image: toxchat/qtox:android-builder.arm64-v8a.release
     <<: *shared_params
   debian:
     image: toxchat/qtox:debian


### PR DESCRIPTION
Something weird happens with Debug builds (probably the debug signing) that Android 7 doesn't like. Let's try building release builds but using the debug version of Qt.

https://github.com/TokTok/qTox/issues/172

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/185)
<!-- Reviewable:end -->
