### PR TITLE
feat: add appimage back to ci

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -216,6 +216,71 @@ jobs:
   # Build, test, and deploy jobs (PR and push)
   ################################################################################################
 
+  build-appimage:
+    name: AppImage on alpine
+    runs-on: ubuntu-22.04
+    needs: [update-nightly-tag]
+    strategy:
+      matrix:
+        features: [full]
+        build_type: [Release]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache compiler output
+        uses: actions/cache@v4
+        with:
+          path: ".cache/ccache"
+          key: ${{ github.job }}-ccache
+      - name: Install docker-compose
+        run: sudo apt-get install -y docker-compose
+      - name: Run build
+        run: docker-compose run --rm -e GITHUB_REPOSITORY=$GITHUB_REPOSITORY -e GITHUB_REF=$GITHUB_REF alpine-appimage ./appimage/build.sh --src-dir /qtox
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: qTox-${{ github.sha }}-x86_64-AppImage
+          path: |
+            qTox-*.AppImage
+            qTox-*.AppImage.zsync
+      - name: Get tag name for AppImage release file name
+        if: contains(github.ref, 'refs/tags/v')
+        id: get_version
+        run: |
+          VERSION="$(echo $GITHUB_REF | cut -d / -f 3)"
+          echo "release_appimage=qTox-$VERSION.x86_64.AppImage" >>$GITHUB_OUTPUT
+      - name: Rename AppImage for release upload
+        if: contains(github.ref, 'refs/tags/v')
+        run: |
+          cp qTox-*.x86_64.AppImage "${{ steps.get_version.outputs.release_appimage }}"
+          sha256sum "${{ steps.get_version.outputs.release_appimage }}" > "${{ steps.get_version.outputs.release_appimage }}.sha256"
+          cp qTox-*.x86_64.AppImage.zsync "${{ steps.get_version.outputs.release_appimage }}.zsync"
+      - name: Upload to versioned release
+        if: contains(github.ref, 'refs/tags/v')
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "${{ steps.get_version.outputs.release_appimage }},${{ steps.get_version.outputs.release_appimage }}.sha256,${{ steps.get_version.outputs.release_appimage }}.zsync"
+      - name: Rename AppImage for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          cp qTox-*.x86_64.AppImage qTox-nightly.x86_64.AppImage
+          sha256sum qTox-nightly.x86_64.AppImage > qTox-nightly.x86_64.AppImage.sha256
+          cp qTox-*.x86_64.AppImage.zsync qTox-nightly.x86_64.AppImage.zsync
+      - name: Upload to nightly release
+        uses: ncipollo/release-action@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          allowUpdates: true
+          tag: nightly
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "qTox-nightly.x86_64.AppImage,qTox-nightly.x86_64.AppImage.sha256,qTox-nightly.x86_64.AppImage.zsync"
+
   build-android:
     name: Android
     needs: [update-nightly-tag]

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -1,100 +1,73 @@
 #!/usr/bin/env bash
 
-# MIT License
-#
+# SPDX-License-Identifier: GPL-3.0-or-later.
 # Copyright © 2019 by The qTox Project Contributors
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Copyright © 2024 The TokTok team
 
 # Fail out on error
 set -exuo pipefail
 
 usage() {
-    echo "$0 --src-dir SRC_DIR"
-    echo "Builds an app image in the CWD based off qtox installation at SRC_DIR"
+  echo "$0 --src-dir SRC_DIR"
+  echo "Builds an app image in the CWD based off qtox installation at SRC_DIR"
 }
 
-while (( $# > 0 )); do
-    case $1 in
-        --src-dir) QTOX_SRC_DIR=$2; shift 2 ;;
-        --help|-h) usage; exit 1 ;;
-        *) echo "Unexpected argument $1"; usage; exit 1;;
-    esac
+while (($# > 0)); do
+  case $1 in
+    --src-dir)
+      QTOX_SRC_DIR=$2
+      shift 2
+      ;;
+    --help | -h)
+      usage
+      exit 1
+      ;;
+    *)
+      echo "Unexpected argument $1"
+      usage
+      exit 1
+      ;;
+  esac
 done
 
 if [ -z "${QTOX_SRC_DIR+x}" ]; then
-    echo "--src-dir is a required argument"
-    usage
-    exit 1
+  echo "--src-dir is a required argument"
+  usage
+  exit 1
 fi
 
 # directory paths
 BUILD_DIR=$(realpath .)
 readonly BUILD_DIR
-QTOX_APP_DIR="$BUILD_DIR"/appdir
+QTOX_APP_DIR="$BUILD_DIR/QTox.AppDir"
 readonly QTOX_APP_DIR
