### PR TITLE
chore: Use `mkstamp` macro to get git version from bazel build.

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load("//third_party/qt:build_defs.bzl", "qt_moc", "qt_uic")
-
-VERSION = "1.16.3"
+load("//tools/project:build_defs.bzl", "mkstamp")
 
 DEFINES = [
     "DEBUG",
@@ -157,15 +156,9 @@ objc_library(
     deps = ["@qt//:qt_core"],
 )
 
-genrule(
+mkstamp(
     name = "version",
-    outs = ["version.h"],
-    cmd = """cat <<EOF > $@
-#define GIT_DESCRIBE "v%s"
-#define GIT_DESCRIBE_EXACT "v%s"
-#define GIT_VERSION "master"
-#define TIMESTAMP "redacted"
-EOF""" % (VERSION, VERSION),
+    hdr = "version.h",
 )
 
 cc_library(


### PR DESCRIPTION
Requires https://github.com/TokTok/toktok-stack/pull/906.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/202)
<!-- Reviewable:end -->
