### PR TITLE
cleanup: Don't use deprecated spelling of tox enums.

### DIFF
--- a/.ci-scripts/build-qtox-macos.sh
+++ b/.ci-scripts/build-qtox-macos.sh
@@ -16,8 +16,10 @@ fi
 
 source "$SCRIPT_DIR/dockerfiles/qtox/build_utils.sh"
 
+SCRIPT_ARCH="macos-$(uname -m)"
+
 # kind of a hack.. but we want to extract DEP_PREFIX from it
-parse_arch --arch macos --supported macos --dep macos
+parse_arch --arch "$SCRIPT_ARCH" --supported "$SCRIPT_ARCH" --dep qtox
 
 if [ "$1" == "user" ]; then
   CMAKE=cmake

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -97,7 +97,7 @@ bool fileTransferFailed(const ToxFile::FileStatus& status)
 
 bool shouldProcessFileKind(uint8_t inKind)
 {
-    auto kind = static_cast<TOX_FILE_KIND>(inKind);
+    auto kind = static_cast<Tox_File_Kind>(inKind);
 
     switch (kind) {
     case TOX_FILE_KIND_DATA:
@@ -108,7 +108,7 @@ bool shouldProcessFileKind(uint8_t inKind)
         return false;
     }
 
-    qWarning("Unexpected file kind %d", kind);
+    qWarning("Unexpected file kind %d", inKind);
     return false;
 }
 


### PR DESCRIPTION
Needs https://github.com/TokTok/dockerfiles/pull/221

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/323)
<!-- Reviewable:end -->
