### PR TITLE
cleanup: Use version.h in cmake build as well.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -210,10 +210,6 @@ if (NOT GIT_DESCRIBE)
   endif()
 endif()
 
-add_definitions(
-  -DGIT_DESCRIBE="${GIT_DESCRIBE}"
-)
-
 if (NOT GIT_VERSION)
   execute_process(
     COMMAND git rev-parse HEAD
@@ -227,10 +223,6 @@ if (NOT GIT_VERSION)
     set(GIT_VERSION "build without git")
   endif()
 endif()
-
-add_definitions(
-  -DGIT_VERSION="${GIT_VERSION}"
-)
 
 if (NOT GIT_DESCRIBE_EXACT)
   execute_process(
@@ -246,8 +238,11 @@ if (NOT GIT_DESCRIBE_EXACT)
   endif()
 endif()
 
-add_definitions(
-  -DGIT_DESCRIBE_EXACT="${GIT_DESCRIBE_EXACT}"
+# Generate version.h with the above version information.
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/src/version.h
+  @ONLY
 )
 
 set(APPLE_EXT False)
@@ -262,9 +257,7 @@ endif()
 
 if (PLATFORM_EXTENSIONS)
   if (${APPLE_EXT} OR ${X11_EXT} OR WIN32)
-    add_definitions(
-      -DQTOX_PLATFORM_EXT
-    )
+    add_definitions(-DQTOX_PLATFORM_EXT)
     message(STATUS "Using platform extensions")
   else()
     message(WARNING "Not using platform extensions, dependencies not found")
@@ -272,8 +265,4 @@ if (PLATFORM_EXTENSIONS)
   endif()
 endif()
 
-add_definitions(
-  -DLOG_TO_FILE=1
-)
-
-add_definitions(-DCMAKE_BUILD)
+add_definitions(-DLOG_TO_FILE=1)

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -11,13 +11,11 @@
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/persistence/toxsave.h"
+#include "src/version.h"
+#include "src/video/camerasource.h"
 #include "src/widget/tool/messageboxmanager.h"
 #include "src/widget/translator.h"
 #include "src/widget/widget.h"
-#ifndef CMAKE_BUILD
-#include "src/version.h"
-#endif
-#include "src/video/camerasource.h"
 
 #if defined(Q_OS_UNIX)
 #include "src/platform/posixsignalnotifier.h"

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -5,9 +5,7 @@
 #include "src/net/updatecheck.h"
 
 #include "src/persistence/settings.h"
-#ifndef CMAKE_BUILD
 #include "src/version.h"
-#endif
 
 #include <QDebug>
 #include <QJsonDocument>

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+
+#pragma once
+
+#define GIT_DESCRIBE "@GIT_DESCRIBE@"
+#define GIT_VERSION "@GIT_VERSION@"
+#define GIT_DESCRIBE_EXACT "@GIT_DESCRIBE_EXACT@"

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -9,9 +9,7 @@
 #include "src/net/updatecheck.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
-#ifndef CMAKE_BUILD
 #include "src/version.h"
-#endif
 #include "src/widget/style.h"
 #include "src/widget/tool/recursivesignalblocker.h"
 #include "src/widget/translator.h"


### PR DESCRIPTION
This avoids having to do a full rebuild when any of the git describe stuff changes (which is all the time). This greatly speeds up ccache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/339)
<!-- Reviewable:end -->
