### PR TITLE
feat(Pictures): Add QOI image format support.

### DIFF
--- a/.ci-scripts/build-local-deps.sh
+++ b/.ci-scripts/build-local-deps.sh
@@ -22,4 +22,5 @@ install_deps \
   hunspell \
   extra_cmake_modules \
   sonnet \
+  kimageformats \
   toxcore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,20 +679,6 @@ set_target_properties(
              QT_ANDROID_PACKAGE_SOURCE_DIR
              "${CMAKE_CURRENT_SOURCE_DIR}/android/${Qt6Core_VERSION}")
 
-if(QT_FEATURE_static)
-  if(APPLE)
-    target_link_libraries(${PROJECT_NAME}
-                          PRIVATE Qt6::QOffscreenIntegrationPlugin)
-  else()
-    target_link_directories(${PROJECT_NAME} PRIVATE
-                            "/sysroot/opt/qt/plugins/platforms")
-    target_link_libraries(
-      ${PROJECT_NAME}
-      PRIVATE Qt6::QLinuxFbIntegrationPlugin Qt6::QOffscreenIntegrationPlugin
-              Qt6::QVncIntegrationPlugin Qt6::QXcbIntegrationPlugin
-              Qt6::QWaylandIntegrationPlugin)
-  endif()
-endif()
 if(FULLY_STATIC)
   target_link_options(${PROJECT_NAME} PRIVATE -static-pie)
 endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -193,9 +193,27 @@ if(APPLE)
 endif()
 
 if(WIN32)
-  set(ALL_LIBRARIES ${ALL_LIBRARIES} strmiids)
+  add_dependency(strmiids)
   # Qt doesn't provide openssl on windows
   search_dependency(OPENSSL           PACKAGE openssl)
+endif()
+
+if(QT_FEATURE_static)
+  add_dependency(Qt6::QOffscreenIntegrationPlugin)
+  if(LINUX)
+    add_dependency(
+      Qt6::QLinuxFbIntegrationPlugin
+      Qt6::QVncIntegrationPlugin
+      Qt6::QXcbIntegrationPlugin
+      Qt6::QWaylandIntegrationPlugin)
+  endif()
+  find_library(KIMG_QOI_LIBRARY kimg_qoi
+               PATHS "${QT6_INSTALL_PREFIX}/plugins/imageformats")
+  if(KIMG_QOI_LIBRARY)
+    message(STATUS "Found QOI imageformats plugin: ${KIMG_QOI_LIBRARY}")
+    add_dependency(${KIMG_QOI_LIBRARY})
+    set_property(SOURCE src/main.cpp APPEND PROPERTY COMPILE_DEFINITIONS QTOX_USE_KIMG_QOI)
+  endif()
 endif()
 
 if (NOT GIT_VERSION)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,9 @@ int main(int argc, char* argv[])
 }
 
 #ifdef QT_STATIC
+// All platforms support offscreen rendering for testing.
 Q_IMPORT_PLUGIN(QOffscreenIntegrationPlugin)
+
 #if defined(Q_OS_LINUX)
 Q_IMPORT_PLUGIN(QLinuxFbIntegrationPlugin)
 Q_IMPORT_PLUGIN(QVncIntegrationPlugin)
@@ -32,5 +34,9 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
 #else
 #error "No static linking supported for platform"
+#endif
+
+#ifdef QTOX_USE_KIMG_QOI
+Q_IMPORT_PLUGIN(QOIPlugin)
 #endif
 #endif // QT_STATIC

--- a/src/widget/imagepreviewwidget.cpp
+++ b/src/widget/imagepreviewwidget.cpp
@@ -16,10 +16,17 @@
 namespace {
 QPixmap pixmapFromFile(const QString& filename)
 {
-    static const QStringList previewExtensions = {"png", "jpeg", "jpg", "gif", "svg",
-                                                  "PNG", "JPEG", "JPG", "GIF", "SVG"};
+    static const QStringList previewExtensions = {
+        "gif",  // Graphics Interchange Format
+        "jpeg", // Joint Photographic Experts Group
+        "jpg",  // Joint Photographic Experts Group
+        "png",  // Portable Network Graphics
+        "qoi",  // Quite OK Image Format
+        "svg",  // Scalable Vector Graphics
+        "webp", // WebP
+    };
 
-    if (!previewExtensions.contains(QFileInfo(filename).suffix())) {
+    if (!previewExtensions.contains(QFileInfo(filename).suffix().toLower())) {
         return QPixmap();
     }
 


### PR DESCRIPTION
This needs kimageformats, which we'll be adding to the CI build over the next 1-2 PRs. For now, it'll work on macOS (once we rebuild the deps). Also for now it'll only work on our static builds. We can look into discovering the kimg dependencies in the system later on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/393)
<!-- Reviewable:end -->
