### PR TITLE
cleanup: Avoid string concatenation in log output.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1355,7 +1355,7 @@ QString Core::getPeerName(const ToxPk& id) const
     std::vector<uint8_t> nameBuf(nameSize);
     tox_friend_get_name(tox.get(), friendId, nameBuf.data(), &queryError);
     if (!PARSE_ERR(queryError)) {
-        qWarning() << "getPeerName: Can't get name of friend " + QString().setNum(friendId);
+        qWarning() << "getPeerName: Can't get name of friend" << friendId;
         return {};
     }
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -92,7 +92,7 @@ void Settings::loadGlobal()
         defaultSettings = true;
     }
 
-    qDebug() << "Loading settings from " + filePath;
+    qDebug() << "Loading settings from" << filePath;
 
     QSettings s(filePath, QSettings::IniFormat);
 
@@ -604,7 +604,7 @@ void Settings::saveGlobal()
         return;
 
     QString path = paths.getSettingsDirPath() + globalSettingsFile;
-    qDebug() << "Saving global settings at " + path;
+    qDebug() << "Saving global settings at" << path;
 
     QSettings s(path, QSettings::IniFormat);
 


### PR DESCRIPTION
This causes the log output to put quotes around the message. E.g.

```
[16:06:12.863 UTC] src/persistence/settings.cpp:95 : Debug: "Loading settings from :/conf/qtox.ini"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/258)
<!-- Reviewable:end -->
