### PR TITLE
fix: Don't crash on quit during AV call.

### DIFF
--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -94,6 +94,7 @@ private slots:
     void onAudioSinkInvalidated();
 
 private:
+    QMetaObject::Connection audioSourceInvalid;
     QMetaObject::Connection audioSinkInvalid;
     TOXAV_FRIEND_CALL_STATE state{TOXAV_FRIEND_CALL_STATE_NONE};
     std::unique_ptr<IAudioSink> sink;


### PR DESCRIPTION
The problem here was that during the destruction of ToxFriendCall's, audio frames can still be sending. The fix here is very ugly: instead of connecting the audioSource to the call, we directly connect it to CoreAV. This is the same as we currently do for video source -> CoreAV. It's unclear to me whether this is at all safe to do, so maybe some weirdness happens to calls during shutdown, but at least no undefined behaviour should happen during ToxFriendCall destruction now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/274)
<!-- Reviewable:end -->
