### PR TITLE
chore: Cache flatpak's ccache separately (and upgrade to KDE 6.8).

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -425,11 +425,19 @@ jobs:
         with:
           fetch-depth: 100
           fetch-tags: true
-      - name: Cache flatpak-builder cache
+      - name: Cache flatpak-builder cache (except ccache)
         uses: actions/cache@v4
         with:
-          path: ".flatpak-builder"
-          key: ${{ github.job }}
+          path: |
+            .flatpak-builder/cache
+            .flatpak-builder/checksums
+            .flatpak-builder/downloads
+          key: ${{ github.job }}-builder
+      - name: Cache flatpak-builder cache (only ccache)
+        uses: actions/cache@v4
+        with:
+          path: ".flatpak-builder/ccache"
+          key: ${{ github.job }}-ccache
       - name: Get tag name for flatpak release file name
         if: contains(github.ref, 'refs/tags/v')
         id: get_version
@@ -484,7 +492,7 @@ jobs:
   test-flatpak:
     name: Test Flatpak
     needs: [build-flatpak]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Download artifact from Flatpak

--- a/flatpak/io.github.qtox.qTox.json
+++ b/flatpak/io.github.qtox.qTox.json
@@ -2,7 +2,7 @@
   "app-id": "io.github.qtox.qTox",
   "runtime": "org.kde.Platform",
   "sdk": "org.kde.Sdk",
-  "runtime-version": "6.7",
+  "runtime-version": "6.8",
   "command": "qtox",
   "rename-icon": "qtox",
   "finish-args": [


### PR DESCRIPTION
ccache changes much more often than the rest of the cache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/360)
<!-- Reviewable:end -->
