### PR TITLE
fix: Disable video device selection box during call.

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -521,6 +521,13 @@ void CoreAV::invalidateConferenceCallPeerSource(const Conference& conference, To
     it->second->removePeer(peerPk);
 }
 
+bool CoreAV::isAnyCallActive() const
+{
+    QReadLocker locker{&callsLock};
+    return std::any_of(calls.begin(), calls.end(),
+                       [](const auto& call) { return call.second->isActive(); });
+}
+
 /**
  * @brief Get a call's video source.
  * @param friendNum Id of friend in call list.

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -72,6 +72,7 @@ public:
                                        const int16_t* data, unsigned samples, uint8_t channels,
                                        uint32_t sample_rate, void* core);
     void invalidateConferenceCallPeerSource(const Conference& conference, ToxPk peerPk);
+    bool isAnyCallActive() const;
 
 public slots:
     bool startCall(uint32_t friendNum, bool video);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -49,6 +49,18 @@ AVForm::AVForm(IAudioControl& audio_, CoreAV* coreAV_, CameraSource& camera_,
 
     connect(rescanButton, &QPushButton::clicked, this, &AVForm::rescanDevices);
 
+    // TODO(iphydf): Fix the crashing bug when changing the video device during a call.
+    // See https://github.com/TokTok/qTox/issues/281
+    connect(coreAV_, &CoreAV::avStart, this, [this](uint32_t friendId, bool video) {
+        std::ignore = friendId;
+        std::ignore = video;
+        videoDevCombobox->setEnabled(false);
+    });
+    connect(coreAV_, &CoreAV::avEnd, this, [this](uint32_t friendId) {
+        std::ignore = friendId;
+        videoDevCombobox->setEnabled(!coreAV->isAnyCallActive());
+    });
+
     playbackSlider->setTracking(false);
     playbackSlider->setMaximum(totalSliderSteps);
     playbackSlider->setValue(getStepsFromValue(audioSettings_->getOutVolume(),


### PR DESCRIPTION
There's a crashing bug in the AV code caused by changing the video device during a call. The fix for that is non-trivial. In the meantime, we disallow such changes to make sure users don't crash themselves.

See https://github.com/TokTok/qTox/issues/281

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/284)
<!-- Reviewable:end -->