-readonly LOCAL_LIB_DIR="$QTOX_APP_DIR"/local/lib
-# ldqt binary
-readonly LDQT_BIN="/usr/lib/qt5/bin/linuxdeployqt"
+
+rm -f appimagetool-*.AppImage
+wget "https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)"
+chmod +x appimagetool-*.AppImage
 
 # update information to be embeded in AppImage
-readonly UPDATE_INFO="gh-releases-zsync|qTox|qTox|latest|qTox-*.x86_64.AppImage.zsync"
-export GIT_VERSION=$(git -C "${QTOX_SRC_DIR}" rev-parse --short HEAD)
+#readonly UPDATE_INFO="gh-releases-zsync|TokTok|qTox|latest|qTox-*.x86_64.AppImage.zsync"
+#export GIT_VERSION=$(git -C "${QTOX_SRC_DIR}" rev-parse --short HEAD)
 
-echo $QTOX_APP_DIR
-cmake "${QTOX_SRC_DIR}" -DDESKTOP_NOTIFICATIONS=ON -DUPDATE_CHECK=ON -DCMAKE_BUILD_TYPE=Release
-make -j$(nproc)
-rm -fr appdir
-make DESTDIR=appdir install
+echo "$QTOX_APP_DIR"
+cmake "$QTOX_SRC_DIR" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="/work/lib64/cmake;/work/qt/lib/cmake" \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DUPDATE_CHECK=ON \
+  -B _build
+cmake --build _build
+#rm -fr QTox.AppDir
+cmake --install _build --prefix QTox.AppDir/usr
 
-unset QTDIR; unset QT_PLUGIN_PATH; unset LD_LIBRARY_PATH;
+export QTDIR=/work/qt
+export LD_LIBRARY_PATH="/work/lib64:$QTDIR/lib"
 
-readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.desktop
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/x86_64-linux-gnu/
+./appimagetool-*.AppImage --appimage-extract-and-run -s deploy "$QTOX_APP_DIR"/usr/share/applications/*.desktop
 
-eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
+# print all links not contained inside the AppDir
+LD_LIBRARY_PATH='' find "$QTOX_APP_DIR" -type f -exec ldd {} \; 2>&1 | grep '=>' | grep -v "$QTOX_APP_DIR"
 
-# Move the required files to the correct directory
-mv "$QTOX_APP_DIR"/usr/* "$QTOX_APP_DIR/"
-rm -rf "$QTOX_APP_DIR/usr"
-
-# Warning: This is hard coded to debain:stretch.
-libs=(
-# copy OpenSSL libs to AppImage
-/usr/lib/x86_64-linux-gnu/libssl.so
-/usr/lib/x86_64-linux-gnu/libcrypt.so
-/usr/lib/x86_64-linux-gnu/libcrypto.so
-# Also bundle libjack.so* without which the AppImage does not work in Fedora Workstation
-/usr/lib/x86_64-linux-gnu/libjack.so.0
-# And libglib needed by Red Hat and derivatives to work with our old gnutls
-/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
-/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
-/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0
-/usr/lib/x86_64-linux-gnu/libpango-1.0.so.0
-/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0
-/usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0
-)
-
-for lib in "${libs[@]}"; do
-    lib_file_name=$(basename "$lib")
-    cp -P $(echo "$lib"*) "$LOCAL_LIB_DIR"
-    patchelf --set-rpath '$ORIGIN' "$LOCAL_LIB_DIR/$lib_file_name"
-done
-
-appimagetool -u "$UPDATE_INFO" $QTOX_APP_DIR qTox-${GIT_VERSION}.x86_64.AppImage
+./appimagetool-*.AppImage --appimage-extract-and-run "$QTOX_APP_DIR"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
   alpine:
     image: toxchat/qtox:alpine
     <<: *shared_params
+  alpine-appimage:
+    image: toxchat/qtox:alpine-appimage
+    <<: *shared_params
   alpine-static:
     image: toxchat/qtox:alpine-static
     <<: *shared_params

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -40,7 +40,7 @@
 #include <QtGlobal>
 
 #ifdef SPELL_CHECKING
-#include <KF6/SonnetUi/sonnet/spellcheckdecorator.h>
+#include <sonnet/spellcheckdecorator.h>
 #endif
 
 /**


### PR DESCRIPTION
things still to do:
 - [x] make own alpine image with up-to-date toxcore!!
 - [ ] find a solution for the go-appimage download. it currently always downloads the latest. (they only provide the latest !!)
 - [x] ~test non standalone deploys~ they are funny and dont work
 - [ ] check if the .zsync update diff is properly generated (how?)
 - [x] ccache
 - [x] fix arch? in gh artifact
 - [ ] add arm64 arch?


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/306)
<!-- Reviewable:end -->
