### PR TITLE
cleanup: Clarify what the "blacklist" does in privacy.

### DIFF
--- a/doc/user_manual_en.md
+++ b/doc/user_manual_en.md
@@ -273,9 +273,14 @@ will alter your Tox ID. You don't need to tell your existing contacts your new
 Tox ID, but you have to tell new contacts your new Tox ID. Your Tox ID can be
 found in your [User Profile](#user-profile).
 
-#### BlackList
+#### Conference block list
 
-BlackList is a feature of qTox that locally blocks a conference member's messages across all your joined conferences, in case someone spams a conference. You need to put a members public key into the BlackList text box one per line to activate it. Currently qTox doesn't have a method to get the public key from a conference member, this will be added in the future.
+Conference block list is a feature of qTox that locally blocks a conference
+member's messages across all your joined conferences, in case someone spams a
+conference. You need to put a members public key into the `Conference block
+list` text box one per line to activate it. Currently qTox doesn't have a
+method to get the public key from a conference member, this will be added in
+the future.
 
 ### Audio/Video
 

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -485,7 +485,7 @@ void CoreAV::conferenceCallCallback(void* tox, uint32_t conference, uint32_t pee
 
     const ToxPk peerPk = c->getConferencePeerPk(conference, peer);
     // don't play the audio if it comes from a muted peer
-    if (cav->conferenceSettings.getBlackList().contains(peerPk.toString())) {
+    if (cav->conferenceSettings.getBlockList().contains(peerPk.toString())) {
         return;
     }
 

--- a/src/model/conferencemessagedispatcher.cpp
+++ b/src/model/conferencemessagedispatcher.cpp
@@ -66,7 +66,7 @@ void ConferenceMessageDispatcher::onMessageReceived(const ToxPk& sender, bool is
         return;
     }
 
-    if (conferenceSettings.getBlackList().contains(sender.toString())) {
+    if (conferenceSettings.getBlockList().contains(sender.toString())) {
         qDebug() << "onConferenceMessageReceived: Filtered:" << sender.toString();
         return;
     }

--- a/src/persistence/iconferencesettings.h
+++ b/src/persistence/iconferencesettings.h
@@ -19,12 +19,12 @@ public:
     IConferenceSettings(IConferenceSettings&&) = default;
     IConferenceSettings& operator=(IConferenceSettings&&) = default;
 
-    virtual QStringList getBlackList() const = 0;
-    virtual void setBlackList(const QStringList& blist) = 0;
+    virtual QStringList getBlockList() const = 0;
+    virtual void setBlockList(const QStringList& blist) = 0;
 
     virtual bool getShowConferenceJoinLeaveMessages() const = 0;
     virtual void setShowConferenceJoinLeaveMessages(bool newValue) = 0;
 
-    DECLARE_SIGNAL(blackListChanged, const QStringList& blist);
+    DECLARE_SIGNAL(blockListChanged, const QStringList& blist);
     DECLARE_SIGNAL(showConferenceJoinLeaveMessagesChanged, bool show);
 };

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -496,7 +496,7 @@ void Settings::loadPersonal(const Profile& profile, bool newProfile)
     {
         typingNotification = ps.value("typingNotification", true).toBool();
         enableLogging = ps.value("enableLogging", true).toBool();
-        blackList = ps.value("blackList").toString().split('\n');
+        blockList = ps.value("blackList").toString().split('\n');
     }
     ps.endGroup();
 
@@ -829,7 +829,7 @@ void Settings::savePersonal(QString profileName, const ToxEncrypt* passkey)
     {
         ps.setValue("typingNotification", typingNotification);
         ps.setValue("enableLogging", enableLogging);
-        ps.setValue("blackList", blackList.join('\n'));
+        ps.setValue("blackList", blockList.join('\n'));
     }
     ps.endGroup();
 
@@ -1716,16 +1716,16 @@ void Settings::setTypingNotification(bool enabled)
     }
 }
 
-QStringList Settings::getBlackList() const
+QStringList Settings::getBlockList() const
 {
     QMutexLocker<QRecursiveMutex> locker{&bigLock};
-    return blackList;
+    return blockList;
 }
 
-void Settings::setBlackList(const QStringList& blist)
+void Settings::setBlockList(const QStringList& blist)
 {
-    if (setVal(blackList, blist)) {
-        emit blackListChanged(blist);
+    if (setVal(blockList, blist)) {
+        emit blockListChanged(blist);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -96,7 +96,7 @@ class Settings : public QObject,
     // Privacy
     Q_PROPERTY(bool typingNotification READ getTypingNotification WRITE setTypingNotification NOTIFY
                    typingNotificationChanged FINAL)
-    Q_PROPERTY(QStringList blackList READ getBlackList WRITE setBlackList NOTIFY blackListChanged FINAL)
+    Q_PROPERTY(QStringList blockList READ getBlockList WRITE setBlockList NOTIFY blockListChanged FINAL)
 
     // Audio
     Q_PROPERTY(QString inDev READ getInDev WRITE setInDev NOTIFY inDevChanged FINAL)
@@ -458,9 +458,9 @@ public:
     bool getTypingNotification() const;
     void setTypingNotification(bool enabled);
 
-    QStringList getBlackList() const override;
-    void setBlackList(const QStringList& blist) override;
-    SIGNAL_IMPL(Settings, blackListChanged, const QStringList& blist)
+    QStringList getBlockList() const override;
+    void setBlockList(const QStringList& blist) override;
+    SIGNAL_IMPL(Settings, blockListChanged, const QStringList& blist)
 
     bool getShowConferenceJoinLeaveMessages() const override;
     void setShowConferenceJoinLeaveMessages(bool newValue) override;
@@ -657,7 +657,7 @@ private:
     // Privacy
     bool typingNotification;
     Db::syncType dbSyncType;
-    QStringList blackList;
+    QStringList blockList;
 
     // Audio
     QString inDev;

--- a/src/widget/form/conferenceform.cpp
+++ b/src/widget/form/conferenceform.cpp
@@ -125,7 +125,7 @@ ConferenceForm::ConferenceForm(Core& core_, Conference* chatConference, IChatLog
     connect(conference, &Conference::userLeft, this, &ConferenceForm::onUserLeft);
     connect(conference, &Conference::peerNameChanged, this, &ConferenceForm::onPeerNameChanged);
     connect(conference, &Conference::numPeersChanged, this, &ConferenceForm::updateUserCount);
-    settings.connectTo_blackListChanged(this, [this](const QStringList&) { updateUserNames(); });
+    settings.connectTo_blockListChanged(this, [this](const QStringList&) { updateUserNames(); });
 
     if (settings.getShowConferenceJoinLeaveMessages()) {
         addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::selfJoinedConference, {});
@@ -205,7 +205,7 @@ void ConferenceForm::updateUserNames()
 
         if (peerPk == selfPk) {
             label->setProperty("peerType", LABEL_PEER_TYPE_OUR);
-        } else if (settings.getBlackList().contains(peerPk.toString())) {
+        } else if (settings.getBlockList().contains(peerPk.toString())) {
             label->setProperty("peerType", LABEL_PEER_TYPE_MUTED);
         }
 
@@ -401,7 +401,7 @@ void ConferenceForm::onLabelContextMenuRequested(const QPoint& localPos)
     const QPoint pos = label->mapToGlobal(localPos);
     const QString muteString = tr("mute");
     const QString unmuteString = tr("unmute");
-    QStringList blackList = settings.getBlackList();
+    QStringList blockList = settings.getBlockList();
     QMenu* const contextMenu = new QMenu(this);
     const ToxPk selfPk = core.getSelfPublicKey();
     ToxPk peerPk;
@@ -414,7 +414,7 @@ void ConferenceForm::onLabelContextMenuRequested(const QPoint& localPos)
         return;
     }
 
-    const bool isPeerBlocked = blackList.contains(peerPk.toString());
+    const bool isPeerBlocked = blockList.contains(peerPk.toString());
     QString menuTitle = label->text();
     if (menuTitle.endsWith(QLatin1String(", "))) {
         menuTitle.chop(2);
@@ -434,15 +434,15 @@ void ConferenceForm::onLabelContextMenuRequested(const QPoint& localPos)
     const QAction* selectedItem = contextMenu->exec(pos);
     if (selectedItem == toggleMuteAction) {
         if (isPeerBlocked) {
-            const int index = blackList.indexOf(peerPk.toString());
+            const int index = blockList.indexOf(peerPk.toString());
             if (index != -1) {
-                blackList.removeAt(index);
+                blockList.removeAt(index);
             }
         } else {
-            blackList << peerPk.toString();
+            blockList << peerPk.toString();
         }
 
-        settings.setBlackList(blackList);
+        settings.setBlockList(blockList);
     }
 }
 

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -85,7 +85,7 @@ void PrivacyForm::showEvent(QShowEvent* event)
     bodyUI->nospamLineEdit->setText(core->getSelfId().getNoSpamString());
     bodyUI->cbTypingNotification->setChecked(s.getTypingNotification());
     bodyUI->cbKeepHistory->setChecked(settings.getEnableLogging());
-    bodyUI->blackListTextEdit->setText(s.getBlackList().join('\n'));
+    bodyUI->blockListTextEdit->setText(s.getBlockList().join('\n'));
 }
 
 void PrivacyForm::on_randomNospamButton_clicked()
@@ -110,10 +110,10 @@ void PrivacyForm::on_nospamLineEdit_textChanged()
     }
 }
 
-void PrivacyForm::on_blackListTextEdit_textChanged()
+void PrivacyForm::on_blockListTextEdit_textChanged()
 {
-    const QStringList strlist = bodyUI->blackListTextEdit->toPlainText().split('\n');
-    settings.setBlackList(strlist);
+    const QStringList strlist = bodyUI->blockListTextEdit->toPlainText().split('\n');
+    settings.setBlockList(strlist);
 }
 
 void PrivacyForm::retranslateUi()

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -36,7 +36,7 @@ private slots:
     void on_nospamLineEdit_editingFinished();
     void on_randomNospamButton_clicked();
     void on_nospamLineEdit_textChanged();
-    void on_blackListTextEdit_textChanged();
+    void on_blockListTextEdit_textChanged();
     void showEvent(QShowEvent* event) final;
 
 private:

--- a/src/widget/form/settings/privacysettings.ui
+++ b/src/widget/form/settings/privacysettings.ui
@@ -123,13 +123,13 @@ If you are getting spammed with friend requests, change the NoSpam.</string>
           <string/>
          </property>
          <property name="title">
-          <string>BlackList</string>
+          <string>Conference block list</string>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QTextEdit" name="blackListTextEdit">
+           <widget class="QTextEdit" name="blockListTextEdit">
             <property name="toolTip">
-             <string>Filter conference messages by conference members' public keys. Put public keys here, one per line.</string>
+             <string>Filter out conference messages by conference members' public keys. Put public keys here, one per line.</string>
             </property>
            </widget>
           </item>

--- a/test/model/conferencemessagedispatcher_test.cpp
+++ b/test/model/conferencemessagedispatcher_test.cpp
@@ -53,9 +53,9 @@ class MockConferenceSettings : public QObject, public IConferenceSettings
     Q_OBJECT
 
 public:
-    QStringList getBlackList() const override;
-    void setBlackList(const QStringList& blist) override;
-    SIGNAL_IMPL(MockConferenceSettings, blackListChanged, const QStringList& blist)
+    QStringList getBlockList() const override;
+    void setBlockList(const QStringList& blist) override;
+    SIGNAL_IMPL(MockConferenceSettings, blockListChanged, const QStringList& blist)
 
     bool getShowConferenceJoinLeaveMessages() const override
     {
@@ -68,17 +68,17 @@ public:
     SIGNAL_IMPL(MockConferenceSettings, showConferenceJoinLeaveMessagesChanged, bool show)
 
 private:
-    QStringList blacklist;
+    QStringList blockList;
 };
 
-QStringList MockConferenceSettings::getBlackList() const
+QStringList MockConferenceSettings::getBlockList() const
 {
-    return blacklist;
+    return blockList;
 }
 
-void MockConferenceSettings::setBlackList(const QStringList& blist)
+void MockConferenceSettings::setBlockList(const QStringList& blist)
 {
-    blacklist = blist;
+    blockList = blist;
 }
 
 class TestConferenceMessageDispatcher : public QObject
@@ -94,7 +94,7 @@ private slots:
     void testMessageSending();
     void testEmptyConference();
     void testSelfReceive();
-    void testBlacklist();
+    void testBlockList();
 
     void onMessageSent(DispatchedMessageId id, Message message)
     {
@@ -235,16 +235,16 @@ void TestConferenceMessageDispatcher::testSelfReceive()
 }
 
 /**
- * @brief Tests that messages from blacklisted peers do not get propagated from the dispatcher
+ * @brief Tests that messages from block-listed peers do not get propagated from the dispatcher
  */
-void TestConferenceMessageDispatcher::testBlacklist()
+void TestConferenceMessageDispatcher::testBlockList()
 {
     uint8_t id[ToxPk::size] = {1};
     auto otherPk = ToxPk(id);
     conferenceMessageDispatcher->onMessageReceived(otherPk, false, "Test");
     QVERIFY(receivedMessages.size() == 1);
 
-    conferenceSettings->setBlackList({otherPk.toString()});
+    conferenceSettings->setBlockList({otherPk.toString()});
     conferenceMessageDispatcher->onMessageReceived(otherPk, false, "Test");
     QVERIFY(receivedMessages.size() == 1);
 }

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -1992,11 +1992,11 @@ If you are getting spammed with friend requests, change the NoSpam.</source>
         <translation>خصوصية</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -1988,11 +1988,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation>Прыватнасць</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Чорны спіс</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -2009,7 +2009,7 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -1986,11 +1986,11 @@ If you are getting spammed with friend requests, change the NoSpam.</source>
         <translation>Поверителност</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Черен списък</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Филтрирай групови съобщения по публични ключове на членове. Постави ключовете тук, по един на линия.</translation>
     </message>
 </context>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -1989,11 +1989,11 @@ Pokud jste obtěžováni žádostmi o přidání, měli byste si změnit vaše N
         <translation>Soukromí</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Černá listina</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtrujte skupinové zprávy podle veřejných klíčů členů skupiny. Sem vložte veřejné klíče, jeden na řádek.</translation>
     </message>
 </context>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -1976,11 +1976,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -1994,11 +1994,11 @@ Die Sicherung des Verlaufs ist noch in Entwicklung. Formatierungsänderungen bei
         <translation>Datenschutz</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Denial-Liste</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation>Filtere Konferenznachricht nach öffentlichem Schlüssel des Konferenzmitglieds. Füge öffentlichen Schlüssel hier ein, einen pro Zeile.</translation>
     </message>
 </context>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -1976,11 +1976,11 @@ If you are getting spammed with friend requests, change the NoSpam.</source>
         <translation>Ιδιωτικό απόρρητο</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Λίστα ανεπιθύμητων (Black list)</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -1965,11 +1965,11 @@ If you are getting spammed with friend requests, change the NoSpam.</source>
         <translation>Privateco</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -1986,11 +1986,11 @@ Es posible que haya cambios en el formato de guardado, lo que puede generar una 
         <translation>Privacidad</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Lista negra</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation>Filtrar mensajes de grupo por clave pública de miembros del grupo. Ponga la clave pública aquí, una por línea.</translation>
     </message>
 </context>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -1987,11 +1987,11 @@ Kui saad hulgaliselt soovimatuid sõbrakutseid, muuda seda väärtust.</translat
         <translation>Privaatsus</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Must nimekiri</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtreeri grupisõnumeid vastvalt grupi liikmete avalikele võtmetele. Pane avalikud võtmed, üks igal real, siia.</translation>
     </message>
 </context>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -1980,11 +1980,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation>حریم خصوصی</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>لیست سیاه</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -1985,11 +1985,11 @@ Tallennusformaatin muutokset ovat mahdollisia, mitkä saattavat johtaa tiedon me
         <translation>Yksityisyys</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Musta lista</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Lajittele ryhmäviestit ryhmän jäsenten julkisten avainten mukaan. Laita julkiset avaimet tänne. Yksi avain yhdelle linjalle.</translation>
     </message>
 </context>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -1985,11 +1985,11 @@ Les changements de format de sauvegarde sont possibles, ce qui pourrait entraine
         <translation>Vie privée</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Liste noire</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtrer le message de groupe par clé publique du membre du groupe. Mettre la clé publique ici, une par ligne.</translation>
     </message>
 </context>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -1984,11 +1984,11 @@ O formato do ficheiro de gardado podería cambiar, o que pode causar a perda de 
         <translation type="unfinished">Privacidade</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Lista negra</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -1980,11 +1980,11 @@ Ako te zatrpavaju zahtjevima za prijateljstvo, promijeni NoSpam.</translation>
         <translation>Privatnost</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Crna lista</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -1972,11 +1972,11 @@ Ha kéretlen partnerfelkérésekkel bombázzák, változtassa meg a NoSpam-ot.</
         <translation>Adatvédelem</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Tiltólista</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -1985,11 +1985,11 @@ Se ricevi molte richieste di amicizia indesiderate cambia questo valore.</transl
         <translation>Privacy</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Lista Nera</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtra i messaggi di gruppo dalle chiavi pubbliche dei membri. Inserisci qui le chiavi pubbliche, una per linea.</translation>
     </message>
 </context>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -1971,11 +1971,11 @@ If you are getting spammed with friend requests, change the NoSpam.</source>
         <translation>プライバシー</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>ブラックリスト</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -2005,7 +2005,7 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -1991,11 +1991,11 @@ Failo formatas dar gali pasikeisti, todėl galite prarasti sukauptus duomenis.</
         <translation>Privatumas</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Juodasis sąrašas</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtruoti grupės pranešimus pagal grupės narių viešuosius raktus. Čia įrašykite viešuosius raktus, po vieną kiekvienoje eilutėje.</translation>
     </message>
 </context>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -1995,11 +1995,11 @@ Iespējama saglabāšanas formāta izmaiņas, kas var novest pie datu zaudēšan
         <translation>Konfidencialitātes politika</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Melnais saraksts</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -1988,11 +1988,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Црна листа</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -1985,11 +1985,11 @@ Het is mogelijk dat er zich veranderingen in het formaat voordoen, wat kan leide
         <translation>Privacy</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Weigerlijst</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation>Filter conferentieberichten op openbare sleutels van conferentieleden. Plaats hier openbare sleutels, één per regel.</translation>
     </message>
 </context>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -1984,11 +1984,11 @@ Het is mogelijk dat er zich veranderingen in het formaat voordoen, wat kan leide
         <translation></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Zwarte lijst</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -1987,11 +1987,11 @@ Endringer av lagringsformat er mulig, som kan forårsake data tap.</translation>
         <translation>Personvern</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Svarteliste</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtrer gruppemeldinger etter gruppemedlemmers offentlige nøkler. Legg inn offentlige nøkler her, én på hver linje.</translation>
     </message>
 </context>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -2013,11 +2013,11 @@ Możliwe są zmianay formatu zapisu, co może skutkować utratą danych.</transl
         <translation>Prywatność</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Czarna lista</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtruj wiadomości grupowe według kluczy publicznych należących do członków grupy. Umieść tutaj klucze publiczne, po jednym w każdym wierszu.</translation>
     </message>
 </context>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -2009,7 +2009,7 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -1985,11 +1985,11 @@ Por isso podem ocorrer alterações no formato do ficheiro guardado, o que pode 
         <translation>Privacidade</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Lista negra</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtrar as mensagens de grupo por chaves públicas dos membros do grupo. Ponha aqui as chaves públicas, uma por linha.</translation>
     </message>
 </context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -1993,11 +1993,11 @@ Mudanças no arquivo salvo podem ocorrer, isso pode resultar em perda de dados.<
         <translation>Privacidade</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Lista negra</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtrar as mensagens de grupo por chaves públicas dos membros do grupo. Coloque aqui as chaves públicas, uma por linha.</translation>
     </message>
 </context>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -1997,11 +1997,11 @@ Salvarea modificărilor formatelor este posibilă, ceea ce poate duce la pierder
         <translation>Confidențialitate</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Listă neagră</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation>Filtrează mesajele conferinței după cheile publice ale membrilor conferinței. Puneți aici cheile publice, câte una pe fiecare rând.</translation>
     </message>
 </context>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -1992,11 +1992,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation>Приватность</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Список блокировки</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation>Фильтруйте сообщения в конференции с помощью открытых (публичных) ключей её участников. Добавьте открытые (публичные) ключи сюда, один на каждую строку.</translation>
     </message>
 </context>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -1997,11 +1997,11 @@ Sú možné zmeny formátu, ktoré môžu spôsobiť stratu dát.</translation>
         <translation>Súkromie</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Čierna listina</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtrovať skupinové správy podľa verejných kľúčov členov skupín. Vložte sem verejné kľúče, jeden kľúč na riadok.</translation>
     </message>
 </context>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -1982,11 +1982,11 @@ If you are getting spammed with friend requests, change the NoSpam.</source>
         <translation type="unfinished">Zasebnost</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -1988,11 +1988,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation>Приватност</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Црна листа</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -1989,11 +1989,11 @@ Promene u formatu snimanja su moguće, što može dovesti do gubitka podataka.</
         <translation>Privatnost</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Crna lista</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -1985,11 +1985,11 @@ Om du blir spammad med vänförfrågningar, ändra NoSpam.</translation>
         <translation>Integritet</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Blocklista</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Filtrera gruppmeddelanden efter gruppmedlemmars offentliga nycklar. Sätt offentliga nycklar här, en per rad.</translation>
     </message>
 </context>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -1979,11 +1979,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -1985,11 +1985,11 @@ Arkadaşlık istemleriyle rahatsız ediliyorsanız, NoSpam&apos;ı değiştirin.
         <translation>Gizlilik</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>KaraListe</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Grup iletilerini grup üyelerinin açık anahtarlarına göre filtreleyin. Açık anahtarları her satıra bir tane olacak şekilde buraya koyun.</translation>
     </message>
 </context>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -1984,11 +1984,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation>مەخپىيەتلىك</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>قارا تىزىملىك</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -1995,11 +1995,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation>Приватність</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Список блокування</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation>Фільтруйте повідомлення в конференції через відкриті (публічні) ключі учасників конференції. Впишіть сюди відкриті (публічні) ключі, по одному на рядок.</translation>
     </message>
 </context>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -1981,11 +1981,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -1989,11 +1989,11 @@ Có thể thay đổi định dạng lưu, điều này có thể làm mất d�
         <translation>Bảo mật</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>Danh sách đen</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished">Lọc tin nhắn nhóm theo khóa công khai của thành viên nhóm. Đặt các khóa công khai ở đây, một khóa trên mỗi dòng.</translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1981,11 +1981,11 @@ If you are getting spammed with friend requests, change the NoSpam.</source>
         <translation>隐私</translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation>黑名单</translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation>按会议成员的公钥过滤会议消息。在此处输入公钥，每行一个。</translation>
     </message>
 </context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -1973,11 +1973,11 @@ Save format changes are possible, which may result in data loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>BlackList</source>
+        <source>Conference block list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Filter conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
+        <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Renamed it to "Conference block list". Without the tooltip, it was unclear to me what it does. Also the tooltip was inverted. We don't filter by key, we filter *out* by key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/285)
<!-- Reviewable:end -->
