### PR TITLE
cleanup: Use mutex lockers where possible in video frame handling.

### DIFF
--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -120,9 +120,10 @@ private:
 
     void deleteFrameBuffer();
 
-    template <typename T>
-    T toGenericObject(const QSize& dimensions, const int pixelFormat, const bool requireAligned,
-                      const std::function<T(AVFrame* const)>& objectConstructor, const T& nullObject);
+    template <typename F>
+    std::invoke_result_t<F, AVFrame* const> toGenericObject(const QSize& dimensions,
+                                                            int pixelFormat, bool requireAligned,
+                                                            const F& objectConstructor);
 
 private:
     // ID


### PR DESCRIPTION
There's a deadlock somewhere in here. I'm not sure how it happens, yet, but this will at least mostly eliminate the possibility of forgotten unlocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/275)
<!-- Reviewable:end -->
