### PR TITLE
fix: Fix uninitialised read in contact circle widget.

### DIFF
--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -29,7 +29,7 @@ QHash<int, CircleWidget*> CircleWidget::circleList;
 CircleWidget::CircleWidget(const Core& core_, FriendListWidget* parent, int id_, Settings& settings_,
                            Style& style_, IMessageBoxManager& messageBoxManager_,
                            FriendList& friendList_, ConferenceList& conferenceList_, Profile& profile_)
-    : CategoryWidget(isCompact(), settings_, style_, parent)
+    : CategoryWidget(settings_.getCompactLayout(), settings_, style_, parent)
     , id(id_)
     , core{core_}
     , settings{settings_}


### PR DESCRIPTION
`isCompact` reads from `this->compact`, which isn't ready yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/314)
<!-- Reviewable:end -->
