### PR TITLE
fix: Avoid occasional crash when changing video devices or closing qTox.

### DIFF
--- a/.ci-scripts/macos_install_deps.sh
+++ b/.ci-scripts/macos_install_deps.sh
@@ -25,4 +25,5 @@ install_deps() {
     popd
     rm -rf "external/$dep"
   done
+  rmdir external
 }

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -50,6 +50,8 @@ jobs:
         run: .ci-scripts/import-developer-keys.sh
       - name: Verify signatures
         if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: tools/verify-release-assets.py
 
   update-nightly-tag:

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -408,8 +408,8 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
     Toxav_Err_Send_Frame err;
     int retries = 0;
     do {
-        if (!toxav_video_send_frame(toxav.get(), callId, frame.width, frame.height, frame.y,
-                                    frame.u, frame.v, &err)) {
+        if (!toxav_video_send_frame(toxav.get(), callId, frame.width, frame.height, frame.y.data(),
+                                    frame.u.data(), frame.v.data(), &err)) {
             if (err == TOXAV_ERR_SEND_FRAME_SYNC) {
                 ++retries;
                 QThread::usleep(500);

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -64,6 +64,7 @@ QVector<QPair<QString, QString>> avfoundation::getDeviceList()
     QVector<QPair<QString, QString>> result;
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+    CGRequestScreenCaptureAccess();
     const AVAuthorizationStatus authStatus =
         [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
     if (authStatus != AVAuthorizationStatusDenied && authStatus != AVAuthorizationStatusNotDetermined) {

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -24,6 +24,7 @@ extern "C"
 #include <functional>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 struct ToxYUVFrame
 {
@@ -34,9 +35,9 @@ public:
     const std::uint16_t width;
     const std::uint16_t height;
 
-    const uint8_t* y;
-    const uint8_t* u;
-    const uint8_t* v;
+    const std::vector<uint8_t> y;
+    const std::vector<uint8_t> u;
+    const std::vector<uint8_t> v;
 };
 
 class VideoFrame


### PR DESCRIPTION
There was an AV race condition caused by clearing the frame buffer while the VideoFrame is in flight towards toxav. The fix is heavy-handed in that we're now just copying the frame every time, even though we almost never have this problem (only when changing devices). So we pay the cost all the time even though it's rarely needed. However, this is a serious crashing bug (heap-use-after-free), so I'd rather have it fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/312)
<!-- Reviewable:end -->
