### PR TITLE
cleanup: Remove unnecessary space at the end of a warning message.

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -239,7 +239,7 @@ void ChatForm::onFileNameChanged(const ToxPk& friendPk)
     }
 
     QMessageBox::warning(this, tr("Filename contained illegal characters"),
-                         tr("Illegal characters have been changed to _ \n"
+                         tr("Illegal characters have been changed to _\n"
                             "so you can save the file on Windows."));
 }
 

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -693,7 +693,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -691,7 +691,7 @@ which may lead to problems with video calls.</source>
         <translation>Назва файла змяшчае недапушчальныя сімвалы</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -648,7 +648,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -694,7 +694,7 @@ which may lead to problems with video calls.</source>
         <translation>Името на файла съдържа недействителни символи</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Невалидните знаци бяха преобразувани в _
 за да запазите файла в Уиндоус.</translation>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -686,7 +686,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -694,7 +694,7 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
         <translation>Název souboru obsahuje nepovolené znaky</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Nepovolené znaky byly nahrazeny podtržítkem (_),
 takže můžete soubor uložit i v systému Windows.</translation>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -689,7 +689,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -694,7 +694,7 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
         <translation>Der Dateiname enthält nicht unterstützte Satzzeichen</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Nicht unterstützte Satzzeichen wurden zu _ geändert,
 um sie in Windows speichern zu können.</translation>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -689,7 +689,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -685,7 +685,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -694,7 +694,7 @@ lo que puede provocar problemas en las videollamadas.</translation>
         <translation>Nombre del archivo contenía caracteres no válidos</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Los caracteres no válidos fueran cambiados a _
 para que puedas guardar el archivo en windows.</translation>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -693,7 +693,7 @@ mis võib põhjustada probleeme videokõnedega.</translation>
         <translation>Failinimi sisaldas keelatud märke</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Mõned mittesobilikud tähemärgid oleme asendanud alakriipsuga
 ja sa saad seda faili nüüd Windowsis salvestada.</translation>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -689,7 +689,7 @@ which may lead to problems with video calls.</source>
         <translation>نام فایل حاوی کاراکتر‌های غیر‎‌مجاز است</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -693,7 +693,7 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
         <translation>Tiedostonimi sisälsi kiellettyjä merkkejä</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Kielletyt merkit on vaihdettu _
 joten voit tallentaa tiedoston Windowsissa.</translation>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -693,7 +693,7 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
         <translation>Le nom de fichier contient des caractères non autorisés</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Les caractères illégaux ont été changés en _
 afin que vous puissiez enregistrer le fichier sur windows.</translation>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -690,7 +690,7 @@ which may lead to problems with video calls.</source>
         <translation>O ficheiro tiña caracteres ilegais</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -686,7 +686,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -690,7 +690,7 @@ which may lead to problems with video calls.</source>
         <translation>Ime datoteke je sadržalo nedozvoljene znakove</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -688,7 +688,7 @@ which may lead to problems with video calls.</source>
         <translation>A fájlnév illegális karaktereket tartalmaz</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -686,7 +686,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -693,7 +693,7 @@ il che può portare a problemi con le videochiamate.</translation>
         <translation>Il nome del file conteneva caratteri non autorizzati</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>I caratteri non validi sono stati cambiati in _
 in modo da poter salvare il file su Windows.</translation>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -688,7 +688,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -647,7 +647,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -686,7 +686,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -689,7 +689,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -694,7 +694,7 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
         <translation>Failo pavadinime buvo neleidžiamų simbolių</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Neleidžiami simboliai buvo pakeisti į _
 tad dabar galite įrašyti failą Windows sistemoje.</translation>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -695,7 +695,7 @@ kas var radīt video zvanu problēmas.</translation>
         <translation>Faila nosaukums satur nederīgas rakstzīmes</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Nederīgas rakstzīmes tiks aizvietotas ar _
 lai varētu saglabāt failus Windows operētājsistēmā.</translation>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -691,7 +691,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -693,7 +693,7 @@ wat kan leiden tot problemen met videogesprekken.</translation>
         <translation>Bestandsnaam bevatte niet-toegestane tekens</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Ongeldige tekens zijn vervangen door _
 zodat u het bestand op Windows kunt opslaan.</translation>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -690,7 +690,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -695,7 +695,7 @@ noe som kan forårsake problemer i videosamtaler.</translation>
         <translation>Filnavnet inneholdt ulovlige tegn</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Ulovlige tegn har blitt endret til _
 slik at du kan lagre filen på Windows.</translation>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -701,7 +701,7 @@ co może powodować problemy z rozmowami wideo.</translation>
         <translation>Nazwa pliku zawiera niedozwolone znaki</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Niedozwolone znaki zostały zmienione na _
 więc możesz zapisać ten plik na systemie Windows.</translation>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -651,7 +651,7 @@ Take heed, fer higher qualities demand clearer skies.If yer seas are stormy, yer
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -693,7 +693,7 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
         <translation>O nome do ficheiro contém caracteres não permitidos</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Os caracteres ilegais foram alterados para _
 de forma que possa guardar o ficheiro no Windows.</translation>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -694,7 +694,7 @@ o que pode levar a problemas com as videochamadas.</translation>
         <translation>O nome do arquivo continha caracteres não autorizados</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Os caracteres ilegais foram alterados para _
 de forma que você possa salvar o arquivo no Windows.</translation>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -695,7 +695,7 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
         <translation>Denumirea fișierului conține caractere neconforme</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Caracterele ilegale au fost schimbate în _
 astfel încât să puteți salva fișierul pe Windows.</translation>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -696,7 +696,7 @@ which may lead to problems with video calls.</source>
         <translation>Имя файла содержит недопустимые символы</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Недопустимые символы изменены на _
 чтобы вы смогли сохранить файл в Windows.</translation>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -686,7 +686,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -695,7 +695,7 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
         <translation>Názov súboru obsahoval nepovolené znaky</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Nepovolené znaky boli zmenené na _
 so you can save the file on Windows.</translation>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -691,7 +691,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -686,7 +686,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -691,7 +691,7 @@ which may lead to problems with video calls.</source>
         <translation>Назив датотеке садржи неисправне знакове</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -691,7 +691,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -693,7 +693,7 @@ vilket kan leda till problem med videosamtal.</translation>
         <translation>Filnamnet innehåller förbjudna tecken</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Olagliga tecken har ändrats till _
 så att du kan spara filen i Windows.</translation>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -686,7 +686,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -691,7 +691,7 @@ qTox இல் தாங்கள் சிக்கலோ பாதுகாப
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -695,7 +695,7 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
         <translation>Dosya adı yasaklanmış karakterler içeriyor</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Dosyayı Windows&apos;ta kaydedebilmeniz için
 geçersiz karakterler _ olarak değiştirildi.</translation>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -690,7 +690,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -694,7 +694,7 @@ which may lead to problems with video calls.</source>
         <translation>Ім&apos;я файлу містить недозволені символи</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Недозволені символи були змінені на _
 щоб ви могли зберегти файл у Windows.</translation>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -694,7 +694,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -693,7 +693,7 @@ có thể dẫn đến sự cố với cuộc gọi điện video.</translation>
         <translation>Tên tệp chứa các ký tự không hợp lệ</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>Các ký tự không hợp lệ đã được đổi thành _
 để bạn có thể lưu tệp trên Windows.</translation>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -692,7 +692,7 @@ which may lead to problems with video calls.</source>
         <translation>文件名包含非法字符</translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation>非法字符已更改为 _
 因此，您可以在 Windows 上保存该文件。</translation>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -689,7 +689,7 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Illegal characters have been changed to _ 
+        <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This messes up XML processing tools for translations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/345)
<!-- Reviewable:end -->
