### PR TITLE
cleanup: Ensure message structs don't have uninitialised members.

### DIFF
--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -29,7 +29,7 @@ struct SearchPos
     ChatLogIdx logIdx;
     // Number of matches we've had. This is always number of matches from the
     // start even if we're searching backwards.
-    size_t numMatches;
+    size_t numMatches{0};
 
     bool operator==(const SearchPos& other) const
     {
@@ -54,10 +54,10 @@ struct SearchPos
 
 struct SearchResult
 {
-    bool found;
+    bool found{false};
     SearchPos pos;
-    size_t start;
-    size_t len;
+    size_t start{0};
+    size_t len{0};
 
     // This is unfortunately needed to shoehorn our API into the highlighting
     // API of above classes. They expect to re-search the same thing we did

--- a/src/model/message.h
+++ b/src/model/message.h
@@ -26,14 +26,14 @@ struct MessageMetadata
 {
     MessageMetadataType type;
     // Indicates start position within a Message::content
-    size_t start;
+    size_t start{0};
     // Indicates end position within a Message::content
-    size_t end;
+    size_t end{0};
 };
 
 struct Message
 {
-    bool isAction;
+    bool isAction{false};
     QString content;
     QDateTime timestamp;
     std::vector<MessageMetadata> metadata;

--- a/util/include/util/strongtype.h
+++ b/util/include/util/strongtype.h
@@ -102,16 +102,21 @@ struct Orderable : EqualityComparible<T, Underlying>
 };
 
 
-/* This class facilitates creating a named class which wraps underlying POD,
+/**
+ * This class facilitates creating a named class which wraps underlying POD,
  * avoiding implict casts and arithmetic of the underlying data.
  * Usage: Declare named type with arbitrary tag, then hook up Qt metatype for use
  * in signals/slots. For queued connections, registering the metatype is also
  * required before the type is used.
+ *
+ * <code>
  *   using ReceiptNum = NamedType<uint32_t, struct ReceiptNumTag>;
  *   Q_DECLARE_METATYPE(ReceiptNum)
  *   qRegisterMetaType<ReceiptNum>();
+ * </code>
+ *
+ * The value member is always initialized to 0.
  */
-
 template <typename T, typename Tag, template <typename, typename> class... Properties>
 class NamedType : public Properties<NamedType<T, Tag, Properties...>, T>...
 {
@@ -133,7 +138,7 @@ public:
     }
 
 private:
-    T value_;
+    T value_{0};
 };
 
 template <typename T, typename Tag, template <typename, typename> class... Properties>


### PR DESCRIPTION
Coverity tripped over this. In reality this is probably fine, but the cost of this extra initialisation is negligible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/272)
<!-- Reviewable:end -->
