### PR TITLE
chore: Build all deps including Qt statically on macOS.

### DIFF
--- a/.ci-scripts/.gitignore
+++ b/.ci-scripts/.gitignore
@@ -1,0 +1,1 @@
+/dockerfiles

--- a/.ci-scripts/build-macos-qt.sh
+++ b/.ci-scripts/build-macos-qt.sh
@@ -9,15 +9,6 @@ set -euo pipefail
 readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 . "$SCRIPT_DIR/macos_install_deps.sh"
 
+# Needs openssl from build-macos-deps.sh to already have been installed.
 install_deps \
-  build_openssl.sh \
-  build_qrencode.sh \
-  build_libexif.sh \
-  build_sodium.sh \
-  build_openal.sh \
-  build_vpx.sh \
-  build_opus.sh \
-  build_ffmpeg.sh \
-  build_sqlcipher.sh \
-  build_hunspell.sh \
-  build_toxcore.sh
+  build_qt_macos.sh

--- a/.ci-scripts/build-macos-qtdeps.sh
+++ b/.ci-scripts/build-macos-qtdeps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2024 The TokTok team
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+. "$SCRIPT_DIR/macos_install_deps.sh"
+
+# Install qTox dependencies that depend on Qt.
+install_deps \
+  build_extra_cmake_modules.sh \
+  build_sonnet.sh

--- a/.ci-scripts/build-qtox-macos.sh
+++ b/.ci-scripts/build-qtox-macos.sh
@@ -20,8 +20,10 @@ source "$SCRIPT_DIR/dockerfiles/qtox/build_utils.sh"
 parse_arch --arch macos --supported macos --dep macos
 
 if [ "$1" == "user" ]; then
+  CMAKE=cmake
   PREFIX_PATH="$(brew --prefix qt@6)"
 elif [ "$1" == "dist" ]; then
+  CMAKE="$DEP_PREFIX/qt/bin/qt-cmake"
   PREFIX_PATH="$DEP_PREFIX;$(brew --prefix qt@6)"
 else
   echo "Unknown arg $1"
@@ -31,7 +33,7 @@ fi
 build_qtox() {
   # Explicitly include with -isystem to avoid warnings from system headers.
   # CMake will use -I instead of -isystem, so we need to set it manually.
-  cmake \
+  "$CMAKE" \
     -DCMAKE_CXX_FLAGS="-isystem/usr/local/include" \
     -DUBSAN=ON \
     -DUPDATE_CHECK=ON \

--- a/.ci-scripts/macos_install_deps.sh
+++ b/.ci-scripts/macos_install_deps.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2022 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
+
+set -euo pipefail
+
+if [ ! -d "$SCRIPT_DIR/dockerfiles" ]; then
+  git clone --depth=1 https://github.com/TokTok/dockerfiles "$SCRIPT_DIR/dockerfiles"
+fi
+
+ARCH="$1"
+
+install_deps() {
+  for dep in "$@"; do
+    mkdir -p _build-dep
+    pushd _build-dep
+    "$SCRIPT_DIR/dockerfiles/qtox/$dep" --arch "macos-$ARCH" --libtype "static"
+    popd
+    rm -rf _build-dep
+  done
+}

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -334,21 +334,38 @@ jobs:
         with:
           path: ".cache/ccache"
           key: ${{ github.job }}-${{ matrix.arch }}-ccache
+      - name: Cache dependencies (except/requires Qt)
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            .ci-scripts/dockerfiles/local-deps/bin
+            .ci-scripts/dockerfiles/local-deps/include
+            .ci-scripts/dockerfiles/local-deps/lib
+            .ci-scripts/dockerfiles/local-deps/share
+          key: ${{ runner.os }}-${{ matrix.arch }}-local-deps
+      - name: Cache dependencies (only Qt)
+        id: cache-qt
+        uses: actions/cache@v4
+        with:
+          path: |
+            .ci-scripts/dockerfiles/local-deps/qt
+          key: ${{ runner.os }}-${{ matrix.arch }}-qt
       - name: Set up ccache
         run: brew install ccache && ccache --set-config=max_size=200M --set-config=cache_dir="$PWD/.cache/ccache" && ccache --show-config
       - name: Fetch build scripts
         run: git clone --depth=1 https://github.com/TokTok/dockerfiles ".ci-scripts/dockerfiles"
       - name: Homebrew dependencies to build dependencies
         run: brew bundle --file ./macos/Brewfile-DepBuildDeps
-      - name: Cache dependencies
-        id: cache-deps
-        uses: actions/cache@v4
-        with:
-          path: ".ci-scripts/dockerfiles/local-deps"
-          key: ${{ runner.os }}-${{ matrix.arch }}-local-deps
-      - name: Build dependencies
+      - name: Build dependencies (except Qt)
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: ./.ci-scripts/build-macos-deps.sh ${{ matrix.arch }}
+      - name: Build dependencies (only Qt)
+        if: steps.cache-qt.outputs.cache-hit != 'true'
+        run: ./.ci-scripts/build-macos-qt.sh ${{ matrix.arch }}
+      - name: Build dependencies (requires Qt)
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: ./.ci-scripts/build-macos-qtdeps.sh ${{ matrix.arch }}
       - name: Build qTox
         run: ./.ci-scripts/build-qtox-macos.sh dist ${{ matrix.arch }}
       - name: Upload dmg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(APPLE)
   # The /opt version is needed on arm64, but it doesn't harm on x86_64. The
   # /usr/local version is needed on x86_64, but it doesn't harm on arm64.
   set(ENV{PKG_CONFIG_PATH}
-      /opt/homebrew/opt/openal-soft/lib/pkgconfig:/usr/local/opt/openal-soft/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}
+      $ENV{PKG_CONFIG_PATH}:/opt/homebrew/opt/openal-soft/lib/pkgconfig:/usr/local/opt/openal-soft/lib/pkgconfig
   )
 endif()
 
