### PR TITLE
fix: Avoid hanging when capture device permissions denied on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,8 @@ set(${PROJECT_NAME}_SOURCES
     src/video/ivideosettings.h
     src/video/netcamview.cpp
     src/video/netcamview.h
+    src/video/scopedavdictionary.cpp
+    src/video/scopedavdictionary.h
     src/video/videoframe.cpp
     src/video/videoframe.h
     src/video/videomode.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -331,7 +331,7 @@ bool Core::checkConnection()
 {
     ASSERT_CORE_THREAD;
     auto selfConnection = tox_self_get_connection_status(tox.get());
-    QString connectionName;
+    const char* connectionName;
     bool toxConnected = false;
     switch (selfConnection) {
     case TOX_CONNECTION_NONE:
@@ -351,7 +351,7 @@ bool Core::checkConnection()
     }
 
     if (toxConnected && !isConnected) {
-        qDebug().noquote() << "Connected to" << connectionName;
+        qDebug() << "Connected to" << connectionName;
         emit connected();
     } else if (!toxConnected && isConnected) {
         qDebug() << "Disconnected from the DHT";

--- a/src/platform/camera/avfoundation.h
+++ b/src/platform/camera/avfoundation.h
@@ -9,13 +9,11 @@
 #include <QString>
 #include <QVector>
 
-#ifndef Q_OS_MACOS
-#error "This file is only meant to be compiled for macOS targets"
-#endif
-
+#ifdef Q_OS_MACOS
 namespace avfoundation {
 bool isDesktopCapture(const QString& devName);
 bool hasPermission(const QString& devName);
 QVector<VideoMode> getDeviceModes(const QString& devName);
 QVector<QPair<QString, QString>> getDeviceList();
 } // namespace avfoundation
+#endif

--- a/src/platform/camera/avfoundation.h
+++ b/src/platform/camera/avfoundation.h
@@ -14,7 +14,8 @@
 #endif
 
 namespace avfoundation {
-bool isDesktopCapture(QString devName);
-QVector<VideoMode> getDeviceModes(QString devName);
+bool isDesktopCapture(const QString& devName);
+bool hasPermission(const QString& devName);
+QVector<VideoMode> getDeviceModes(const QString& devName);
 QVector<QPair<QString, QString>> getDeviceList();
 } // namespace avfoundation

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -135,7 +135,7 @@ QVector<VideoMode> avfoundation::getDeviceModes(const QString& devName)
                 VideoMode mode;
                 mode.width = dimensions.width;
                 mode.height = dimensions.height;
-                mode.FPS = range.maxFrameRate;
+                mode.fps = range.maxFrameRate;
                 result.append(mode);
             }
         }

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -41,11 +41,22 @@ NSArray* getDevices()
 
 } // namespace
 
-bool avfoundation::isDesktopCapture(QString devName)
+bool avfoundation::isDesktopCapture(const QString& devName)
 {
     NSArray* devices = getDevices();
     const int index = devName.toInt();
     return index >= [devices count];
+}
+
+bool avfoundation::hasPermission(const QString& devName)
+{
+    if (isDesktopCapture(devName)) {
+        return CGPreflightScreenCaptureAccess();
+    }
+
+    const AVAuthorizationStatus authStatus =
+        [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    return authStatus == AVAuthorizationStatusAuthorized;
 }
 
 QVector<QPair<QString, QString>> avfoundation::getDeviceList()
@@ -98,7 +109,7 @@ QVector<QPair<QString, QString>> avfoundation::getDeviceList()
     return result;
 }
 
