### PR TITLE
chore: Support toxcore 0.2.19 and below.

### DIFF
--- a/util/src/toxcoreerrorparser.cpp
+++ b/util/src/toxcoreerrorparser.cpp
@@ -151,9 +151,11 @@ bool ToxcoreErrorParser::parseErr(Tox_Err_Conference_Join error, const char* fil
         qCriticalFrom(file, line, func) << "Wrong conference type";
         return false;
 
+#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 20)
     case TOX_ERR_CONFERENCE_JOIN_NULL:
         qCriticalFrom(file, line, func) << "Null argument";
         return false;
+#endif
     }
     qCriticalFrom(file, line, func) << "Unknown Tox_Err_Conference_Join error code:" << error;
     return false;


### PR DESCRIPTION
We still recommend using newer toxcore, but this at least makes it compile.

Fixes https://github.com/TokTok/qTox/issues/277

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/280)
<!-- Reviewable:end -->
