### PR TITLE
cleanup: Avoid contextless `connect`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ add_definitions(-DQT_NO_CAST_TO_ASCII)
 add_definitions(-DQT_RESTRICTED_CAST_FROM_ASCII)
 add_definitions(-DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT)
 add_definitions(-DQT_NO_URL_CAST_FROM_STRING)
+add_definitions(-DQT_NO_CONTEXTLESS_CONNECT)
 
 # Use ccache when available to speed up builds.
 if(USE_CCACHE)

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -131,7 +131,7 @@ ToxFriendCall::ToxFriendCall(uint32_t friendNum, bool VideoEnabled, CoreAV& av_,
             cameraSource.setupDefault();
         }
         cameraSource.subscribe();
-        videoInConn = QObject::connect(&cameraSource, &VideoSource::frameAvailable,
+        videoInConn = QObject::connect(&cameraSource, &VideoSource::frameAvailable, &av_,
                                        [&av_, friendNum](std::shared_ptr<VideoFrame> frame) {
                                            av_.sendCallVideo(friendNum, frame);
                                        });
@@ -219,7 +219,7 @@ ToxConferenceCall::~ToxConferenceCall()
 void ToxConferenceCall::onAudioSourceInvalidated()
 {
     auto newSrc = audio.makeSource();
-    connect(audioSource.get(), &IAudioSource::frameAvailable,
+    connect(audioSource.get(), &IAudioSource::frameAvailable, this,
             [this](const int16_t* pcm, size_t samples, uint8_t chans, uint32_t rate) {
                 if (conference.getPeersCount() <= 1) {
                     return;

--- a/src/net/avatarbroadcaster.cpp
+++ b/src/net/avatarbroadcaster.cpp
@@ -70,7 +70,7 @@ void AvatarBroadcaster::enableAutoBroadcast(bool state)
 {
     disconnect(&core, nullptr, this, nullptr);
     if (state) {
-        connect(&core, &Core::friendStatusChanged,
+        connect(&core, &Core::friendStatusChanged, this,
                 [this](uint32_t friendId, Status::Status) { sendAvatarTo(friendId); });
     }
 }

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -124,7 +124,7 @@ void Nexus::start()
 
     minimizeAction = windowMenu->addAction(QString());
     minimizeAction->setShortcut(Qt::CTRL | Qt::Key_M);
-    connect(minimizeAction, &QAction::triggered, [this]() {
+    connect(minimizeAction, &QAction::triggered, this, [this]() {
         minimizeAction->setEnabled(false);
         QApplication::focusWindow()->showMinimized();
     });

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -120,23 +120,23 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, Settings& s
     connections +=
         connect(selfVideoSurface, &VideoSurface::ratioChanged, this, &NetCamView::updateRatio);
 
-    connections += connect(videoSurface, &VideoSurface::boundaryChanged, [this]() {
+    connections += connect(videoSurface, &VideoSurface::boundaryChanged, this, [this]() {
         QRect boundingRect = videoSurface->getBoundingRect();
         updateFrameSize(boundingRect.size());
         selfFrame->setBoundary(boundingRect);
     });
 
-    connections += connect(videoSurface, &VideoSurface::ratioChanged, [this]() {
+    connections += connect(videoSurface, &VideoSurface::ratioChanged, this, [this]() {
         selfFrame->setMinimumWidth(selfFrame->minimumHeight() * selfVideoSurface->getRatio());
         QRect boundingRect = videoSurface->getBoundingRect();
         updateFrameSize(boundingRect.size());
         selfFrame->resetBoundary(boundingRect);
     });
 
-    connections += connect(&profile, &Profile::selfAvatarChanged,
+    connections += connect(&profile, &Profile::selfAvatarChanged, this,
                            [this](const QPixmap& pixmap) { selfVideoSurface->setAvatar(pixmap); });
 
-    connections += connect(&profile, &Profile::friendAvatarChanged,
+    connections += connect(&profile, &Profile::friendAvatarChanged, this,
                            [this](ToxPk friendPkArg, const QPixmap& pixmap) {
                                if (friendPk == friendPkArg)
                                    videoSurface->setAvatar(pixmap);

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -42,12 +42,12 @@ CircleWidget::CircleWidget(const Core& core_, FriendListWidget* parent, int id_,
     setName(settings.getCircleName(id), false);
     circleList[id] = this;
 
-    connect(nameLabel, &CroppingLabel::editFinished, [this](const QString& newName) {
+    connect(nameLabel, &CroppingLabel::editFinished, this, [this](const QString& newName) {
         if (!newName.isEmpty())
             emit renameRequested(this, newName);
     });
 
-    connect(nameLabel, &CroppingLabel::editRemoved, [this]() {
+    connect(nameLabel, &CroppingLabel::editRemoved, this, [this]() {
         if (isCompact())
             nameLabel->minimizeMaximumWidth();
     });

--- a/src/widget/form/conferenceform.cpp
+++ b/src/widget/form/conferenceform.cpp
@@ -267,7 +267,7 @@ void ConferenceForm::peerAudioPlaying(ToxPk peerPk)
     if (!peerAudioTimers[peerPk]) {
         peerAudioTimers[peerPk] = new QTimer(this);
         peerAudioTimers[peerPk]->setSingleShot(true);
-        connect(peerAudioTimers[peerPk], &QTimer::timeout, [this, peerPk] {
+        connect(peerAudioTimers[peerPk], &QTimer::timeout, this, [this, peerPk] {
             auto it = peerLabels.find(peerPk);
             if (it != peerLabels.end()) {
                 peerLabels[peerPk]->setProperty("playingAudio", LABEL_PEER_NOT_PLAYING_AUDIO);

--- a/src/widget/form/conferenceinviteform.cpp
+++ b/src/widget/form/conferenceinviteform.cpp
@@ -41,7 +41,7 @@ ConferenceInviteForm::ConferenceInviteForm(Settings& settings_, Core& core_)
     , core{core_}
 {
     QVBoxLayout* layout = new QVBoxLayout(this);
-    connect(createButton, &QPushButton::clicked,
+    connect(createButton, &QPushButton::clicked, this,
             [this]() { emit conferenceCreate(TOX_CONFERENCE_TYPE_AV); });
 
     QWidget* innerWidget = new QWidget(scroll);
@@ -114,12 +114,13 @@ bool ConferenceInviteForm::addConferenceInvite(const ConferenceInvite& inviteInf
     ConferenceInviteWidget* widget = new ConferenceInviteWidget(this, inviteInfo, settings, core);
     scroll->widget()->layout()->addWidget(widget);
     invites.append(widget);
-    connect(widget, &ConferenceInviteWidget::accepted, [this](const ConferenceInvite& inviteInfo_) {
-        deleteInviteWidget(inviteInfo_);
-        emit conferenceInviteAccepted(inviteInfo_);
-    });
+    connect(widget, &ConferenceInviteWidget::accepted, this,
+            [this](const ConferenceInvite& inviteInfo_) {
+                deleteInviteWidget(inviteInfo_);
+                emit conferenceInviteAccepted(inviteInfo_);
+            });
 
-    connect(widget, &ConferenceInviteWidget::rejected,
+    connect(widget, &ConferenceInviteWidget::rejected, this,
             [this](const ConferenceInvite& inviteInfo_) { deleteInviteWidget(inviteInfo_); });
     if (isVisible()) {
         emit conferenceInvitesSeen();

--- a/src/widget/form/conferenceinvitewidget.cpp
+++ b/src/widget/form/conferenceinvitewidget.cpp
@@ -32,8 +32,8 @@ ConferenceInviteWidget::ConferenceInviteWidget(QWidget* parent, const Conference
     , settings{settings_}
     , core{core_}
 {
-    connect(acceptButton, &QPushButton::clicked, [this] { emit accepted(inviteInfo); });
-    connect(rejectButton, &QPushButton::clicked, [this] { emit rejected(inviteInfo); });
+    connect(acceptButton, &QPushButton::clicked, this, [this] { emit accepted(inviteInfo); });
+    connect(rejectButton, &QPushButton::clicked, this, [this] { emit rejected(inviteInfo); });
     widgetLayout->addWidget(inviteMessageLabel);
     widgetLayout->addWidget(acceptButton);
     widgetLayout->addWidget(rejectButton);

--- a/src/widget/form/debug/debuglog.cpp
+++ b/src/widget/form/debug/debuglog.cpp
@@ -61,7 +61,7 @@ DebugLogForm::DebugLogForm(Paths& paths, Style& style, QWidget* parent)
 
     // Reload logs every 5 seconds
     reloadTimer_->start(5000);
-    connect(reloadTimer_.get(), &QTimer::timeout, [this, &paths] {
+    connect(reloadTimer_.get(), &QTimer::timeout, this, [this, &paths] {
         if (ui_->cbAutoReload->isChecked()) {
             debugLogModel_->reload(loadLogs(paths));
         }
@@ -74,12 +74,12 @@ DebugLogForm::DebugLogForm(Paths& paths, Style& style, QWidget* parent)
     for (int i = 0; i < filterEnum.keyCount(); ++i) {
         ui_->cmbFilters->addItem(QString::fromUtf8(filterEnum.key(i)));
     }
-    connect(ui_->cmbFilters, qOverload<int>(&QComboBox::currentIndexChanged), [this](int index) {
+    connect(ui_->cmbFilters, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int index) {
         debugLogModel_->setFilter(static_cast<DebugLogModel::Filter>(index));
     });
 
     ui_->debugLog->setModel(debugLogModel_.get());
-    connect(ui_->debugLog, &QListView::doubleClicked, [this](const QModelIndex& index) {
+    connect(ui_->debugLog, &QListView::doubleClicked, this, [this](const QModelIndex& index) {
         const int originalIndex = debugLogModel_->originalIndex(index);
         ui_->cmbFilters->setCurrentIndex(0);
         ui_->debugLog->scrollTo(debugLogModel_->index(originalIndex));

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -439,10 +439,10 @@ FilesForm::FilesForm(CoreFile& coreFile, Settings& settings, Style& style,
         coreFile.cancelFileSend(file.friendId, file.fileNum);
     };
 
-    connect(recvdModel, &FileTransferList::Model::togglePause, pauseFile);
-    connect(recvdModel, &FileTransferList::Model::cancel, cancelFileRecv);
-    connect(sentModel, &FileTransferList::Model::togglePause, pauseFile);
-    connect(sentModel, &FileTransferList::Model::cancel, cancelFileSend);
+    connect(recvdModel, &FileTransferList::Model::togglePause, &coreFile, pauseFile);
+    connect(recvdModel, &FileTransferList::Model::cancel, &coreFile, cancelFileRecv);
+    connect(sentModel, &FileTransferList::Model::togglePause, &coreFile, pauseFile);
+    connect(sentModel, &FileTransferList::Model::cancel, &coreFile, cancelFileSend);
 
     recvd = new FileTransferList::View(recvdModel, settings, style);
     sent = new FileTransferList::View(sentModel, settings, style);

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -152,7 +152,7 @@ void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
 {
     std::ignore = latestVersion;
     QObject::disconnect(linkConnection);
-    linkConnection = connect(bodyUI->updateAvailableButton, &QPushButton::clicked,
+    linkConnection = connect(bodyUI->updateAvailableButton, &QPushButton::clicked, this,
                              [link]() { QDesktopServices::openUrl(link); });
     bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
 }

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -346,10 +346,11 @@ FriendListWidget::SortingMode FriendListWidget::getMode() const
 void FriendListWidget::addConferenceWidget(ConferenceWidget* widget)
 {
     Conference* c = widget->getConference();
-    connect(c, &Conference::titleChanged, [this, widget](const QString& author, const QString& name) {
-        std::ignore = author;
-        renameConferenceWidget(widget, name);
-    });
+    connect(c, &Conference::titleChanged, this,
+            [this, widget](const QString& author, const QString& name) {
+                std::ignore = author;
+                renameConferenceWidget(widget, name);
+            });
 
     manager->addFriendListItem(widget);
 }

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -97,7 +97,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 
     if (chatroom->possibleToOpenInNewWindow()) {
         const auto openChatWindow = menu.addAction(tr("Open chat in new window"));
-        connect(openChatWindow, &QAction::triggered, [this]() { emit newWindowOpened(this); });
+        connect(openChatWindow, &QAction::triggered, this, [this]() { emit newWindowOpened(this); });
     }
 
     if (chatroom->canBeRemovedFromWindow()) {
@@ -117,7 +117,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     for (const auto& conference : chatroom->getConferences()) {
         const auto conferenceAction =
             inviteMenu->addAction(tr("Invite to conference '%1'").arg(conference.name));
-        connect(conferenceAction, &QAction::triggered,
+        connect(conferenceAction, &QAction::triggered, this,
                 [this, conference] { chatroom->inviteFriend(conference.conference); });
     }
 
@@ -139,7 +139,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 
     for (const auto& circle : chatroom->getOtherCircles()) {
         QAction* action = new QAction(tr("Move to circle \"%1\"").arg(circle.name), circleMenu);
-        connect(action, &QAction::triggered, [this, circle] { moveToCircle(circle.circleId); });
+        connect(action, &QAction::triggered, this, [this, circle] { moveToCircle(circle.circleId); });
         circleMenu->addAction(action);
     }
 

--- a/test/widget/filesform_test.cpp
+++ b/test/widget/filesform_test.cpp
@@ -151,12 +151,12 @@ void TestFileTransferList::testControl()
     bool cancelCalled = false;
     bool pauseCalled = false;
 
-    QObject::connect(model.get(), &Model::cancel, [&](ToxFile file) {
+    QObject::connect(model.get(), &Model::cancel, this, [&](ToxFile file) {
         std::ignore = file;
         cancelCalled = true;
     });
 
-    QObject::connect(model.get(), &Model::togglePause, [&](ToxFile file) {
+    QObject::connect(model.get(), &Model::togglePause, this, [&](ToxFile file) {
         std::ignore = file;
         pauseCalled = true;
     });


### PR DESCRIPTION
To ensure signals are disconnected when target objects go out of scope.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/248)
<!-- Reviewable:end -->
