### PR TITLE
cleanup: Use consistent nomenclature for "full screen".

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -118,9 +118,9 @@ void Nexus::start()
     windowMenu = globalMenuBar->addMenu(QString());
     globalMenuBar->addAction(windowMenu->menuAction());
 
-    fullscreenAction = viewMenu->addAction(QString());
-    fullscreenAction->setShortcut(QKeySequence::FullScreen);
-    connect(fullscreenAction, &QAction::triggered, this, &Nexus::toggleFullscreen);
+    fullScreenAction = viewMenu->addAction(QString());
+    fullScreenAction->setShortcut(QKeySequence::FullScreen);
+    connect(fullScreenAction, &QAction::triggered, this, &Nexus::toggleFullScreen);
 
     minimizeAction = windowMenu->addAction(QString());
     minimizeAction->setShortcut(Qt::CTRL | Qt::Key_M);
@@ -315,9 +315,9 @@ void Nexus::onWindowStateChanged(Qt::WindowStates state)
             minimizeAction->setEnabled(false);
 
         if (state & Qt::WindowFullScreen)
-            fullscreenAction->setText(tr("Exit Fullscreen"));
+            fullScreenAction->setText(tr("Exit Full Screen"));
         else
-            fullscreenAction->setText(tr("Enter Fullscreen"));
+            fullScreenAction->setText(tr("Enter Full Screen"));
 
         updateWindows();
     }
@@ -399,7 +399,7 @@ void Nexus::onOpenWindow(QObject* object)
     window->requestActivate();
 }
 