@@ -673,14 +673,21 @@ set_target_properties(
              QT_ANDROID_PACKAGE_SOURCE_DIR
              "${CMAKE_CURRENT_SOURCE_DIR}/android/${Qt6Core_VERSION}")
 
+if(QT_FEATURE_static)
+  if(APPLE)
+    target_link_libraries(${PROJECT_NAME}
+                          PRIVATE Qt6::QOffscreenIntegrationPlugin)
+  else()
+    target_link_directories(${PROJECT_NAME} PRIVATE
+                            "/sysroot/opt/qt/plugins/platforms")
+    target_link_libraries(
+      ${PROJECT_NAME}
+      PRIVATE Qt6::QLinuxFbIntegrationPlugin Qt6::QOffscreenIntegrationPlugin
+              Qt6::QVncIntegrationPlugin Qt6::QXcbGlxIntegrationPlugin
+              Qt6::QXcbIntegrationPlugin Qt6::QWaylandIntegrationPlugin)
+  endif()
+endif()
 if(FULLY_STATIC)
-  target_link_directories(${PROJECT_NAME} PRIVATE
-                          "/sysroot/opt/qt/plugins/platforms")
-  target_link_libraries(
-    ${PROJECT_NAME}
-    PRIVATE Qt6::QLinuxFbIntegrationPlugin Qt6::QOffscreenIntegrationPlugin
-            Qt6::QVncIntegrationPlugin Qt6::QXcbGlxIntegrationPlugin
-            Qt6::QXcbIntegrationPlugin Qt6::QWaylandIntegrationPlugin)
   target_link_options(${PROJECT_NAME} PRIVATE -static)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,42 +2,78 @@
   "version": 3,
   "configurePresets": [
     {
+      "name": "static",
+      "binaryDir": "${sourceDir}/_build-static",
+      "generator": "Ninja",
+      "environment": {
+        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+      },
+      "cacheVariables": {
+        "SPELL_CHECK": true,
+        "STRICT_OPTIONS": true,
+        "UPDATE_CHECK": true,
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14"
+      }
+    },
+    {
       "name": "asan",
       "binaryDir": "${sourceDir}/_build-asan",
       "generator": "Ninja",
+      "environment": {
+        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+      },
       "cacheVariables": {
         "ASAN": true,
         "UBSAN": true,
         "SPELL_CHECK": true,
         "STRICT_OPTIONS": true,
+        "UPDATE_CHECK": true,
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "CMAKE_EXPORT_COMPILE_COMMANDS": true
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14"
       }
     },
     {
       "name": "tsan",
       "binaryDir": "${sourceDir}/_build-tsan",
       "generator": "Ninja",
+      "environment": {
+        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+      },
       "cacheVariables": {
         "TSAN": true,
         "SPELL_CHECK": true,
         "STRICT_OPTIONS": true,
+        "UPDATE_CHECK": true,
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "CMAKE_EXPORT_COMPILE_COMMANDS": true
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14"
       }
     },
     {
       "name": "profiling",
       "binaryDir": "${sourceDir}/_build-profiling",
       "generator": "Ninja",
+      "environment": {
+        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+      },
       "cacheVariables": {
         "SPELL_CHECK": true,
         "STRICT_OPTIONS": true,
+        "UPDATE_CHECK": true,
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "CMAKE_EXPORT_COMPILE_COMMANDS": true
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14"
       }
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,13 +2,14 @@
   "version": 3,
   "configurePresets": [
     {
-      "name": "static",
+      "name": "static-release",
       "binaryDir": "${sourceDir}/_build-static",
       "generator": "Ninja",
       "environment": {
         "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
       },
       "cacheVariables": {
+        "UBSAN": true,
         "SPELL_CHECK": true,
         "STRICT_OPTIONS": true,
         "UPDATE_CHECK": true,
@@ -16,7 +17,29 @@
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "14"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/qt/lib/cmake/Qt6/qt.toolchain.cmake"
+      }
+    },
+    {
+      "name": "static-asan",
+      "binaryDir": "${sourceDir}/_build-static",
+      "generator": "Ninja",
+      "environment": {
+        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+      },
+      "cacheVariables": {
+        "ASAN": true,
+        "UBSAN": true,
+        "SPELL_CHECK": true,
+        "STRICT_OPTIONS": true,
+        "UPDATE_CHECK": true,
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/qt/lib/cmake/Qt6/qt.toolchain.cmake"
       }
     },
     {

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -15,7 +15,6 @@ find_package(Qt6Core          REQUIRED)
 find_package(Qt6Gui           REQUIRED)
 find_package(Qt6Linguist      REQUIRED)
 find_package(Qt6Network       REQUIRED)
-find_package(Qt6OpenGL        REQUIRED)
 find_package(Qt6Svg           REQUIRED)
 find_package(Qt6Test          REQUIRED)
 find_package(Qt6Widgets       REQUIRED)
@@ -30,17 +29,22 @@ add_dependency(
   Qt6::Core
   Qt6::Gui
   Qt6::Network
-  Qt6::OpenGL
   Qt6::Svg
   Qt6::Widgets
   Qt6::Xml)
 
-# Optional dependency for desktop notifications.
-find_package(Qt6DBus)
+if(QT_FEATURE_dbus)
+  # Optional dependency for desktop notifications.
+  find_package(Qt6DBus)
 
-if(Qt6DBus_FOUND)
-  add_dependency(Qt6::DBus)
-  message(STATUS "Using DBus for desktop notifications")
+  if(Qt6DBus_FOUND)
+    if(Qt6DBus_DIR MATCHES "^${Qt6_DIR}")
+      add_dependency(Qt6::DBus)
+      message(STATUS "Using DBus for desktop notifications")
+    else()
+      message(STATUS "Not using DBus (Qt6DBus found in ${Qt6DBus_DIR}, which is outside Qt6 installation ${Qt6_DIR})")
+    endif()
+  endif()
 endif()
 
 include(CMakeParseArguments)
@@ -126,7 +130,12 @@ search_dependency(LIBQRENCODE         PACKAGE libqrencode)
 search_dependency(LIBSODIUM           PACKAGE libsodium)
 search_dependency(LIBSWSCALE          PACKAGE libswscale)
 search_dependency(SQLCIPHER           PACKAGE sqlcipher)
+search_dependency(OPUS                PACKAGE opus)
 search_dependency(VPX                 PACKAGE vpx)
+
+if(APPLE)
+  search_dependency(LIBCRYPTO         PACKAGE libcrypto)
+endif()
 
 if(SPELL_CHECK)
     find_package(KF6Sonnet)

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -18,9 +18,16 @@ function(auto_test subsystem module extra_res extra_libs)
     ${CHECK_LIBRARIES}
     Qt6::Test
     ${extra_libs})
+  if(QT_FEATURE_static)
+    target_link_libraries(test_${module}
+      Qt6::QOffscreenIntegrationPlugin)
+  endif()
   add_test(
     NAME test_${module}
     COMMAND ${TEST_CROSSCOMPILING_EMULATOR} test_${module})
+  # don't require a display server for GUI tests
+  set_tests_properties(test_${module} PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endfunction()
 
 add_subdirectory(test/mock)

--- a/macos/Brewfile-DepBuildDeps
+++ b/macos/Brewfile-DepBuildDeps
@@ -1,11 +1,9 @@
-# Dependencies for building all of qTox's dependencies from source. Needed for
-# distributable builds, but users should use Brewfile if they are just compiling
-# for their own machine.
+# Dependencies for building all of qTox's dependencies except Qt from source.
+# Needed for distributable builds, but users should use Brewfile if they are
+# just compiling for their own machine.
 brew "cmake"
 brew "coreutils"
 brew "git"
 brew "libtool"
 brew "ninja"
 brew "yasm"
-
-brew "qt@6" # Qt sets a low compatibility version by default: https://doc.qt.io/qt-6/macos.html#target-platforms

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,9 @@
 
 int main(int argc, char* argv[])
 {
+#if defined(QT_STATIC) && defined(SPELL_CHECKING)
+    Q_INIT_RESOURCE(trigrams);
+#endif
     AppManager appManager(argc, argv);
     int errorcode = appManager.run();
 
@@ -19,10 +22,16 @@ int main(int argc, char* argv[])
 }
 
 #ifdef QT_STATIC
-Q_IMPORT_PLUGIN(QLinuxFbIntegrationPlugin)
 Q_IMPORT_PLUGIN(QOffscreenIntegrationPlugin)
+#if defined(Q_OS_LINUX)
+Q_IMPORT_PLUGIN(QLinuxFbIntegrationPlugin)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 Q_IMPORT_PLUGIN(QXcbGlxIntegrationPlugin)
 Q_IMPORT_PLUGIN(QVncIntegrationPlugin)
 Q_IMPORT_PLUGIN(QWaylandIntegrationPlugin)
+#elif defined(Q_OS_MACOS)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
+#else
+#error "No static linking supported for platform"
 #endif
+#endif // QT_STATIC

--- a/test/persistence/smileypack_test.cpp
+++ b/test/persistence/smileypack_test.cpp
@@ -32,8 +32,6 @@ QString MockSettings::getSmileyPack() const
 class TestSmileyPack : public QObject
 {
     Q_OBJECT
-public:
-    TestSmileyPack();
 
 private slots:
     void testSmilifySingleCharEmoji();
@@ -42,20 +40,8 @@ private slots:
 
 private:
     std::unique_ptr<QGuiApplication> app;
-    std::unique_ptr<MockSettings> settings;
+    std::unique_ptr<MockSettings> settings = std::make_unique<MockSettings>();
 };
-
-TestSmileyPack::TestSmileyPack()
-{
-    static char arg1[]{"QToxSmileyPackTestApp"};
-    static char arg2[]{"-platform"};
-    static char arg3[]{"offscreen"};
-    static char* qtTestAppArgv[] = {arg1, arg2, arg3};
-    static int qtTestAppArgc = 3;
-
-    app = std::unique_ptr<QGuiApplication>(new QGuiApplication(qtTestAppArgc, qtTestAppArgv));
-    settings = std::unique_ptr<MockSettings>(new MockSettings());
-}
 
 /**
  * @brief Test that single-character emojis (non-ascii) are correctly smilified
@@ -115,5 +101,5 @@ void TestSmileyPack::testSmilifyAsciiEmoticon()
 }
 
 
-QTEST_GUILESS_MAIN(TestSmileyPack)
+QTEST_MAIN(TestSmileyPack)
 #include "smileypack_test.moc"


### PR DESCRIPTION
This way we can avoid the buggy macdeployqt entirely. Unfortunately, CrowdStrike doesn't like the modified binaries it produces and kills qTox on startup (unless running in `lldb`).

Related: https://github.com/Mozilla-Ocho/llamafile/issues/14

Requires:
- https://github.com/TokTok/dockerfiles/pull/185
- https://github.com/TokTok/dockerfiles/pull/187
- https://github.com/TokTok/dockerfiles/pull/190

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/254)
<!-- Reviewable:end -->
