### PR TITLE
feat(UI): Better integration with system dark modes.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
-Checks: '
-	-*,
-	readability-named-parameter,
-	readability-inconsistent-declaration-parameter-name'
+Checks: "-*
+, modernize-use-emplace
+, readability-named-parameter
+, readability-inconsistent-declaration-parameter-name
+"
 WarningsAsErrors: "*"

--- a/src/widget/style.h
+++ b/src/widget/style.h
@@ -57,6 +57,9 @@ public:
         Light,
         Dark
     };
+    Q_ENUM(MainTheme)
+
+    static int defaultThemeColor(MainTheme theme);
 
     static QStringList getThemeColorNames();
     static QString getThemeFolder(int themeColor);


### PR DESCRIPTION
If the OS/desktop environment have dark mode set, then qTox will select the default dark color scheme as well.

Also, if the user sets light mode, this sets Qt to light mode as well. This avoids conflicting style hints resulting in invisible text (dark grey on black).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/261)
<!-- Reviewable:end -->
