### PR TITLE
perf: Improve performance of video frame buffering.

### DIFF
--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -109,6 +109,14 @@ private:
         const bool linesizeAligned;
     };
 
+    struct FrameBufferKeyHash
+    {
+        size_t operator()(const FrameBufferKey& key) const
+        {
+            return FrameBufferKey::hash(key);
+        }
+    };
+
 private:
     static FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt, const int linesize);
     static FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt,
@@ -131,8 +139,7 @@ private:
     const IDType sourceID;
 
     // Main framebuffer store
-    std::unordered_map<FrameBufferKey, AVFrame*, std::function<decltype(FrameBufferKey::hash)>>
-        frameBuffer{3, FrameBufferKey::hash};
+    std::unordered_map<FrameBufferKey, AVFrame*, FrameBufferKeyHash> frameBuffer{3};
 
     // Source frame
     const QRect sourceDimensions;


### PR DESCRIPTION
This hashtable used std::function dispatch to a function pointer for no good reason. It could have just used the function pointer instead. Now we use neither and statically bind the hash function to the hash map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/276)
<!-- Reviewable:end -->
