### PR TITLE
chore: Install homebrew bash v5.

### DIFF
--- a/macos/Brewfile
+++ b/macos/Brewfile
@@ -1,3 +1,4 @@
+brew "bash"  # macOS bash is too old
 brew "cmake"
 brew "coreutils"
 brew "create-dmg"

--- a/macos/Brewfile-DepBuildDeps
+++ b/macos/Brewfile-DepBuildDeps
@@ -1,6 +1,7 @@
 # Dependencies for building all of qTox's dependencies except Qt from source.
 # Needed for distributable builds, but users should use Brewfile if they are
 # just compiling for their own machine.
+brew "bash"  # macOS bash is too old
 brew "cmake"
 brew "coreutils"
 brew "create-dmg"

--- a/macos/createdmg
+++ b/macos/createdmg
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# SPDX-License-Identifier: GPL-3.0-or-later.
+# SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2017-2019 by The qTox Project Contributors
 # Copyright © 2024 The TokTok team
 

--- a/macos/update-plist-version.sh
+++ b/macos/update-plist-version.sh
@@ -1,19 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-#    Copyright © 2016-2019 The qTox Project Contributors
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2016-2019 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 # script to change qTox version in `Info.plist` file to the supplied one
 #
@@ -29,7 +18,7 @@
 #
 # $version has to be composed of at least one number/dot
 
-set -eu -o pipefail
+set -euo pipefail
 
 # update version in `Info.plist` file to supplied one after the right lines
 update_version() {


### PR DESCRIPTION
macOS comes with bash v3, which doesn't do arrays. We can't comply with restyled/codacy requirements without arrays.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/321)
<!-- Reviewable:end -->
