### PR TITLE
fix: Fix use-after-free when closing qTox during a call.

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -12,6 +12,7 @@
 #include "src/persistence/iconferencesettings.h"
 #include "src/video/corevideosource.h"
 #include "src/video/videoframe.h"
+#include "util/algorithm.h"
 #include "util/toxcoreerrorparser.h"
 
 #include <QCoreApplication>
@@ -153,12 +154,8 @@ IAudioControl* CoreAV::getAudio()
 CoreAV::~CoreAV()
 {
     /* Gracefully leave calls and conference calls to avoid deadlocks in destructor */
-    for (const auto& call : calls) {
-        cancelCall(call.first);
-    }
-    for (const auto& call : conferenceCalls) {
-        leaveConferenceCall(call.first);
-    }
+    forEachKey(calls, [this](uint32_t callId) { cancelCall(callId); });
+    forEachKey(conferenceCalls, [this](int callId) { leaveConferenceCall(callId); });
 
     assert(calls.empty());
     assert(conferenceCalls.empty());

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -3,9 +3,14 @@
 
 add_library(
   util_library STATIC
-  "include/util/interface.h" "include/util/strongtype.h"
-  "include/util/display.h" "src/display.cpp"
-  "include/util/toxcoreerrorparser.h" "src/toxcoreerrorparser.cpp")
+  include/util/algorithm.h
+  src/algorithm.cpp
+  include/util/interface.h
+  include/util/strongtype.h
+  include/util/display.h
+  src/display.cpp
+  include/util/toxcoreerrorparser.h
+  src/toxcoreerrorparser.cpp)
 
 # We need this directory, and users of our library will need it too
 target_include_directories(util_library PUBLIC include/)

--- a/util/include/util/algorithm.h
+++ b/util/include/util/algorithm.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024 The TokTok team.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <map>
+#include <vector>
+
+template <typename K, typename V, typename F>
+void forEachKey(const std::map<K, V>& map, F func)
+{
+    // Copy keys because func may modify the map.
+    std::vector<K> keys;
+    keys.reserve(map.size());
+    std::transform(map.begin(), map.end(), std::back_inserter(keys),
+                   [](const auto& pair) { return pair.first; });
+    for (const auto key : keys) {
+        func(key);
+    }
+}

--- a/util/src/algorithm.cpp
+++ b/util/src/algorithm.cpp
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024 The TokTok team.
+ */
+
+#include "util/algorithm.h"


### PR DESCRIPTION
You shouldn't iterate over a container and modify it at the same time (unless you do `it = c.erase(...)` which this code can't do, and you can't do in range-for anyway.

Fixes #180.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/192)
<!-- Reviewable:end -->
