### PR TITLE
fix(Security): Fix heap buffer overflow in receiving pictures.

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -184,6 +184,20 @@ cc_library(
 )
 
 cc_library(
+    name = "exiftransform",
+    srcs = ["model/exiftransform.cpp"],
+    hdrs = ["model/exiftransform.h"],
+    copts = COPTS,
+    tags = ["qt"],
+    visibility = ["//qtox:__subpackages__"],
+    deps = [
+        "@libexif",
+        "@qt//:qt_core",
+        "@qt//:qt_gui",
+    ],
+)
+
+cc_library(
     name = "src",
     srcs = [":version"] + [
         ":src_moc",
@@ -191,13 +205,17 @@ cc_library(
     ] + glob(
         ["**/*.cpp"],
         exclude = [
+            "model/exiftransform.cpp",
             "persistence/serialize.cpp",
             "main.cpp",
         ],
     ),
     hdrs = glob(
         ["**/*.h"],
-        exclude = ["persistence/serialize.h"],
+        exclude = [
+            "model/exiftransform.h",
+            "persistence/serialize.h",
+        ],
     ),
     copts = COPTS,
     defines = DEFINES,
@@ -211,13 +229,13 @@ cc_library(
     tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
+        ":exiftransform",
         ":serialize",
         "//c-toxcore",
         "//qtox:res_lib",
         "//qtox/audio",
         "//qtox/util",
         "@ffmpeg",
-        "@libexif",
         "@libqrencode",
         "@libsodium",
         "@libvpx",

--- a/src/model/exiftransform.cpp
+++ b/src/model/exiftransform.cpp
@@ -29,6 +29,11 @@ Orientation getOrientation(QByteArray imageData)
         return Orientation::TopLeft;
     }
 
+    if (exifEntry->size < 2) {
+        exif_data_free(exifData);
+        return Orientation::TopLeft;
+    }
+
     const int orientation = exif_get_short(exifEntry->data, byteOrder);
     exif_data_free(exifData);
 
@@ -50,7 +55,7 @@ Orientation getOrientation(QByteArray imageData)
     case 8:
         return Orientation::LeftBottom;
     default:
-        qWarning() << "Invalid exif orientation";
+        qWarning() << "Invalid exif orientation" << orientation;
         return Orientation::TopLeft;
     }
 }

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -84,6 +84,7 @@ cc_library(
 ) for src in glob(
     ["**/*_test.cpp"],
     exclude = [
+        "model/exiftransform_test.cpp",
         "persistence/dbschema_test.cpp",
         "**/*_fuzz_test.cpp",
     ],
@@ -97,4 +98,23 @@ cc_fuzz_test(
     copts = COPTS,
     tags = ["qt"],
     deps = ["//qtox/src:serialize"],
+)
+
+qt_test(
+    name = "exiftransform_test",
+    size = "small",
+    src = "model/exiftransform_test.cpp",
+    copts = COPTS,
+    mocopts = ["-Iqtox"],
+    deps = ["//qtox/src:exiftransform"],
+)
+
+cc_fuzz_test(
+    name = "exiftransform_fuzz_test",
+    size = "small",
+    testonly = True,
+    srcs = ["model/exiftransform_fuzz_test.cpp"],
+    copts = COPTS,
+    tags = ["qt"],
+    deps = ["//qtox/src:exiftransform"],
 )

--- a/test/model/exiftransform_fuzz_test.cpp
+++ b/test/model/exiftransform_fuzz_test.cpp
@@ -1,0 +1,28 @@
+#include "src/model/exiftransform.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+void test_getOrientation(const uint8_t* data, size_t size)
+{
+    ExifTransform::Orientation orientation =
+        ExifTransform::getOrientation(QByteArray(reinterpret_cast<const char*>(data), size));
+    assert(orientation >= ExifTransform::Orientation::TopLeft
+           && orientation <= ExifTransform::Orientation::LeftBottom);
+}
+
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    qInstallMessageHandler([](QtMsgType, const QMessageLogContext&, const QString&) {
+        // Ignore messages
+    });
+
+    test_getOrientation(data, size);
+    return 0;
+}

--- a/test/model/exiftransform_test.cpp
+++ b/test/model/exiftransform_test.cpp
@@ -69,6 +69,7 @@ private slots:
     void testRightTop();
     void testRightBottom();
     void testLeftBottom();
+    void testInputTooShort();
 
 private:
     QImage inputImage;
@@ -145,6 +146,18 @@ void TestExifTransform::testLeftBottom()
         ExifTransform::applyTransformation(inputImage, ExifTransform::Orientation::LeftBottom);
     QVERIFY(getColor(image, Side::left) == rowColor);
     QVERIFY(getColor(image, Side::bottom) == colColor);
+}
+
+void TestExifTransform::testInputTooShort()
+{
+    const QByteArray garbage = QByteArray::fromBase64(
+        "AEV4aWYAAE1NACoAAAAA0v///7p6h2kAaWYAAAAAAABNeGlmAABRMAAjGEQAAAAAAAAAQAAAAAAA"
+        "/////////////////wEBASMBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBARIAAQAAAAEB"
+        "AAABAAEBAQEjAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAAEBAADCwsLCwsLCwsLCwsLCwsLCwsLC"
+        "wsLCAQEBAQEBAQEBAQEBAQAAAQEAAAABAAEBAQEjAQEBAAAAAAAAAAD/////////////////BgD/"
+        "/////wAAAQABAQEBIwEBAQEjAQEB/////wEBAQEBAQEBAQEBAQEBAQEB");
+
+    ExifTransform::getOrientation(garbage.mid(1));
 }
 
 QTEST_APPLESS_MAIN(TestExifTransform)


### PR DESCRIPTION
Exif data handling had a heap buffer overflow. Not likely possible to abuse, but still not good.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/415)
<!-- Reviewable:end -->
