### PR TITLE
fix: Make camera input work again on macOS.

### DIFF
--- a/audio/src/backend/openal.cpp
+++ b/audio/src/backend/openal.cpp
@@ -275,11 +275,7 @@ std::unique_ptr<IAudioSource> OpenAL::makeSource()
         return {};
     }
 
-    const auto source = new AlSource(*this);
-    if (source == nullptr) {
-        return {};
-    }
-
+    auto* const source = new AlSource(*this);
     sources.insert(source);
 
     qDebug() << "Subscribed to audio input device [" << sources.size() << "subscriptions ]";

--- a/audio/src/backend/openal.h
+++ b/audio/src/backend/openal.h
@@ -37,7 +37,7 @@ class OpenAL : public IAudioControl
     Q_OBJECT
 
 public:
-    OpenAL(IAudioSettings& _settings);
+    explicit OpenAL(IAudioSettings& _settings);
     virtual ~OpenAL();
 
     qreal maxOutputVolume() const

--- a/macos/info.plist
+++ b/macos/info.plist
@@ -91,6 +91,8 @@
 	<string>qTox needs access to the camera for video calls.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>qTox needs access to the microphone for audio calls.</string>
+        <key>NSCameraUseContinuityCameraDeviceType</key>
+        <true/>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -153,6 +153,10 @@ ToxFriendCall::~ToxFriendCall()
 void ToxFriendCall::onAudioSourceInvalidated()
 {
     auto newSrc = audio.makeSource();
+    if (newSrc == nullptr) {
+        qWarning() << "Failed to create a new audio source";
+        return;
+    }
     connect(newSrc.get(), &IAudioSource::frameAvailable, this,
             [this](const int16_t* pcm, size_t samples, uint8_t chans, uint32_t rate) {
                 av->sendCallAudio(friendId, pcm, samples, chans, rate);
@@ -197,6 +201,11 @@ ToxConferenceCall::ToxConferenceCall(const Conference& conference_, CoreAV& av_,
     : ToxCall(false, av_, audio_)
     , conference{conference_}
 {
+    if (audioSource == nullptr) {
+        qWarning() << "Created conference call without working audio source";
+        return;
+    }
+
     // register audio
     connect(audioSource.get(), &IAudioSource::frameAvailable, this,
             [this](const int16_t* pcm, size_t samples, uint8_t chans, uint32_t rate) {
@@ -220,7 +229,11 @@ ToxConferenceCall::~ToxConferenceCall()
 void ToxConferenceCall::onAudioSourceInvalidated()
 {
     auto newSrc = audio.makeSource();
-    connect(audioSource.get(), &IAudioSource::frameAvailable, this,
+    if (newSrc == nullptr) {
+        qWarning() << "Failed to create a new audio source";
+        return;
+    }
+    connect(newSrc.get(), &IAudioSource::frameAvailable, this,
             [this](const int16_t* pcm, size_t samples, uint8_t chans, uint32_t rate) {
                 if (conference.getPeersCount() <= 1) {
                     return;

--- a/src/platform/camera/avfoundation.h
+++ b/src/platform/camera/avfoundation.h
@@ -14,8 +14,7 @@
 #endif
 
 namespace avfoundation {
-const QString CAPTURE_SCREEN{"Capture screen"};
-
+bool isDesktopCapture(QString devName);
 QVector<VideoMode> getDeviceModes(QString devName);
 QVector<QPair<QString, QString>> getDeviceList();
 } // namespace avfoundation

--- a/src/video/videomode.cpp
+++ b/src/video/videomode.cpp
@@ -64,7 +64,7 @@ uint32_t VideoMode::tolerance() const
 /**
  * @brief All zeros means a default/unspecified mode
  */
-VideoMode::operator bool() const
+bool VideoMode::isUnspecified() const
 {
-    return width || height || static_cast<int>(FPS);
+    return width == 0 || height == 0 || static_cast<int>(FPS) == 0;
 }

--- a/src/video/videomode.h
+++ b/src/video/videomode.h
@@ -15,13 +15,13 @@ struct VideoMode
     float FPS = -1.0f;
     uint32_t pixel_format = 0;
 
-    VideoMode(int width = 0, int height = 0, int x = 0, int y = 0, float FPS = -1.0f);
+    explicit VideoMode(int width = 0, int height = 0, int x = 0, int y = 0, float FPS = -1.0f);
 
     explicit VideoMode(QRect rect);
 
     QRect toRect() const;
 
-    operator bool() const;
+    bool isUnspecified() const;
     bool operator==(const VideoMode& other) const;
     uint32_t norm(const VideoMode& other) const;
     uint32_t tolerance() const;

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -124,7 +124,9 @@ void AVForm::showEvent(QShowEvent* event)
 
     if (audioSrc == nullptr) {
         audioSrc = audio.makeSource();
-        connect(audioSrc.get(), &IAudioSource::volumeAvailable, this, &AVForm::setVolume);
+        if (audioSrc != nullptr) {
+            connect(audioSrc.get(), &IAudioSource::volumeAvailable, this, &AVForm::setVolume);
+        }
     }
 
     if (audioSink == nullptr) {
@@ -526,7 +528,9 @@ void AVForm::on_inDevCombobox_currentIndexChanged(int deviceIndex)
         audioSettings->setInDev(deviceName);
         audio.reinitInput(deviceName);
         audioSrc = audio.makeSource();
-        connect(audioSrc.get(), &IAudioSource::volumeAvailable, this, &AVForm::setVolume);
+        if (audioSrc != nullptr) {
+            connect(audioSrc.get(), &IAudioSource::volumeAvailable, this, &AVForm::setVolume);
+        }
     }
 
     microphoneSlider->setEnabled(inputEnabled);


### PR DESCRIPTION
It was broken with newer ffmpeg versions. This change aligns the device input names with the expectation of newer ffmpeg. Tested against 7.1, but it's the same on 6.x and maybe some versions before as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/267)
<!-- Reviewable:end -->
