### PR TITLE
perf: Don't log verbose toxav messages.

### DIFF
--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -107,6 +107,12 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
     const QString file = canonicalLogFilePath(ctxt.file);
     const QString category =
         ctxt.category ? QString::fromUtf8(ctxt.category) : QStringLiteral("default");
+    if ((type == QtDebugMsg && category == QStringLiteral("tox.core")
+         && (file == QStringLiteral("rtp.c") || file == QStringLiteral("video.c")))
+        || (file == QStringLiteral("bwcontroller.c") && msg.contains("update"))) {
+        // Don't log verbose toxav messages.
+        return;
+    }
 
     // Time should be in UTC to save user privacy on log sharing
     QTime time = QDateTime::currentDateTime().toUTC().time();


### PR DESCRIPTION
Some of these are extremely noisy. Probably we should distinguish toxcore and toxav categories into tox.core and tox.av, but right now that's not doable without hard-coding all the toxav filenames.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/273)
<!-- Reviewable:end -->