-QVector<VideoMode> avfoundation::getDeviceModes(QString devName)
+QVector<VideoMode> avfoundation::getDeviceModes(const QString& devName)
 {
     QVector<VideoMode> result;
     NSArray* devices = getDevices();

--- a/src/platform/camera/directshow.cpp
+++ b/src/platform/camera/directshow.cpp
@@ -227,7 +227,7 @@ QVector<VideoMode> DirectShow::getDeviceModes(QString devName)
 
                 mode.width = vcaps->MaxOutputSize.cx;
                 mode.height = vcaps->MaxOutputSize.cy;
-                mode.FPS = 1e7 / vcaps->MinFrameInterval;
+                mode.fps = 1e7 / vcaps->MinFrameInterval;
                 if (!modes.contains(mode))
                     modes.append(std::move(mode));
 

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -8,7 +8,7 @@
 
 #include "v4l2.h"
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if defined(USING_V4L)
 #include <QDebug>
 #include <dirent.h>
 #include <errno.h>
@@ -156,7 +156,7 @@ QVector<VideoMode> v4l2::getDeviceModes(QString devName)
             }
 
             for (float rate : rates) {
-                mode.FPS = rate;
+                mode.fps = rate;
                 if (!modes.contains(mode)) {
                     modes.append(std::move(mode));
                 }

--- a/src/platform/camera/v4l2.h
+++ b/src/platform/camera/v4l2.h
@@ -9,7 +9,8 @@
 #include <QString>
 #include <QVector>
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if (defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)) && !defined(ANDROID)
+#define USING_V4L 1
 namespace v4l2 {
 QVector<VideoMode> getDeviceModes(QString devName);
 QVector<QPair<QString, QString>> getDeviceList();

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -15,6 +15,7 @@ extern "C"
 #pragma GCC diagnostic pop
 }
 #include "cameradevice.h"
+#include "scopedavdictionary.h"
 #include "src/persistence/settings.h"
 
 #include <QDebug>
@@ -90,58 +91,6 @@ constexpr auto toCharArray()
 
 // Compile-time unit test for the above function.
 static_assert(toCharArray<12345>() == std::array<char, 6>{'1', '2', '3', '4', '5', '\0'});
