### PR TITLE
cleanup: Some random warning cleanups and some typo fixes.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,7 @@ project(license = "gpl3-https")
 qt_lconvert(
     name = "qtox_qms",
     srcs = glob(["translations/*.ts"]),
-    tags = ["no-cross"],
+    tags = ["qt"],
 )
 
 genrule(
@@ -15,14 +15,14 @@ genrule(
     srcs = ["translations/translations.qrc"],
     outs = ["translations/translations_local.qrc"],
     cmd = "cp $< $@",
-    tags = ["no-cross"],
+    tags = ["qt"],
 )
 
 qt_rcc(
     name = "translations",
     srcs = [":translations_qrc"],
     data = [":qtox_qms"],
-    tags = ["no-cross"],
+    tags = ["qt"],
 )
 
 qt_rcc(
@@ -38,7 +38,7 @@ qt_rcc(
         "smileys/*/*",
         "themes/**/*",
     ]),
-    tags = ["no-cross"],
+    tags = ["qt"],
 )
 
 cc_library(
@@ -47,14 +47,14 @@ cc_library(
         ":res",
         ":translations",
     ],
-    tags = ["no-cross"],
+    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     alwayslink = True,
 )
 
 cc_binary(
     name = "qtox",
-    tags = ["no-cross"],
+    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = ["//qtox/src:main"],
 )

--- a/audio/BUILD.bazel
+++ b/audio/BUILD.bazel
@@ -12,7 +12,7 @@ qt_moc(
     ],
     hdrs = glob(["**/*.h"]),
     mocopts = ["-Iqtox/audio/include"],
-    tags = ["no-cross"],
+    tags = ["qt"],
     deps = ["//qtox/util"],
 )
 
@@ -20,13 +20,13 @@ qt_rcc(
     name = "audio_res",
     srcs = ["resources/audio_res.qrc"],
     data = glob(["resources/*.pcm"]),
-    tags = ["no-cross"],
+    tags = ["qt"],
 )
 
 cc_library(
     name = "audio_res_lib",
     srcs = [":audio_res"],
-    tags = ["no-cross"],
+    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     alwayslink = True,
 )
@@ -54,7 +54,7 @@ cc_library(
         "UPDATE_CHECK_ENABLED",
     ],
     includes = ["include"],
-    tags = ["no-cross"],
+    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         ":audio_res_lib",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -130,7 +130,7 @@ qt_moc(
         "-Iqtox",
         "-Iqtox/util/include",
     ] + ["-D%s=1" % d for d in DEFINES],
-    tags = ["no-cross"],
+    tags = ["qt"],
     deps = [
         "//qtox/util",
         "@qt//:qt_widgets",
@@ -140,7 +140,7 @@ qt_moc(
 qt_uic(
     name = "src_ui",
     srcs = glob(["**/*.ui"]),
-    tags = ["no-cross"],
+    tags = ["qt"],
 )
 
 objc_library(
@@ -195,7 +195,7 @@ cc_library(
         "//tools/config:osx": ["-framework IOKit"],
         "//tools/config:windows": [],
     }),
-    tags = ["no-cross"],
+    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         "//c-toxcore",
@@ -239,10 +239,12 @@ cc_library(
         "//tools/config:osx": [],
         "//tools/config:windows": [],
     }),
-    tags = ["no-cross"],
+    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         ":src",
         "//qtox/audio",
+        "@qt//:qt_core",
+        "@qt//:qt_gui",
     ],
 )

--- a/src/chatlog/chatlinecontentproxy.cpp
+++ b/src/chatlog/chatlinecontentproxy.cpp
@@ -10,14 +10,6 @@
 #include <QPainter>
 #include <QWidget>
 
-/**
- * @enum ChatLineContentProxy::ChatLineContentProxyType
- * @brief Type tag to avoid dynamic_cast of contained QWidget*
- *
- * @value GenericType
- * @value FileTransferWidgetType = 0
- */
-
 ChatLineContentProxy::ChatLineContentProxy(QWidget* widget, ChatLineContentProxyType type,
                                            int minWidth, float widthInPercent)
     : widthPercent(widthInPercent)

--- a/src/chatlog/chatlinecontentproxy.h
+++ b/src/chatlog/chatlinecontentproxy.h
@@ -15,9 +15,13 @@ class ChatLineContentProxy : public ChatLineContent
     Q_OBJECT
 
 public:
+    /**
+     * @brief Type tag to avoid dynamic_cast of contained QWidget*
+     */
     enum ChatLineContentProxyType
     {
-        GenericType,
+        // TODO(iphydf): Why are these the same value?
+        GenericType = 0,
         FileTransferWidgetType = 0,
     };
 

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -1472,8 +1472,6 @@ bool ChatWidget::needsToHideName(ChatLogIdx idx, bool prevIdxRendered) const
 
     qint64 messagesTimeDiff = prevItem.getTimestamp().secsTo(currentItem.getTimestamp());
     return currentItem.getSender() == prevItem.getSender() && messagesTimeDiff < repNameAfter;
