### PR TITLE
chore: Enable rtti in all builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,6 @@ set(AUTORCC_OPTIONS ${AUTORCC_OPTIONS} -format-version 1)
 # Use C++20.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
 # Hardening flags (ASLR, warnings, etc)
 set(POSITION_INDEPENDENT_CODE True)


### PR DESCRIPTION
Qt occasionally does `dynamic_cast` and there's no (good) way of disabling RTTI in Qt builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/204)
<!-- Reviewable:end -->
