### PR TITLE
fix(Security): Harden the persistence/serialization functions.

### DIFF
--- a/src/persistence/serialize.cpp
+++ b/src/persistence/serialize.cpp
@@ -5,81 +5,42 @@
 
 #include "src/persistence/serialize.h"
 
+#include <climits>
+
 /**
  * @file serialize.cpp
- * Most of functions in this file are unsafe unless otherwise specified.
- * @warning Do not use them on untrusted data (e.g. check a signature first).
+ *
+ * These functions are hardened against any input data and will not crash.
+ * They will return an empty string or 0 if the data is invalid. The 0 was
+ * chosen (as opposed to e.g. -1) to avoid potential out-of-bounds problems
+ * in the caller.
+ *
+ * There is no error handling here. Callers should ideally only pass valid
+ * data to these functions.
  */
 
-QString dataToString(QByteArray data)
-{
-    char num3;
-    int strlen = 0;
-    int num2 = 0;
-    int i = 0;
-    do {
-        num3 = data[i++];
-        strlen |= (num3 & 0x7f) << num2;
-        num2 += 7;
-    } while ((num3 & 0x80) != 0);
-
-    if (strlen <= 0)
-        return QString();
-
-    // Remove the strlen
-    data.remove(0, i);
-    data.truncate(strlen);
-
-    return QString::fromUtf8(data);
-}
-
-uint64_t dataToUint64(const QByteArray& data)
-{
-    return static_cast<uint64_t>(data[0]) | (static_cast<uint64_t>(data[1]) << 8)
-           | (static_cast<uint64_t>(data[2]) << 16) | (static_cast<uint64_t>(data[3]) << 24)
-           | (static_cast<uint64_t>(data[4]) << 32) | (static_cast<uint64_t>(data[5]) << 40)
-           | (static_cast<uint64_t>(data[6]) << 48) | (static_cast<uint64_t>(data[7]) << 56);
+namespace {
+constexpr size_t intWidth = sizeof(int) * CHAR_BIT;
 }
 
 int dataToVInt(const QByteArray& data)
 {
     char num3;
     int num = 0;
-    int num2 = 0;
+    size_t num2 = 0;
     int i = 0;
     do {
+        if (i >= data.size()) {
+            return 0;
+        }
         num3 = data[i++];
         num |= static_cast<int>(num3 & 0x7f) << num2;
         num2 += 7;
+        if (num2 > intWidth) {
+            return 0;
+        }
     } while ((num3 & 0x80) != 0);
     return num;
-}
-
-size_t dataToVUint(const QByteArray& data)
-{
-    char num3;
-    size_t num = 0;
-    int num2 = 0;
-    int i = 0;
-    do {
-        num3 = data[i++];
-        num |= static_cast<size_t>(num3 & 0x7f) << num2;
-        num2 += 7;
-    } while ((num3 & 0x80) != 0);
-    return num;
-}
-
-unsigned getVUint32Size(QByteArray data)
-{
-    unsigned lensize = 0;
-
-    char num3;
-    do {
-        num3 = data[lensize];
-        ++lensize;
-    } while ((num3 & 0x80) != 0);
-
-    return lensize;
 }
 
 QByteArray vintToData(int num)
@@ -88,24 +49,15 @@ QByteArray vintToData(int num)
     // Write the size in a Uint of variable length (8-32 bits)
     int i = 0;
     while (num >= 0x80) {
+        if (i >= data.size()) {
+            return {};
+        }
         data[i] = static_cast<char>(num | 0x80);
         ++i;
         num = num >> 7;
     }
-    data[i] = static_cast<char>(num);
-    data.resize(i + 1);
-    return data;
-}
-
-QByteArray vuintToData(size_t num)
-{
-    QByteArray data(sizeof(size_t), 0);
-    // Write the size in a Uint of variable length (8-32 bits)
-    int i = 0;
-    while (num >= 0x80) {
-        data[i] = static_cast<char>(num | 0x80);
-        ++i;
-        num = num >> 7;
+    if (i >= data.size()) {
+        return {};
     }
     data[i] = static_cast<char>(num);
     data.resize(i + 1);

--- a/src/persistence/serialize.h
+++ b/src/persistence/serialize.h
@@ -3,17 +3,9 @@
  * Copyright © 2024 The TokTok team.
  */
 
-
 #pragma once
 
 #include <QByteArray>
-#include <QString>
-#include <cstdint>
 
-QString dataToString(QByteArray data);
-uint64_t dataToUint64(const QByteArray& data);
 int dataToVInt(const QByteArray& data);
-size_t dataToVUint(const QByteArray& data);
-unsigned getVUint32Size(QByteArray data);
 QByteArray vintToData(int num);
-QByteArray vuintToData(size_t num);


### PR DESCRIPTION
These ought to be used with safe data, but who knows whether they actually are. Now, these functions will never fatally misbehave.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/335)
<!-- Reviewable:end -->