-
-    return false;
 }
 
 bool ChatWidget::shouldRenderMessage(ChatLogIdx idx) const

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -929,7 +929,6 @@ void Core::setStatus(Status::Status status)
 
     default:
         return;
-        break;
     }
 
     tox_self_set_status(tox.get(), userstatus);

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -112,7 +112,6 @@ void Settings::loadGlobal()
                 .arg(globalSettingsVersion)
                 .arg(GLOBAL_SETTINGS_VERSION));
         std::terminate();
-        return;
     }
     globalSettingsVersion = GLOBAL_SETTINGS_VERSION;
 
@@ -489,7 +488,6 @@ void Settings::loadPersonal(const Profile& profile, bool newProfile)
                 .arg(personalSettingsVersion)
                 .arg(PERSONAL_SETTINGS_VERSION));
         std::terminate();
-        return;
     }
     personalSettingsVersion = PERSONAL_SETTINGS_VERSION;
 

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -226,8 +226,6 @@ bool CategoryWidget::cycleChats(FriendWidget* activeChatroomWidget, bool forward
             emit chatWidget->chatroomWidgetClicked(chatWidget);
         return true;
     }
-
-    return false;
 }
 
 void CategoryWidget::onCompactChanged(bool _compact)

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -327,7 +327,6 @@ void ContentDialog::cycleChats(bool forward, bool inverse)
         currentLayout = nextLayout(currentLayout, forward);
         if (currentLayout == nullptr) {
             qFatal("Layouts changed during iteration");
-            break;
         }
         int newCount = currentLayout->count();
         if (index < 0) {

--- a/src/widget/contentdialogmanager.h
+++ b/src/widget/contentdialogmanager.h
@@ -14,7 +14,7 @@
 #include <QObject>
 
 /**
- * @breaf Manage all content dialogs
+ * @brief Manage all content dialogs
  */
 class ContentDialogManager : public QObject, public IDialogsManager
 {

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -6,7 +6,7 @@ qt_rcc(
     testonly = True,
     srcs = ["resources/test_data.qrc"],
     data = glob(["resources/**/*.png"]),
-    tags = ["no-cross"],
+    tags = ["qt"],
 )
 
 COPTS = ["-Iqtox"] + select({
@@ -24,7 +24,7 @@ qt_moc(
         "-Iqtox",
         "-Iqtox/util/include",
     ],
-    tags = ["no-cross"],
+    tags = ["qt"],
     deps = [
         "//qtox/src",
         "//qtox/util",
@@ -38,7 +38,7 @@ cc_library(
     hdrs = ["dbutility/include/dbutility/dbutility.h"],
     copts = COPTS,
     strip_include_prefix = "dbutility/include",
-    tags = ["no-cross"],
+    tags = ["qt"],
     deps = [
         "//qtox/src",
         "@qt//:qt_core",
@@ -56,8 +56,11 @@ cc_library(
     hdrs = glob(["mock/include/mock/*.h"]),
     copts = COPTS,
     includes = ["mock/include"],
-    tags = ["no-cross"],
-    deps = ["//qtox/src"],
+    tags = ["qt"],
+    deps = [
+        "//qtox/src",
+        "@qt//:qt_core",
+    ],
 )
 
 [qt_test(
@@ -73,6 +76,9 @@ cc_library(
         "//qtox:res_lib",
         "//qtox/src",
         "//qtox/util",
+        "@qt//:qt_core",
+        "@qt//:qt_gui",
+        "@qt//:qt_network",
     ],
 ) for src in glob(
     ["**/*_test.cpp"],

--- a/test/core/fileprogress_test.cpp
+++ b/test/core/fileprogress_test.cpp
@@ -198,7 +198,7 @@ void TestFileProgress::testNoSamples()
 {
     auto progress = ToxFileProgress(100, 1000);
     QCOMPARE(progress.getSpeed(), 0.0);
-    QVERIFY(progress.getTimeLeftSeconds() == std::numeric_limits<double>::infinity());
+    QCOMPARE(progress.getTimeLeftSeconds(), std::numeric_limits<double>::infinity());
     QCOMPARE(progress.getProgress(), 0.0);
 }
 

--- a/test/model/sessionchatlog_test.cpp
+++ b/test/model/sessionchatlog_test.cpp
@@ -27,7 +27,6 @@ public:
     ToxId getSelfId() const override
     {
         std::terminate();
-        return ToxId();
     }
 
     ToxPk getSelfPublicKey() const override

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -21,7 +21,7 @@ cc_library(
         "UPDATE_CHECK_ENABLED",
     ],
     includes = ["include"],
-    tags = ["no-cross"],
+    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
         "//c-toxcore",


### PR DESCRIPTION
Also tag targets as `qt` instead of `no-cross` to have more precision in selecting targets in various bazel builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/198)
<!-- Reviewable:end -->
