### PR TITLE
refactor: Add logging category to debug log.

### DIFF
--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -105,11 +105,14 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
     }
 
     const QString file = canonicalLogFilePath(ctxt.file);
+    const QString category =
+        ctxt.category ? QString::fromUtf8(ctxt.category) : QStringLiteral("default");
 
     // Time should be in UTC to save user privacy on log sharing
     QTime time = QDateTime::currentDateTime().toUTC().time();
     QString logPrefix =
-        QStringLiteral("[%1 UTC] %2:%3 : ").arg(time.toString("HH:mm:ss.zzz")).arg(file).arg(ctxt.line);
+        QStringLiteral("[%1 UTC] (%2) %3:%4 : ")
+            .arg(time.toString("HH:mm:ss.zzz"), category, file, QString::number(ctxt.line));
     switch (type) {
     case QtDebugMsg:
         logPrefix += "Debug";

--- a/src/model/debug/debuglogmodel.h
+++ b/src/model/debug/debuglogmodel.h
@@ -30,6 +30,7 @@ public:
         int index;
 
         QString time;
+        QString category;
         QString file;
         int line;
         QtMsgType type;


### PR DESCRIPTION
This is useful to distinguish log sources. In the future, we can use this to e.g. make more verbose logging optional or allow category-filtering in the debug log view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/256)
<!-- Reviewable:end -->
