### PR TITLE
cleanup: Reduce amount of implicit casting in signals/slots.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,8 @@ endif()
 add_definitions(-DQT_NO_CAST_FROM_BYTEARRAY)
 add_definitions(-DQT_NO_CAST_TO_ASCII)
 add_definitions(-DQT_RESTRICTED_CAST_FROM_ASCII)
+add_definitions(-DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT)
+add_definitions(-DQT_NO_URL_CAST_FROM_STRING)
 
 # Use ccache when available to speed up builds.
 if(USE_CCACHE)

--- a/audio/src/backend/openal.cpp
+++ b/audio/src/backend/openal.cpp
@@ -60,8 +60,7 @@ OpenAL::OpenAL(IAudioSettings& _settings)
 
     voiceTimer.setSingleShot(true);
     voiceTimer.moveToThread(audioThread);
-    connect(this, &OpenAL::startActive, &voiceTimer,
-            static_cast<void (QTimer::*)(int)>(&QTimer::start));
+    connect(this, &OpenAL::startActive, this, [this](qreal time) { voiceTimer.start(time); });
     connect(&voiceTimer, &QTimer::timeout, this, &OpenAL::stopActive);
 
     connect(&captureTimer, &QTimer::timeout, this, &OpenAL::doAudio);

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -273,7 +273,7 @@ void Text::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 
     // open anchor in browser
     if (!anchor.isEmpty())
-        QDesktopServices::openUrl(anchor);
+        QDesktopServices::openUrl(QUrl(anchor));
 }
 
 void Text::hoverMoveEvent(QGraphicsSceneHoverEvent* event)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -728,7 +728,7 @@ void Core::sendConferenceAction(int conferenceId, const QString& message)
     sendConferenceMessageWithType(conferenceId, message, TOX_MESSAGE_TYPE_ACTION);
 }
 
