### PR TITLE
fix: Use the *last* `/src/` to find the source root.

### DIFF
--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -45,9 +45,9 @@ constexpr std::string_view sourceRootPath()
     // nullptr in release builds.
     constexpr std::string_view path = __FILE__;
     constexpr size_t srcRootPos = [=]() {
-        size_t pos = path.find("/src/");
+        size_t pos = path.rfind("/src/");
         if (pos == std::string_view::npos) {
-            pos = path.find("\\src\\");
+            pos = path.rfind("\\src\\");
         }
         return pos;
     }();


### PR DESCRIPTION
In case someone has `/src/` in the path leading up to qtox source root.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/237)
<!-- Reviewable:end -->
