### PR TITLE
fix(UI): Message edit context menu now changes colour to hover/selection

### DIFF
--- a/res.qrc
+++ b/res.qrc
@@ -99,7 +99,6 @@
         <file>themes/dark/fileTransferInstance/yes.svg</file>
         <file>themes/dark/fileTransferWidget/fileDone.svg</file>
         <file>themes/dark/friendList/friendList.qss</file>
-        <file>themes/dark/genericChatForm/genericChatForm.qss</file>
         <file>themes/dark/genericChatRoomWidget/genericChatRoomWidget.qss</file>
         <file>themes/dark/loginScreen/loginScreen.qss</file>
         <file>themes/dark/msgEdit/msgEdit.qss</file>
@@ -168,7 +167,6 @@
         <file>themes/default/fileTransferInstance/yes.svg</file>
         <file>themes/default/fileTransferWidget/fileDone.svg</file>
         <file>themes/default/friendList/friendList.qss</file>
-        <file>themes/default/genericChatForm/genericChatForm.qss</file>
         <file>themes/default/genericChatRoomWidget/genericChatRoomWidget.qss</file>
         <file>themes/default/loginScreen/loginScreen.qss</file>
         <file>themes/default/msgEdit/msgEdit.qss</file>

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -5,7 +5,6 @@
 
 #include "genericchatform.h"
 
-#include "src/chatlog/chatlinecontentproxy.h"
 #include "src/chatlog/chatwidget.h"
 #include "src/chatlog/content/filetransferwidget.h"
 #include "src/chatlog/content/timestamp.h"
@@ -18,12 +17,10 @@
 #include "src/persistence/smileypack.h"
 #include "src/widget/chatformheader.h"
 #include "src/widget/contentdialog.h"
-#include "src/widget/contentdialogmanager.h"
 #include "src/widget/contentlayout.h"
 #include "src/widget/emoticonswidget.h"
 #include "src/widget/form/chatform.h"
 #include "src/widget/form/loadhistorydialog.h"
-#include "src/widget/maskablepixmapwidget.h"
 #include "src/widget/searchform.h"
 #include "src/widget/style.h"
 #include "src/widget/tool/chattextedit.h"
@@ -367,7 +364,6 @@ QDateTime GenericChatForm::getLatestTime() const
 
 void GenericChatForm::reloadTheme()
 {
-    setStyleSheet(style.getStylesheet("genericChatForm/genericChatForm.qss", settings));
     msgEdit->setStyleSheet(style.getStylesheet("msgEdit/msgEdit.qss", settings)
                            + fontToCss(settings.getChatMessageFont(), "QTextEdit"));
 

--- a/themes/dark/genericChatForm/genericChatForm.qss
+++ b/themes/dark/genericChatForm/genericChatForm.qss
@@ -1,4 +1,0 @@
-QWidget
-{
-    background: @groundBase;
-}

--- a/themes/default/genericChatForm/genericChatForm.qss
+++ b/themes/default/genericChatForm/genericChatForm.qss
@@ -1,4 +1,0 @@
-QWidget
-{
-    background: white;
-}


### PR DESCRIPTION
We don't need the background stylesheet anymore, because we use Qt style hints. Also, testing without those style hints it still works fine, so there seems to be some redundancy in setting backgrounds for widgets.

Fixes #387.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/388)
<!-- Reviewable:end -->