-void Core::changeConferenceTitle(int conferenceId, const QString& title)
+void Core::changeConferenceTitle(uint32_t conferenceId, const QString& title)
 {
     QMutexLocker<QRecursiveMutex> ml{&coreLoopLock};
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -116,7 +116,7 @@ public slots:
     bool sendMessage(uint32_t friendId, const QString& message, ReceiptNum& receipt) override;
     void sendConferenceMessage(int conferenceId, const QString& message) override;
     void sendConferenceAction(int conferenceId, const QString& message) override;
-    void changeConferenceTitle(int conferenceId, const QString& title);
+    void changeConferenceTitle(uint32_t conferenceId, const QString& title);
     bool sendAction(uint32_t friendId, const QString& action, ReceiptNum& receipt) override;
     void sendTyping(uint32_t friendId, bool typing);
 
@@ -163,21 +163,22 @@ signals:
     void friendRemoved(uint32_t friendId);
     void friendLastSeenChanged(uint32_t friendId, const QDateTime& dateTime);
 
-    void emptyConferenceCreated(int conferencenumber, const ConferenceId conferenceId,
+    void emptyConferenceCreated(uint32_t conferencenumber, const ConferenceId conferenceId,
                                 const QString& title = QString());
     void conferenceInviteReceived(const ConferenceInvite& inviteInfo);
-    void conferenceMessageReceived(int conferencenumber, int peernumber, const QString& message,
-                                   bool isAction);
-    void conferenceNamelistChanged(int conferencenumber, int peernumber, uint8_t change);
-    void conferencePeerlistChanged(int conferencenumber);
-    void conferencePeerNameChanged(int conferencenumber, const ToxPk& peerPk, const QString& newName);
-    void conferenceTitleChanged(int conferencenumber, const QString& author, const QString& title);
-    void conferencePeerAudioPlaying(int conferencenumber, ToxPk peerPk);
-    void conferenceSentFailed(int conferenceId);
-    void conferenceJoined(int conferencenumber, ConferenceId conferenceId);
+    void conferenceMessageReceived(uint32_t conferencenumber, uint32_t peernumber,
+                                   const QString& message, bool isAction);
+    void conferenceNamelistChanged(uint32_t conferencenumber, uint32_t peernumber, uint8_t change);
+    void conferencePeerlistChanged(uint32_t conferencenumber);
+    void conferencePeerNameChanged(uint32_t conferencenumber, const ToxPk& peerPk,
+                                   const QString& newName);
+    void conferenceTitleChanged(uint32_t conferencenumber, const QString& author, const QString& title);
+    void conferencePeerAudioPlaying(uint32_t conferencenumber, ToxPk peerPk);
+    void conferenceSentFailed(uint32_t conferenceId);
+    void conferenceJoined(uint32_t conferencenumber, ConferenceId conferenceId);
     void actionSentResult(uint32_t friendId, const QString& action, int success);
 
-    void receiptReceived(int friedId, ReceiptNum receipt);
+    void receiptReceived(uint32_t friendId, ReceiptNum receipt);
 
     void failedToRemoveFriend(uint32_t friendId);
 

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -21,8 +21,7 @@
 
 #ifdef UPDATE_CHECK_ENABLED
 namespace {
-const QString versionUrl{
-    QStringLiteral("https://api.github.com/repos/TokTok/qTox/releases/latest")};
+const QUrl versionUrl{QStringLiteral("https://api.github.com/repos/TokTok/qTox/releases/latest")};
 // Release candidates are ignored, as they are prereleases and don't appear in
 // the response to the releases/latest API call.
 const QString versionRegexString{QStringLiteral(R"(v([0-9]+)\.([0-9]+)\.([0-9]+))")};

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1250,7 +1250,7 @@ void Widget::addFriendFailed(const ToxPk& userId, const QString& errorInfo)
     QMessageBox::critical(nullptr, "Error", info);
 }
 
-void Widget::onCoreFriendStatusChanged(int friendId, Status::Status status)
+void Widget::onCoreFriendStatusChanged(uint32_t friendId, Status::Status status)
 {
     const auto& friendPk = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendPk);
@@ -1282,7 +1282,7 @@ void Widget::onFriendStatusChanged(const ToxPk& friendPk, Status::Status status)
     contentDialogManager->updateFriendStatus(friendPk);
 }
 
-void Widget::onFriendStatusMessageChanged(int friendId, const QString& message)
+void Widget::onFriendStatusMessageChanged(uint32_t friendId, const QString& message)
 {
     const auto& friendPk = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendPk);
@@ -1316,7 +1316,7 @@ void Widget::onFriendDisplayedNameChanged(const QString& displayed)
     chatListWidget->itemsChanged();
 }
 
-void Widget::onFriendUsernameChanged(int friendId, const QString& username)
+void Widget::onFriendUsernameChanged(uint32_t friendId, const QString& username)
 {
     const auto& friendPk = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendPk);
@@ -1412,7 +1412,7 @@ void Widget::onFriendMessageReceived(uint32_t friendnumber, const QString& messa
     friendMessageDispatchers[f->getPublicKey()]->onMessageReceived(isAction, message);
 }
 
-void Widget::onReceiptReceived(int friendId, ReceiptNum receipt)
+void Widget::onReceiptReceived(uint32_t friendId, ReceiptNum receipt)
 {
     const auto& friendKey = friendList->id2Key(friendId);
     Friend* f = friendList->findFriend(friendKey);
@@ -1955,7 +1955,7 @@ void Widget::onConferenceInviteAccepted(const ConferenceInvite& inviteInfo)
     }
 }
 
