### PR TITLE
chore: Don't consider an untagged build to be stable.

### DIFF
--- a/.ci-scripts/smoke-test.sh
+++ b/.ci-scripts/smoke-test.sh
@@ -3,11 +3,9 @@
 set -eux -o pipefail
 
 # Release tags *or* master builds where the current commit is tagged
-# with 'v.*' are considered stable. We also consider the version stable
-# if the current commit message is "chore: Release v.*".
+# with 'v.*' are considered stable.
 if [ -n "$(echo "$GITHUB_REF" | grep -o 'refs/tags/v.*')" ] ||
-  [ -n "$(git tag --points-at HEAD | grep '^v.*')" ] ||
-  [ -n "$(git log -1 --pretty=%B | grep '^chore: Release v.*')" ]; then
+  [ -n "$(git tag --points-at HEAD | grep '^v.*')" ]; then
   REGEX="qTox v.* (stable)"
 else
   REGEX="qTox v.* (unstable)"


### PR DESCRIPTION
Even if the current master *will* become a release build, the nightly that comes out of it should be considered an unstable non-release build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/384)
<!-- Reviewable:end -->
