### PR TITLE
cleanup: Stop loading smileypack in a separate thread.

### DIFF
--- a/src/persistence/smileypack.h
+++ b/src/persistence/smileypack.h
@@ -34,11 +34,10 @@ public:
     static QString getAsRichText(const QString& key);
 
 private slots:
-    void onSmileyPackChanged();
+    void load(const QString& filename);
     void cleanupIconsCache();
 
 private:
-    bool load(const QString& filename);
     void constructRegex();
 
     mutable std::map<QString, std::shared_ptr<QIcon>> cachedIcon;


### PR DESCRIPTION
It takes 10ms to load the file. There's no need to do this in a separate thread anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/215)
<!-- Reviewable:end -->
