### PR TITLE
fix: Show actual smileys in the smileypack selector.

### DIFF
--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -226,13 +226,14 @@ void UserInterfaceForm::reloadSmileys()
 
     // sometimes there are no emoticons available, don't crash in this case
     if (emoticons.isEmpty()) {
-        qDebug() << "reloadSmilies: No emoticons found";
+        qDebug() << "reloadSmileys: No emoticons found";
         return;
     }
 
     QStringList smileys;
-    for (int i = 0; i < emoticons.size(); ++i)
-        smileys.push_front(emoticons.at(i).first());
+    for (const auto& emoticon : emoticons) {
+        smileys.push_back(emoticon.first());
+    }
 
     emoticonsIcons.clear();
     const QSize size(18, 18);


### PR DESCRIPTION
Right now it's showing the last few elements of the smiley list, which is some countries flags. We should show the first ones, which is faces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/231)
<!-- Reviewable:end -->
