### PR TITLE
fix: Make sure camera access is gained on macOS before calling.

### DIFF
--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -60,6 +60,7 @@ QVector<QPair<QString, QString>> avfoundation::getDeviceList()
     } else {
         qDebug() << "We don't have access to the camera yet; asking user for permission.";
         QMutex mutex;
+        mutex.lock();
         QMutex* mutexPtr = &mutex;
         __block BOOL isGranted = false;
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
@@ -67,6 +68,7 @@ QVector<QPair<QString, QString>> avfoundation::getDeviceList()
                                    isGranted = granted;
                                    mutexPtr->unlock();
                                  }];
+        // Lock it again so the callback can unlock it and we can proceed.
         mutex.lock();
         if (isGranted) {
             qInfo() << "We now have access to the camera.";


### PR DESCRIPTION
This blocks the main thread and is not ideal, but it's better than the undefined behaviour it has at the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/283)
<!-- Reviewable:end -->
