### PR TITLE
chore: Use qt_binary instead of cc_binary for qtox.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("//third_party/qt:build_defs.bzl", "qt_lconvert", "qt_rcc")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//third_party/qt:build_defs.bzl", "qt_binary", "qt_lconvert", "qt_rcc")
 load("//tools/project:build_defs.bzl", "project")
 
 project(license = "gpl3-https")
@@ -52,9 +52,8 @@ cc_library(
     alwayslink = True,
 )
 
-cc_binary(
+qt_binary(
     name = "qtox",
-    tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = ["//qtox/src:main"],
 )


### PR DESCRIPTION
The macro sets up the right environment for `bazel run :qtox` to find the platform, network, and image format plugins.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/201)
<!-- Reviewable:end -->
