### PR TITLE
test: Make the invalid proxy test less flaky.

### DIFF
--- a/test/core/core_test.cpp
+++ b/test/core/core_test.cpp
@@ -77,7 +77,7 @@ void bootstrapToxes(Core& alice, MockBootstrapListGenerator& alicesNodes, Core& 
 
 void TestCore::startup_with_invalid_socks5_proxy()
 {
-    settings.setProxyAddr("Test");
+    settings.setProxyAddr("Test::haha:::nope");
     settings.setProxyPort(9985);
     settings.setProxyType(MockSettings::ProxyType::ptSOCKS5);
 
@@ -88,7 +88,7 @@ void TestCore::startup_with_invalid_socks5_proxy()
 
 void TestCore::startup_with_invalid_http_proxy()
 {
-    settings.setProxyAddr("Test");
+    settings.setProxyAddr("Test::haha:::nope");
     settings.setProxyPort(9985);
     settings.setProxyType(MockSettings::ProxyType::ptHTTP);
 


### PR DESCRIPTION
In some cases and on some systems, "Test" is a valid proxy address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/197)
<!-- Reviewable:end -->
