### PR TITLE
refactor: Use Qt's DNS lookup instead of toxcore's.

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -28,6 +28,7 @@
 #include <functional>
 #include <memory>
 
+class QHostAddress;
 class CoreAV;
 class CoreFile;
 class IAudioControl;
@@ -220,6 +221,7 @@ private:
     void makeTox(QByteArray savedata, ICoreSettings* s);
     void loadFriends();
     void loadConferences();
+    void bootstrapTo(const DhtServer& dhtServer, const QHostAddress& address);
     void bootstrapDht();
 
     void checkLastOnline(uint32_t friendId);

--- a/src/core/toxoptions.cpp
+++ b/src/core/toxoptions.cpp
@@ -24,6 +24,10 @@ ToxOptions::ToxOptions(Tox_Options* options_, const QByteArray& proxyAddrData_)
     : options(options_)
     , proxyAddrData(proxyAddrData_)
 {
+    assert(options != nullptr);
+#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 21)
+    tox_options_set_experimental_disable_dns(options, true);
+#endif
 }
 
 ToxOptions::~ToxOptions()

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -6,6 +6,7 @@
 
 #include "src/persistence/settings.h"
 #include "src/version.h"
+#include "util/laterdeleter.h"
 
 #include <QDebug>
 #include <QJsonDocument>
@@ -124,11 +125,12 @@ void UpdateCheck::handleResponse(QNetworkReply* reply)
         return;
     }
 
+    const LaterDeleter replyDeleter(reply);
+
 #ifdef UPDATE_CHECK_ENABLED
     if (reply->error() != QNetworkReply::NoError) {
         qWarning() << "Failed to check for update:" << reply->error();
         emit updateCheckFailed();
-        reply->deleteLater();
         return;
     }
     const QByteArray result = reply->readAll();
@@ -139,7 +141,6 @@ void UpdateCheck::handleResponse(QNetworkReply* reply)
     if (latestVersion.isEmpty()) {
         qWarning() << "No tag name found in response:";
         emit updateCheckFailed();
-        reply->deleteLater();
         return;
     }
 
@@ -154,7 +155,5 @@ void UpdateCheck::handleResponse(QNetworkReply* reply)
         qInfo() << "qTox is up to date";
         emit upToDate();
     }
-
-    reply->deleteLater();
 #endif
 }

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(
   util_library STATIC
   include/util/algorithm.h
   src/algorithm.cpp
+  include/util/laterdeleter.h
+  src/laterdeleter.cpp
   include/util/interface.h
   include/util/ranges.h
   src/ranges.cpp

--- a/util/include/util/laterdeleter.h
+++ b/util/include/util/laterdeleter.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+
+#pragma once
+
+class QObject;
+
+struct LaterDeleter
+{
+    QObject* ptr;
+
+    explicit LaterDeleter(QObject* ptr_);
+    ~LaterDeleter();
+};

--- a/util/src/laterdeleter.cpp
+++ b/util/src/laterdeleter.cpp
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+
+#include "util/laterdeleter.h"
+
+#include <QObject>
+
+LaterDeleter::LaterDeleter(QObject* ptr_)
+    : ptr(ptr_)
+{
+}
+
+LaterDeleter::~LaterDeleter()
+{
+    ptr->deleteLater();
+}


### PR DESCRIPTION
This is in preparation for sending DNS lookups to tor-resolve.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/346)
<!-- Reviewable:end -->
