### PR TITLE
fix: Avoid occasional crash when changing video devices or closing qTox.

### DIFF
--- a/.ci-scripts/macos_install_deps.sh
+++ b/.ci-scripts/macos_install_deps.sh
@@ -25,4 +25,5 @@ install_deps() {
     popd
     rm -rf "external/$dep"
   done
+  rmdir external
 }

--- a/macos/createdmg
+++ b/macos/createdmg
@@ -27,18 +27,23 @@ else
   echo "No Development identity found, skipping code signing"
 fi
 
-create-dmg \
-  --filesystem APFS \
-  --no-internet-enable \
-  --volname "qTox $APP_VER" \
-  --volicon "$QTOX_DIR/img/icons/qtox.icns" \
-  --background "$QTOX_DIR/macos/backgroundImage.tiff" \
-  --eula "$QTOX_DIR/macos/gplv3.rtf" \
-  --window-pos 200 120 \
-  --window-size 640 480 \
-  --icon-size 128 \
-  --hide-extension "qTox.app" \
-  --icon "qTox.app" 0 300 \
-  --app-drop-link 400 300 \
-  "$BUILD_DIR/qTox.dmg" \
-  "$BUNDLE_PATH"
+createdmg() {
+  create-dmg \
+    --filesystem APFS \
+    --no-internet-enable \
+    --volname "qTox $APP_VER" \
+    --volicon "$QTOX_DIR/img/icons/qtox.icns" \
+    --background "$QTOX_DIR/macos/backgroundImage.tiff" \
+    --eula "$QTOX_DIR/macos/gplv3.rtf" \
+    --window-pos 200 120 \
+    --window-size 640 480 \
+    --icon-size 128 \
+    --hide-extension "qTox.app" \
+    --icon "qTox.app" 0 300 \
+    --app-drop-link 400 300 \
+    "$BUILD_DIR/qTox.dmg" \
+    "$BUNDLE_PATH"
+}
+
+# Retry 3 times in case of "hdiutil: create failed - Resource busy".
+createdmg || createdmg || createdmg

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -397,9 +397,9 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
         call.setNullVideoBitrate(false);
     }
 
-    ToxYUVFrame frame = vframe->toToxYUVFrame();
+    auto [frame, frameLocker] = vframe->toToxYUVFrame();
 
-    if (!frame) {
+    if (!frame.isValid()) {
         return;
     }
 

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -64,6 +64,7 @@ QVector<QPair<QString, QString>> avfoundation::getDeviceList()
     QVector<QPair<QString, QString>> result;
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+    CGRequestScreenCaptureAccess();
     const AVAuthorizationStatus authStatus =
         [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
     if (authStatus != AVAuthorizationStatusDenied && authStatus != AVAuthorizationStatusNotDetermined) {


### PR DESCRIPTION
There was an AV race condition caused by clearing the frame buffer while the VideoFrame is in flight towards toxav. This change makes it so the receiver of the frame retains the lock of the frame buffer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/313)
<!-- Reviewable:end -->