-void Nexus::toggleFullscreen()
+void Nexus::toggleFullScreen()
 {
     QWidget* window = QApplication::activeWindow();
 

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -52,7 +52,7 @@ public:
     QMenu* viewMenu;
     QMenu* windowMenu;
     QAction* minimizeAction;
-    QAction* fullscreenAction;
+    QAction* fullScreenAction;
     QAction* frontAction;
     QMenu* dockMenu;
 
@@ -63,7 +63,7 @@ public slots:
     void updateWindowsClosed();
     void updateWindowsStates();
     void onOpenWindow(QObject* object);
-    void toggleFullscreen();
+    void toggleFullScreen();
     void bringAllToFront();
 
 private:

--- a/src/widget/conferencewidget.cpp
+++ b/src/widget/conferencewidget.cpp
@@ -166,7 +166,7 @@ void ConferenceWidget::updateStatusLight()
 QString ConferenceWidget::getStatusString() const
 {
     if (chatroom->hasNewMessage()) {
-        return tr("New Message");
+        return tr("New message");
     } else {
         return tr("Online");
     }

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -567,7 +567,7 @@ void ChatForm::clearChatArea()
 void ChatForm::onScreenshotClicked()
 {
     doScreenshot();
-    // Give the window manager a moment to open the fullscreen grabber window
+    // Give the window manager a moment to open the full-screen grabber window
     QTimer::singleShot(SCREENSHOT_GRABBER_OPENING_DELAY, this, &ChatForm::hideFileMenu);
 }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -376,7 +376,7 @@ void Widget::init()
     new QShortcut(Qt::CTRL | Qt::Key_Tab, this, this, &Widget::nextChat);
     new QShortcut(Qt::CTRL | Qt::Key_PageUp, this, this, &Widget::previousChat);
     new QShortcut(Qt::CTRL | Qt::Key_PageDown, this, this, &Widget::nextChat);
-    new QShortcut(Qt::Key_F11, this, this, &Widget::toggleFullscreen);
+    new QShortcut(Qt::Key_F11, this, this, &Widget::toggleFullScreen);
 
 #ifdef Q_OS_MAC
     QMenuBar* globalMenu = nexus.globalMenuBar;
@@ -403,9 +403,8 @@ void Widget::init()
     editMenu = globalMenu->insertMenu(viewMenu, new QMenu(this));
     editMenu->menu()->addSeparator();
 
-    viewMenu->menu()->insertMenu(nexus.fullscreenAction, filterMenu);
-
-    viewMenu->menu()->insertSeparator(nexus.fullscreenAction);
+    viewMenu->menu()->insertMenu(nexus.fullScreenAction, filterMenu);
+    viewMenu->menu()->insertSeparator(nexus.fullScreenAction);
 
     contactMenu = globalMenu->insertMenu(windowMenu, new QMenu(this));
 
@@ -584,7 +583,7 @@ void Widget::updateIcons()
         QString path = ":/img/taskbar/" + color + "/taskbar_" + assetSuffix + ".svg";
         QSvgRenderer renderer(path);
 
-        // Prepare a QImage with desired characteritisc
+        // Prepare a QImage with desired characteristics
         QImage image = QImage(250, 250, QImage::Format_ARGB32);
         image.fill(Qt::transparent);
         QPainter painter(&image);
@@ -1781,7 +1780,7 @@ void Widget::onConferenceDialogShown(Conference* c)
     onDialogShown(conferenceWidgets[conferenceId]);
 }
 
-void Widget::toggleFullscreen()
+void Widget::toggleFullScreen()
 {
     if (windowState().testFlag(Qt::WindowFullScreen)) {
         setWindowState(windowState() & ~Qt::WindowFullScreen);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -195,7 +195,7 @@ public slots:
     void previousChat();
     void onFriendDialogShown(const Friend* f);
     void onConferenceDialogShown(Conference* c);
-    void toggleFullscreen();
+    void toggleFullScreen();
     void refreshPeerListsLocal(const QString& username);
     void onUpdateAvailable();
     void onCoreChanged(Core& core);

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -893,8 +893,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">رسالة جديدة</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1862,11 +1862,11 @@ Please make sure to enter the same password twice.</source>
         <translation>في المقدمة</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>إلغاء ملئ الشاشة</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>ملئ الشاشة</translation>
     </message>
 </context>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -885,7 +885,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Новае паведамленне</translation>
     </message>
     <message>
@@ -1861,11 +1861,11 @@ Please make sure to enter the same password twice.</source>
         <translation>На пярэдні план</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Выхад з поўнаэкраннага рэжыму</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Увайсці ў поўнаэкранны рэжым</translation>
     </message>
 </context>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -1384,7 +1384,7 @@ instead of system taskbar.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1923,11 +1923,11 @@ You may want to create one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -887,7 +887,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Ново съобщение</translation>
     </message>
     <message>
@@ -1860,11 +1860,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Извеждане на всички на преден план</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Изход от Цял екран</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Влизане в Цял екран</translation>
     </message>
 </context>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -878,7 +878,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1851,11 +1851,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -889,7 +889,7 @@ takže můžete soubor uložit i v systému Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nová zpráva</translation>
     </message>
     <message>
@@ -1862,11 +1862,11 @@ Ujistěte se, že zadáváte stejné heslo dvakrát.</translation>
         <translation>Přenést vše do popředí</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Opustit režim celé obrazovky</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Přepnout na celou obrazovku</translation>
     </message>
 </context>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -881,8 +881,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">Ny besked</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1854,11 +1854,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -887,7 +887,7 @@ um sie in Windows speichern zu können.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Neue Nachricht</translation>
     </message>
     <message>
@@ -1867,11 +1867,11 @@ Bitte gib in beide Felder das gleiche Passwort ein.</translation>
         <translation>Alles in den Vordergrund bringen</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Vollbildmodus verlassen</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Vollbildmodus</translation>
     </message>
 </context>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -881,7 +881,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Νέο μήνυμα</translation>
     </message>
     <message>
@@ -1850,11 +1850,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Μεταφορά Όλων στο Προσκήνιο</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Έξοδος από Πλήρη οθόνη</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Είσοδος σε Πλήρη οθόνη</translation>
     </message>
 </context>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -877,8 +877,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">Nova mesaĝo</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1843,11 +1843,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -887,7 +887,7 @@ para que puedas guardar el archivo en windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nuevo Mensaje</translation>
     </message>
     <message>
@@ -1860,11 +1860,11 @@ Verifica que sean la misma en ambos recuadros.</translation>
         <translation>Traer todos al frente</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Salir de pantalla completa</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Pantalla completa</translation>
     </message>
 </context>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -886,7 +886,7 @@ ja sa saad seda faili nüüd Windowsis salvestada.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Uus sõnum</translation>
     </message>
     <message>
@@ -1860,11 +1860,11 @@ Palun vaata, et sa mõlemal korral sisestad sama salasõna.</translation>
         <translation>Too kõik esile</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Ära kuva üle kogu ekraani</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Kuva üle kogu ekraani</translation>
     </message>
 </context>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -879,7 +879,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>پیام جدید</translation>
     </message>
     <message>
@@ -1855,11 +1855,11 @@ Please make sure to enter the same password twice.</source>
         <translation>همه پنجره ها را جلو بیاور</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>خروج از نمای تمام صفحه</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>ورود به نمای تمام صفحه</translation>
     </message>
 </context>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -886,7 +886,7 @@ joten voit tallentaa tiedoston Windowsissa.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Uusi viesti</translation>
     </message>
     <message>
@@ -1859,11 +1859,11 @@ Varmista, että syötät saman salasanan kahdesti.</translation>
         <translation>Tuo kaikki eteen</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Sulje kokoruututila</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Mene kokoruututilaan</translation>
     </message>
 </context>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -886,7 +886,7 @@ afin que vous puissiez enregistrer le fichier sur windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nouveau message</translation>
     </message>
     <message>
@@ -1859,11 +1859,11 @@ Veuillez vous assurer d&apos;entrer deux fois le même mot de passe.</translatio
         <translation>Envoyer tout au premier plan</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Quitter le plein écran</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Entrer en plein écran</translation>
     </message>
 </context>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -882,7 +882,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nova Mensaxe</translation>
     </message>
     <message>
@@ -1858,11 +1858,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Traer todo á fronte</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Saír de pantalla completa</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Acceder a pantalla completa</translation>
     </message>
 </context>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -878,7 +878,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1851,11 +1851,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -884,7 +884,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nova poruka</translation>
     </message>
     <message>
@@ -1853,11 +1853,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Prikaži sve naprijed</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Prekini cjeloekranski prikaz</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Otvori cjeloekranski prikaz</translation>
     </message>
 </context>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -878,7 +878,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Új üzenet</translation>
     </message>
     <message>
@@ -1847,11 +1847,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Mind előrehozása</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Teljes képernyő bezárása</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Teljes képernyő</translation>
     </message>
 </context>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -878,7 +878,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1851,11 +1851,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -886,7 +886,7 @@ in modo da poter salvare il file su Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nuovo messaggio</translation>
     </message>
     <message>
@@ -1859,11 +1859,11 @@ Assicurati di inserire la stessa password due volte.</translation>
         <translation>Porta tutto in primo piano</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Esci dal Fullscreen</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Metti in Fullscreen</translation>
     </message>
 </context>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -878,8 +878,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">新しいメッセージ</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1846,11 +1846,11 @@ Please make sure to enter the same password twice.</source>
         <translation>すべて最前面に表示</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>全画面表示を終了</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>全画面表示を開始</translation>
     </message>
 </context>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -1381,7 +1381,7 @@ instead of system taskbar.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1920,11 +1920,11 @@ You may want to create one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -878,8 +878,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">ಹೊಸ ಸಂದೇಶ</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1851,11 +1851,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -879,7 +879,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1852,11 +1852,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -889,7 +889,7 @@ tad dabar galite įrašyti failą Windows sistemoje.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nauja žinutė</translation>
     </message>
     <message>
@@ -1862,11 +1862,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Fokusuoti viską</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Išjungti pilno ekrano režimą</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Aktyvuoti pilno ekrano režimą</translation>
     </message>
 </context>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -890,7 +890,7 @@ lai varētu saglabāt failus Windows operētājsistēmā.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Jauns ziņojums</translation>
     </message>
     <message>
@@ -1868,11 +1868,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Novietot visu priekšā</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Iziet no pilnekrāna režīma</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Aktivizēt pilnekrāna režīmu</translation>
     </message>
 </context>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -885,8 +885,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">Нова порака</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1861,11 +1861,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Донесе Се напред</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Излез од цел екран</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Отвори на цел екран</translation>
     </message>
 </context>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -886,7 +886,7 @@ zodat u het bestand op Windows kunt opslaan.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nieuw bericht</translation>
     </message>
     <message>
@@ -1859,11 +1859,11 @@ Zorg ervoor dat je hetzelfde wachtwoord twee keer invoert.</translation>
         <translation>Alles naar de voorgrond brengen</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Volledig scherm verlaten</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Volledig scherm gebruiken</translation>
     </message>
 </context>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -882,8 +882,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">Nieuw bericht</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1858,11 +1858,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Breng alles naar de voorgrond</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Volledig scherm verlaten</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Volledig scherm gebruiken</translation>
     </message>
 </context>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -888,7 +888,7 @@ slik at du kan lagre filen på Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Ny melding</translation>
     </message>
     <message>
@@ -1861,11 +1861,11 @@ Skriv inn samme passord to ganger.</translation>
         <translation>Bring alle til forgrunnen</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Gå ut av fullskjermsvisning</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Fullskjermsvisning</translation>
     </message>
 </context>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -898,7 +898,7 @@ więc możesz zapisać ten plik na systemie Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nowa Wiadomość</translation>
     </message>
     <message>
@@ -1882,12 +1882,12 @@ Pamiętaj, aby dwukrotnie wprowadzić to samo hasło.</translation>
         <translation>Pokaż na pierwszym planie</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translatorcomment>better translation?</translatorcomment>
         <translation>Opuść pełny ekran</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Pełny ekran</translation>
     </message>
 </context>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -1385,7 +1385,7 @@ instead of system taskbar.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1924,11 +1924,11 @@ You may want to create one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -886,7 +886,7 @@ de forma que possa guardar o ficheiro no Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nova mensagem</translation>
     </message>
     <message>
@@ -1859,11 +1859,11 @@ Certifique-se de introduziu a mesma palavra-passe duas vezes.</translation>
         <translation>Trazer tudo para a frente</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Sair do ecrã inteiro</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Mudar para ecrã inteiro</translation>
     </message>
 </context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -887,7 +887,7 @@ de forma que você possa salvar o arquivo no Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nova Mensagem</translation>
     </message>
     <message>
@@ -1867,11 +1867,11 @@ Certifique-se de que você entrou a mesma senha duas vezes.</translation>
         <translation>Trazer Todos para a Frente</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Sair da Tela Cheia</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Entrar em Tela Cheia</translation>
     </message>
 </context>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -890,7 +890,7 @@ astfel încât să puteți salva fișierul pe Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Mesaj nou</translation>
     </message>
     <message>
@@ -1870,11 +1870,11 @@ Vă rugăm să vă asigurați că introduceți aceeași parolă de două ori.</t
         <translation>Aduceți tot în față</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Ieșiți din ecranul complet</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Intrați în ecranul complet</translation>
     </message>
 </context>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -891,7 +891,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Новое сообщение</translation>
     </message>
     <message>
@@ -1865,11 +1865,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Отобразить все</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Выйти из полноэкранного режима</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Войти в полноэкранный режим</translation>
     </message>
 </context>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -878,7 +878,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1851,11 +1851,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -890,7 +890,7 @@ so you can save the file on Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nová správa</translation>
     </message>
     <message>
@@ -1870,11 +1870,11 @@ Prosím, uistite sa, že ste zadali to isté heslo dvakrát.</translation>
         <translation>Presunúť všetko dopredu</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Opustiť režim celej obrazovky</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Na celú obrazovku</translation>
     </message>
 </context>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -887,8 +887,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">Novo sporočilo</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1857,11 +1857,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -878,7 +878,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1851,11 +1851,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -885,7 +885,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Нова порука</translation>
     </message>
     <message>
@@ -1861,11 +1861,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Све у први план</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Напусти цео екран</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Пређи на цео екран</translation>
     </message>
 </context>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -885,8 +885,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">Nova poruka</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1862,11 +1862,11 @@ Please make sure to enter the same password twice.</source>
         <translation>Stavi sve ispred</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Napusti ceo ekran</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Pređi na ceo ekran</translation>
     </message>
 </context>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -886,7 +886,7 @@ så att du kan spara filen i Windows.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Nytt meddelande</translation>
     </message>
     <message>
@@ -1859,11 +1859,11 @@ Vänligen se till att du skriver samma lösenord två gånger.</translation>
         <translation>Flytta längst fram</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Avsluta helskärmsläge</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Använd helskärm</translation>
     </message>
 </context>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -878,7 +878,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1851,11 +1851,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -883,8 +883,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">புதிய செய்தி</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1857,11 +1857,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -886,7 +886,7 @@ geçersiz karakterler _ olarak değiştirildi.</translation>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Yeni İleti</translation>
     </message>
     <message>
@@ -1860,11 +1860,11 @@ Lütfen aynı parolayı iki kez girdiğinizden emin olun.</translation>
         <translation>Tümünü Öne Getir</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Tam Ekrandan Çık</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Tam Ekran Yap</translation>
     </message>
 </context>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -882,8 +882,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">يېڭى ئۇچۇر</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1858,11 +1858,11 @@ Please make sure to enter the same password twice.</source>
         <translation>ئەڭ ئۈستىگە يۆتكەش</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>تولۇق ئېكراندىن چېكىنىش</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>تولۇق ئېكران ھالىتى</translation>
     </message>
 </context>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -888,8 +888,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">Нове повідомлення</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1863,11 +1863,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished">На передній план</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Вимкнути повноекранний режим</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Увімкнути повноекранний режим</translation>
     </message>
 </context>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -886,7 +886,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1859,11 +1859,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -884,7 +884,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>Tin nhắn mới</translation>
     </message>
     <message>
@@ -1864,11 +1864,11 @@ Hãy đảm bảo nhập cùng một mật khẩu hai lần.</translation>
         <translation>Đưa tất cả lên đầu</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>Thoát toàn màn hình</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>Chế độ toàn màn hình</translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -883,7 +883,7 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
+        <source>New message</source>
         <translation>新消息</translation>
     </message>
     <message>
@@ -1856,11 +1856,11 @@ Please make sure to enter the same password twice.</source>
         <translation>移动全部到最上层</translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation>进入全屏模式</translation>
     </message>
 </context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -879,8 +879,8 @@ so you can save the file on Windows.</source>
         </translation>
     </message>
     <message>
-        <source>New Message</source>
-        <translation type="unfinished"></translation>
+        <source>New message</source>
+        <translation type="unfinished">新訊息</translation>
     </message>
     <message>
         <source>Online</source>
@@ -1852,11 +1852,11 @@ Please make sure to enter the same password twice.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Exit Fullscreen</source>
+        <source>Exit Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enter Fullscreen</source>
+        <source>Enter Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/f/full-screen

Qt agrees with this.

Also fixed the capitalisation of "New Message" -> "New message" in conferences to be aligned with 1:1 chats.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/210)
<!-- Reviewable:end -->
