### PR TITLE
cleanup: Remove unnecessary path cleaner in tox logger.

### DIFF
--- a/src/core/toxlogger.cpp
+++ b/src/core/toxlogger.cpp
@@ -9,21 +9,9 @@
 
 #include <QDebug>
 #include <QLoggingCategory>
-#include <QRegularExpression>
-#include <QString>
-#include <QStringBuilder>
 
 namespace ToxLogger {
 namespace {
-
-QByteArray cleanPath(const char* file)
-{
-    // for privacy, make the path relative to the c-toxcore source directory
-    const QRegularExpression pathCleaner(QLatin1String{"[\\s|\\S]*c-toxcore."});
-    QByteArray cleanedPath = QString::fromUtf8(file).remove(pathCleaner).toUtf8();
-    cleanedPath.append('\0');
-    return cleanedPath;
-}
 
 Q_LOGGING_CATEGORY(toxcore, "tox.core")
 
@@ -38,22 +26,21 @@ void onLogMessage(Tox* tox, Tox_Log_Level level, const char* file, uint32_t line
 {
     std::ignore = tox;
     std::ignore = user_data;
-    const QByteArray cleanedPath = cleanPath(file);
 
     switch (level) {
     case TOX_LOG_LEVEL_TRACE:
         return; // trace level generates too much noise to enable by default
     case TOX_LOG_LEVEL_DEBUG:
-        QMessageLogger(cleanedPath.data(), line, func).debug(toxcore) << message;
+        QMessageLogger(file, line, func).debug(toxcore) << message;
         break;
     case TOX_LOG_LEVEL_INFO:
-        QMessageLogger(cleanedPath.data(), line, func).info(toxcore) << message;
+        QMessageLogger(file, line, func).info(toxcore) << message;
         break;
     case TOX_LOG_LEVEL_WARNING:
-        QMessageLogger(cleanedPath.data(), line, func).warning(toxcore) << message;
+        QMessageLogger(file, line, func).warning(toxcore) << message;
         break;
     case TOX_LOG_LEVEL_ERROR:
-        QMessageLogger(cleanedPath.data(), line, func).critical(toxcore) << message;
+        QMessageLogger(file, line, func).critical(toxcore) << message;
         break;
     }
 }


### PR DESCRIPTION
Toxcore already cleans this path and only passes the filename. This path cleaner wasn't great to begin with (requiring the source directory name to be c-toxcore).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/266)
<!-- Reviewable:end -->
