### PR TITLE
feat: Add caps-lock indicator in password edit on macOS.

### DIFF
--- a/src/widget/passwordedit.h
+++ b/src/widget/passwordedit.h
@@ -8,6 +8,8 @@
 #include <QAction>
 #include <QLineEdit>
 
+#include <memory>
+
 class PasswordEdit : public QLineEdit
 {
     Q_OBJECT
@@ -37,5 +39,5 @@ private:
 private:
     QAction* action;
 
-    static EventHandler* eventHandler;
+    static std::unique_ptr<EventHandler> eventHandler;
 };

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -1923,7 +1923,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK مُفعل</translation>
     </message>
 </context>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -1919,7 +1919,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>УКЛЮЧАНЫ CAPS-LOCK</translation>
     </message>
 </context>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -1944,7 +1944,7 @@ You may want to create one.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -1917,7 +1917,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>КЛАВИШ ЗА ГЛАВНИ БУКВИ ВКЛЮЧЕН</translation>
     </message>
 </context>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -1920,7 +1920,7 @@ Ujistěte se, že zadáváte stejné heslo dvakrát.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK ZAPNUTÝ</translation>
     </message>
 </context>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -1911,7 +1911,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -1924,7 +1924,7 @@ Bitte gib in beide Felder das gleiche Passwort ein.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>FESTSTELLTASTE AKTIVIERT</translation>
     </message>
 </context>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -1907,7 +1907,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS LOCK ΕΝΕΡΓΟΠΟΙΗΜΕΝΟ</translation>
     </message>
 </context>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -1900,7 +1900,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -1917,7 +1917,7 @@ Verifica que sean la misma en ambos recuadros.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>BLOQ MAYÚS ACTIVO</translation>
     </message>
 </context>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -1918,7 +1918,7 @@ Palun vaata, et sa mõlemal korral sisestad sama salasõna.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>SUURTÄHED ON AKTIVEERITUD</translation>
     </message>
 </context>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -1911,7 +1911,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>دکمه بزرگ نویسی (Caps Lock) روشن است</translation>
     </message>
 </context>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -1916,7 +1916,7 @@ Varmista, että syötät saman salasanan kahdesti.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK PÄÄLLÄ</translation>
     </message>
 </context>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -1916,7 +1916,7 @@ Veuillez vous assurer d&apos;entrer deux fois le même mot de passe.</translatio
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>MAJUSCULES ACTIVÉES</translation>
     </message>
 </context>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -1915,7 +1915,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>BLOQUEO DE MAIÚSCULAS HABILITADO</translation>
     </message>
 </context>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -1911,7 +1911,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>PISANJE VELIKIM SLOVIMA UKLJUČENO</translation>
     </message>
 </context>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -1903,7 +1903,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK AKTÍV</translation>
     </message>
 </context>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -1916,7 +1916,7 @@ Assicurati di inserire la stessa password due volte.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK ABILITATO</translation>
     </message>
 </context>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -1902,7 +1902,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>Caps Lock が有効になっています</translation>
     </message>
 </context>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -1940,7 +1940,7 @@ You may want to create one.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -1922,7 +1922,7 @@ Plural:10–20,30,40,..</translatorcomment>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>ĮJUNGTAS „CAPS LOCK“</translation>
     </message>
 </context>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -1926,7 +1926,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>Ir ieslēgts &apos;&apos;Caps Lock&apos;&apos;</translation>
     </message>
 </context>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -1919,7 +1919,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation></translation>
     </message>
 </context>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -1916,7 +1916,7 @@ Zorg ervoor dat je hetzelfde wachtwoord twee keer invoert.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK INGESCHAKELD</translation>
     </message>
 </context>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -1915,7 +1915,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK INGESCHAKELD</translation>
     </message>
 </context>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -1918,7 +1918,7 @@ Skriv inn samme passord to ganger.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK PÅSLÅTT</translation>
     </message>
 </context>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -1941,7 +1941,7 @@ Pamiętaj, aby dwukrotnie wprowadzić to samo hasło.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS LOCK WŁĄCZONY</translation>
     </message>
 </context>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -1944,7 +1944,7 @@ You may want to create one.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -1916,7 +1916,7 @@ Certifique-se de introduziu a mesma palavra-passe duas vezes.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>TECLA DE MAIÚSCULAS ATIVADA</translation>
     </message>
 </context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -1924,7 +1924,7 @@ Certifique-se de que você entrou a mesma senha duas vezes.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>TECLA CAPS-LOCK ATIVADA</translation>
     </message>
 </context>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -1928,7 +1928,7 @@ Vă rugăm să vă asigurați că introduceți aceeași parolă de două ori.</t
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK ACTIVAT</translation>
     </message>
 </context>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -1923,7 +1923,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>Включен Caps Lock</translation>
     </message>
 </context>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -1928,7 +1928,7 @@ Prosím, uistite sa, že ste zadali to isté heslo dvakrát.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>ZAPNUTÝ CAPS-LOCK</translation>
     </message>
 </context>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -1916,7 +1916,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -1919,7 +1919,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>УКЉУЧЕНА СУ ВЕЛИКА СЛОВА</translation>
     </message>
 </context>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -1920,7 +1920,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>UKLjUČEN CAPS-LOCK</translation>
     </message>
 </context>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -1916,7 +1916,7 @@ Vänligen se till att du skriver samma lösenord två gånger.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK AKTIVERAD</translation>
     </message>
 </context>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -1914,7 +1914,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -1916,7 +1916,7 @@ Lütfen aynı parolayı iki kez girdiğinizden emin olun.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK-ETKİN</translation>
     </message>
 </context>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -1915,7 +1915,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK قۇلۇپلاندى</translation>
     </message>
 </context>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -1921,7 +1921,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK УВІМКНЕНИЙ</translation>
     </message>
 </context>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -1916,7 +1916,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -1920,7 +1920,7 @@ Hãy đảm bảo nhập cùng một mật khẩu hai lần.</translation>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>CAPS-LOCK BẬT</translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1912,7 +1912,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation>大写锁定已启用</translation>
     </message>
 </context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -1908,7 +1908,7 @@ Please make sure to enter the same password twice.</source>
 <context>
     <name>PasswordEdit</name>
     <message>
-        <source>CAPS-LOCK ENABLED</source>
+        <source>Caps-lock enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Sometimes macOS shows an indicator by itself, but it's flaky. Ours is more consistent.

Also stop shouting at the user (in English) when caps is on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/213)
<!-- Reviewable:end -->