-void Widget::onConferenceMessageReceived(int conferencenumber, int peernumber,
+void Widget::onConferenceMessageReceived(uint32_t conferencenumber, uint32_t peernumber,
                                          const QString& message, bool isAction)
 {
     const ConferenceId& conferenceId = conferenceList->id2Key(conferencenumber);
@@ -2008,7 +2008,7 @@ void Widget::titleChangedByUser(const QString& title)
     emit changeConferenceTitle(conference->getId(), title);
 }
 
-void Widget::onConferencePeerAudioPlaying(int conferencenumber, ToxPk peerPk)
+void Widget::onConferencePeerAudioPlaying(uint32_t conferencenumber, ToxPk peerPk)
 {
     const ConferenceId& conferenceId = conferenceList->id2Key(conferencenumber);
     assert(conferenceList->findConference(conferenceId));
@@ -2179,7 +2179,7 @@ void Widget::onEmptyConferenceCreated(uint32_t conferencenumber, const Conferenc
     }
 }
 
-void Widget::onConferenceJoined(int conferenceNum, const ConferenceId& conferenceId)
+void Widget::onConferenceJoined(uint32_t conferenceNum, const ConferenceId& conferenceId)
 {
     createConference(conferenceNum, conferenceId);
 }

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -165,30 +165,30 @@ public slots:
     void setStatusMessage(const QString& statusMessage);
     void addFriend(uint32_t friendId, const ToxPk& friendPk);
     void addFriendFailed(const ToxPk& userId, const QString& errorInfo = QString());
-    void onCoreFriendStatusChanged(int friendId, Status::Status status);
+    void onCoreFriendStatusChanged(uint32_t friendId, Status::Status status);
     void onFriendStatusChanged(const ToxPk& friendPk, Status::Status status);
-    void onFriendStatusMessageChanged(int friendId, const QString& message);
+    void onFriendStatusMessageChanged(uint32_t friendId, const QString& message);
     void onFriendDisplayedNameChanged(const QString& displayed);
-    void onFriendUsernameChanged(int friendId, const QString& username);
+    void onFriendUsernameChanged(uint32_t friendId, const QString& username);
     void onFriendAliasChanged(const ToxPk& friendId, const QString& alias);
     void onFriendMessageReceived(uint32_t friendnumber, const QString& message, bool isAction);
-    void onReceiptReceived(int friendId, ReceiptNum receipt);
+    void onReceiptReceived(uint32_t friendId, ReceiptNum receipt);
     void onFriendRequestReceived(const ToxPk& friendPk, const QString& message);
     void onFileReceiveRequested(const ToxFile& file);
     void onEmptyConferenceCreated(uint32_t conferencenumber, const ConferenceId& conferenceId,
                                   const QString& title);
-    void onConferenceJoined(int conferenceNum, const ConferenceId& conferenceId);
+    void onConferenceJoined(uint32_t conferenceNum, const ConferenceId& conferenceId);
     void onConferenceInviteReceived(const ConferenceInvite& inviteInfo);
     void onConferenceInviteAccepted(const ConferenceInvite& inviteInfo);
-    void onConferenceMessageReceived(int conferencenumber, int peernumber, const QString& message,
-                                     bool isAction);
+    void onConferenceMessageReceived(uint32_t conferencenumber, uint32_t peernumber,
+                                     const QString& message, bool isAction);
     void onConferencePeerlistChanged(uint32_t conferencenumber);
     void onConferencePeerNameChanged(uint32_t conferencenumber, const ToxPk& peerPk,
                                      const QString& newName);
     void onConferenceTitleChanged(uint32_t conferencenumber, const QString& author,
                                   const QString& title);
     void titleChangedByUser(const QString& title);
-    void onConferencePeerAudioPlaying(int conferencenumber, ToxPk peerPk);
+    void onConferencePeerAudioPlaying(uint32_t conferencenumber, ToxPk peerPk);
     void onConferenceSendFailed(uint32_t conferencenumber);
     void onFriendTypingChanged(uint32_t friendnumber, bool isTyping);
     void nextChat();


### PR DESCRIPTION
Also don't implicit-cast string to `QUrl`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/249)
<!-- Reviewable:end -->
