### PR TITLE
chore: Make flatpak build's ccache readable by github action.

### DIFF
--- a/flatpak/build.sh
+++ b/flatpak/build.sh
@@ -29,3 +29,7 @@ if [ -n "${FLATPAK_BUILD:-}" ]; then
 fi
 
 rm -f .flatpak-builder/cache/.lock
+
+# Make files world-readable and executable (if they are executable)
+find . -type f -exec chmod a+r {} +
+find . -executable -exec chmod a+x {} +


### PR DESCRIPTION
Right now we get
`Warning: EACCES: permission denied, lstat '/home/runner/work/qTox/qTox/.cache/ccache'` which prevents any caching from actually happening.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/293)
<!-- Reviewable:end -->
