### PR TITLE
cleanup: Remove now unused DESKTOP_NOTIFICATIONS from cmake preset.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,6 @@
       "generator": "Ninja",
       "cacheVariables": {
         "ASAN": true,
-        "DESKTOP_NOTIFICATIONS": true,
         "SPELL_CHECK": true,
         "STRICT_OPTIONS": true,
         "CMAKE_BUILD_TYPE": "Debug",


### PR DESCRIPTION
There's no way to build without desktop notifications now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/189)
<!-- Reviewable:end -->