-
-class ScopedAVDictionary
-{
-    AVDictionary* options = nullptr;
-
-    struct Setter
-    {
-        AVDictionary** dict;
-        const char* key;
-
-        void operator=(const char* value)
-        {
-            av_dict_set(dict, key, value, 0);
-        }
-
-        template <size_t N>
-        void operator=(const std::array<char, N>& value)
-        {
-            *this = value.data();
-        }
-
-        void operator=(const QString& value)
-        {
-            *this = value.toStdString().c_str();
-        }
-
-        void operator=(int64_t value)
-        {
-            av_dict_set_int(dict, key, value, 0);
-        }
-    };
-
-public:
-    ScopedAVDictionary() = default;
-    ScopedAVDictionary& operator=(const ScopedAVDictionary&) = delete;
-    ScopedAVDictionary(const ScopedAVDictionary&) = delete;
-
-    ~ScopedAVDictionary()
-    {
-        av_dict_free(&options);
-    }
-
-    Setter operator[](const char* key)
-    {
-        return {&options, key};
-    }
-
-    AVDictionary** get()
-    {
-        return &options;
-    }
-};
 
 struct AVFormatContextDeleter
 {

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -119,7 +119,7 @@ void CameraSource::setupDefault()
     VideoMode mode_ = VideoMode(settings.getScreenRegion());
     if (!isScreen) {
         mode_ = VideoMode(settings.getCamVideoRes());
-        mode_.FPS = settings.getCamVideoFPS();
+        mode_.fps = settings.getCamVideoFPS();
     }
 
     setupDevice(deviceName_, mode_);

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -143,7 +143,7 @@ void CameraSource::setupDevice(const QString& deviceName_, const VideoMode& mode
         return;
     }
 
-    if (subscriptions) {
+    if (subscriptions != 0) {
         // To force close, ignoring optimization
         int subs = subscriptions;
         subscriptions = 0;
@@ -242,6 +242,7 @@ void CameraSource::openDevice()
     qDebug() << "Opening device" << deviceName << "subscriptions:" << subscriptions;
 
     if (device) {
+        qWarning() << "Device already open";
         device->open();
         emit openFailed();
         return;
@@ -251,7 +252,7 @@ void CameraSource::openDevice()
     device = CameraDevice::open(deviceName, mode);
 
     if (!device) {
-        qWarning() << "Failed to open device!";
+        qWarning() << "Failed to open device" << deviceName;
         emit openFailed();
         return;
     }
@@ -298,7 +299,6 @@ void CameraSource::openDevice()
         return;
     }
 
-
 #if LIBAVCODEC_VERSION_INT < 3747941
     // Copy context, since we apparently aren't allowed to use the original
     cctx = avcodec_alloc_context3(codec);
@@ -321,7 +321,7 @@ void CameraSource::openDevice()
 
     // Open codec
     if (avcodec_open2(cctx, codec, nullptr) < 0) {
-        qWarning() << "Can't open codec";
+        qWarning() << "Can't open codec" << codec->name;
         avcodec_free_context(&cctx);
         emit openFailed();
         return;
@@ -336,6 +336,7 @@ void CameraSource::openDevice()
     while (!streamFuture.isRunning())
         QThread::yieldCurrentThread();
 
+    qDebug() << "Opened device" << deviceName << "with codec" << codec->name;
     emit deviceOpened();
 }
 

--- a/src/video/scopedavdictionary.cpp
+++ b/src/video/scopedavdictionary.cpp
@@ -1,0 +1,41 @@
+#include "scopedavdictionary.h"
+
+#include <QString>
+
+extern "C"
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#include <libavformat/avformat.h>
+#pragma GCC diagnostic pop
+}
+
+void ScopedAVDictionary::Setter::operator=(const char* value)
+{
+    av_dict_set(dict, key, value, 0);
+}
+
+void ScopedAVDictionary::Setter::operator=(const QString& value)
+{
+    *this = value.toStdString().c_str();
+}
+
+void ScopedAVDictionary::Setter::operator=(std::int64_t value)
+{
+    av_dict_set_int(dict, key, value, 0);
+}
+
+ScopedAVDictionary::~ScopedAVDictionary()
+{
+    av_dict_free(&options);
+}
+
+ScopedAVDictionary::Setter ScopedAVDictionary::operator[](const char* key)
+{
+    return {&options, key};
+}
+
+AVDictionary** ScopedAVDictionary::get()
+{
+    return &options;
+}

--- a/src/video/scopedavdictionary.h
+++ b/src/video/scopedavdictionary.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024 The TokTok team.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+struct AVDictionary;
+class QString;
+
+class ScopedAVDictionary
+{
+    AVDictionary* options = nullptr;
+
+    struct Setter
+    {
+        AVDictionary** dict;
+        const char* key;
+
+        void operator=(const char* value);
+        void operator=(const QString& value);
+
+        template <std::size_t N>
+        void operator=(const std::array<char, N>& value)
+        {
+            *this = value.data();
+        }
+
+        void operator=(std::int64_t value);
+    };
+
+public:
+    ScopedAVDictionary() = default;
+    ScopedAVDictionary& operator=(const ScopedAVDictionary&) = delete;
+    ScopedAVDictionary(const ScopedAVDictionary&) = delete;
+
+    ~ScopedAVDictionary();
+
+    Setter operator[](const char* key);
+
+    AVDictionary** get();
+};

--- a/src/video/videomode.cpp
+++ b/src/video/videomode.cpp
@@ -20,15 +20,6 @@
  * @note a value < 0 indicates an invalid value
  */
 
-VideoMode::VideoMode(int width_, int height_, int x_, int y_, float fps_)
-    : width(width_)
-    , height(height_)
-    , x(x_)
-    , y(y_)
-    , fps(fps_)
-{
-}
-
 VideoMode::VideoMode(QRect rect)
     : width(rect.width())
     , height(rect.height())

--- a/src/video/videomode.cpp
+++ b/src/video/videomode.cpp
@@ -15,17 +15,17 @@
  * @var unsigned short VideoMode::x, VideoMode::y
  * @brief Coordinates of upper-left corner.
  *
- * @var float VideoMode::FPS
+ * @var float VideoMode::fps
  * @brief Frames per second supported by the device at this resolution
  * @note a value < 0 indicates an invalid value
  */
 
-VideoMode::VideoMode(int width_, int height_, int x_, int y_, float FPS_)
+VideoMode::VideoMode(int width_, int height_, int x_, int y_, float fps_)
     : width(width_)
     , height(height_)
     , x(x_)
     , y(y_)
-    , FPS(FPS_)
+    , fps(fps_)
 {
 }
 
@@ -45,7 +45,7 @@ QRect VideoMode::toRect() const
 bool VideoMode::operator==(const VideoMode& other) const
 {
     return width == other.width && height == other.height && x == other.x && y == other.y
-           && qFuzzyCompare(FPS, other.FPS) && pixel_format == other.pixel_format;
+           && qFuzzyCompare(fps, other.fps) && pixel_format == other.pixel_format;
 }
 
 uint32_t VideoMode::norm(const VideoMode& other) const
@@ -66,5 +66,5 @@ uint32_t VideoMode::tolerance() const
  */
 bool VideoMode::isUnspecified() const
 {
-    return width == 0 || height == 0 || static_cast<int>(FPS) == 0;
+    return width == 0 || height == 0 || static_cast<int>(fps) == 0;
 }

--- a/src/video/videomode.h
+++ b/src/video/videomode.h
@@ -15,7 +15,15 @@ struct VideoMode
     float fps = -1.0f;
     uint32_t pixel_format = 0;
 
-    explicit VideoMode(int width = 0, int height = 0, int x = 0, int y = 0, float fps = -1.0f);
+    explicit constexpr VideoMode(int width_ = 0, int height_ = 0, int x_ = 0, int y_ = 0,
+                                 float fps_ = -1.0f)
+        : width(width_)
+        , height(height_)
+        , x(x_)
+        , y(y_)
+        , fps(fps_)
+    {
+    }
 
     explicit VideoMode(QRect rect);
 

--- a/src/video/videomode.h
+++ b/src/video/videomode.h
@@ -12,10 +12,10 @@ struct VideoMode
 {
     int width, height;
     int x, y;
-    float FPS = -1.0f;
+    float fps = -1.0f;
     uint32_t pixel_format = 0;
 
-    explicit VideoMode(int width = 0, int height = 0, int x = 0, int y = 0, float FPS = -1.0f);
+    explicit VideoMode(int width = 0, int height = 0, int x = 0, int y = 0, float fps = -1.0f);
 
     explicit VideoMode(QRect rect);
 

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -140,7 +140,7 @@ void AVForm::open(const QString& devName, const VideoMode& mode)
 {
     QRect rect = mode.toRect();
     videoSettings->setCamVideoRes(rect);
-    videoSettings->setCamVideoFPS(static_cast<float>(mode.FPS));
+    videoSettings->setCamVideoFPS(mode.fps);
     camera.setupDevice(devName, mode);
 }
 
@@ -229,7 +229,7 @@ void AVForm::selectBestModes(QVector<VideoMode>& allVideoModes)
         VideoMode mode = allVideoModes[i];
 
         // PS3-Cam protection, everything above 60fps makes no sense
-        if (mode.FPS > 60)
+        if (mode.fps > 60)
             continue;
 
         for (auto iter = idealModes.begin(); iter != idealModes.end(); ++iter) {
@@ -254,13 +254,13 @@ void AVForm::selectBestModes(QVector<VideoMode>& allVideoModes)
 
             if (mode.norm(idealMode) == best.norm(idealMode)) {
                 // prefer higher FPS and "better" pixel formats
-                if (mode.FPS > best.FPS) {
+                if (mode.fps > best.fps) {
                     bestModeIndices[res] = i;
                     continue;
                 }
 
                 bool better = CameraDevice::betterPixelFormat(mode.pixel_format, best.pixel_format);
-                if (mode.FPS >= best.FPS && better)
+                if (mode.fps >= best.fps && better)
                     bestModeIndices[res] = i;
             }
         }
@@ -295,8 +295,8 @@ void AVForm::fillCameraModesComboBox()
 
         QString str;
         std::string pixelFormat = CameraDevice::getPixelFormatString(mode.pixel_format).toStdString();
-        qDebug("width: %d, height: %d, FPS: %f, pixel format: %s", mode.width, mode.height,
-               static_cast<double>(mode.FPS), pixelFormat.c_str());
+        qDebug("width: %d, height: %d, fps: %f, pixel format: %s", mode.width, mode.height,
+               static_cast<double>(mode.fps), pixelFormat.c_str());
 
         if (mode.height && mode.width) {
             str += QString("%1p").arg(mode.height);
@@ -321,7 +321,7 @@ int AVForm::searchPreferredIndex()
     for (int i = 0; i < videoModes.size(); ++i) {
         VideoMode mode = videoModes[i];
         if (mode.width == prefRes.width() && mode.height == prefRes.height()
-            && (qAbs(mode.FPS - prefFPS) < 0.0001f)) {
+            && (qAbs(mode.fps - prefFPS) < 0.0001f)) {
             return i;
         }
     }
@@ -337,8 +337,8 @@ void AVForm::fillScreenModesComboBox()
     for (int i = 0; i < videoModes.size(); ++i) {
         VideoMode mode = videoModes[i];
         std::string pixelFormat = CameraDevice::getPixelFormatString(mode.pixel_format).toStdString();
-        qDebug("%dx%d+%d,%d FPS: %f, pixel format: %s", mode.width, mode.height, mode.x, mode.y,
-               static_cast<double>(mode.FPS), pixelFormat.c_str());
+        qDebug("%dx%d+%d,%d fps: %f, pixel format: %s", mode.width, mode.height, mode.x, mode.y,
+               static_cast<double>(mode.fps), pixelFormat.c_str());
 
         QString name;
         if (mode.width && mode.height)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -49,18 +49,6 @@ AVForm::AVForm(IAudioControl& audio_, CoreAV* coreAV_, CameraSource& camera_,
 
     connect(rescanButton, &QPushButton::clicked, this, &AVForm::rescanDevices);
 
-    // TODO(iphydf): Fix the crashing bug when changing the video device during a call.
-    // See https://github.com/TokTok/qTox/issues/281
-    connect(coreAV_, &CoreAV::avStart, this, [this](uint32_t friendId, bool video) {
-        std::ignore = friendId;
-        std::ignore = video;
-        videoDevCombobox->setEnabled(false);
-    });
-    connect(coreAV_, &CoreAV::avEnd, this, [this](uint32_t friendId) {
-        std::ignore = friendId;
-        videoDevCombobox->setEnabled(!coreAV->isAnyCallActive());
-    });
-
     playbackSlider->setTracking(false);
     playbackSlider->setMaximum(totalSliderSteps);
     playbackSlider->setValue(getStepsFromValue(audioSettings_->getOutVolume(),

--- a/test/core/core_test.cpp
+++ b/test/core/core_test.cpp
@@ -56,7 +56,7 @@ private:
 };
 
 namespace {
-const int bootstrap_timeout = 15000;
+const int bootstrap_timeout = 20000;
 const int connected_message_wait = 5000;
 
 void bootstrapToxes(Core& alice, MockBootstrapListGenerator& alicesNodes, Core& bob,


### PR DESCRIPTION
This would happen e.g. on activating screen capture, but then denying permissions for it in the popup dialog. This doesn't exactly hang the program, but prevents any further changes to the capture device setting, and will hang the program on shutdown (in the destructor of the camera device).

The drive-by cleanups seem to have fixed the crash when changing video devices as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/300)
<!-- Reviewable:end -->
