### PR TITLE
perf(Video): Avoid copying frame buffers unnecessarily.

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -397,9 +397,9 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
         call.setNullVideoBitrate(false);
     }
 
-    ToxYUVFrame frame = vframe->toToxYUVFrame();
+    auto [frame, frameLocker] = vframe->toToxYUVFrame();
 
-    if (!frame) {
+    if (!frame.isValid()) {
         return;
     }
 
@@ -408,8 +408,8 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
     Toxav_Err_Send_Frame err;
     int retries = 0;
     do {
-        if (!toxav_video_send_frame(toxav.get(), callId, frame.width, frame.height, frame.y.data(),
-                                    frame.u.data(), frame.v.data(), &err)) {
+        if (!toxav_video_send_frame(toxav.get(), callId, frame.width, frame.height, frame.y,
+                                    frame.u, frame.v, &err)) {
             if (err == TOXAV_ERR_SEND_FRAME_SYNC) {
                 ++retries;
                 QThread::usleep(500);


### PR DESCRIPTION
We need to extend the frame buffer lock a little more by returning it to the caller, but this way we can avoid copying frames (which can be quite large here).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/337)
<!-- Reviewable:end -->
