### PR TITLE
chore: Don't imgbot-optimise SVGs.

### DIFF
--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,0 +1,7 @@
+{
+    "schedule": "daily",
+    "ignoredFiles": [
+        "*.svg"
+    ],
+    "prTitle" : "perf: ImgBot optimized images"
+}

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -45,9 +45,9 @@ constexpr std::string_view sourceRootPath()
     // nullptr in release builds.
     constexpr std::string_view path = __FILE__;
     constexpr size_t srcRootPos = [=]() {
-        size_t pos = path.find("/src/");
+        size_t pos = path.rfind("/src/");
         if (pos == std::string_view::npos) {
-            pos = path.find("\\src\\");
+            pos = path.rfind("\\src\\");
         }
         return pos;
     }();


### PR DESCRIPTION
We like them readable for security audit purposes. Actual resource compression is much more effective for saving space in binaries than the 7% savings by removing spaces and making them unreadable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/240)
<!-- Reviewable:end -->
