### PR TITLE
feat(Settings): Add an option to disable image previews.

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -7,7 +7,6 @@
 #include "ui_filetransferwidget.h"
 
 #include "src/core/corefile.h"
-#include "src/model/exiftransform.h"
 #include "src/persistence/settings.h"
 #include "src/widget/style.h"
 #include "src/widget/tool/imessageboxmanager.h"
@@ -22,6 +21,7 @@
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QVariantAnimation>
 
 #include <cassert>
@@ -86,6 +86,12 @@ FileTransferWidget::FileTransferWidget(QWidget* parent, CoreFile& _coreFile, Tox
     // Set lastStatus to anything but the file's current value, this forces an update
     lastStatus = file.status == ToxFile::FINISHED ? ToxFile::INITIALIZING : ToxFile::FINISHED;
     updateWidget(file);
+
+    connect(&settings, &Settings::imagePreviewChanged, this, [this](bool) {
+        if (fileInfo.status == ToxFile::FINISHED) {
+            showPreview(fileInfo.filePath);
+        }
+    });
 
     setFixedHeight(64);
 }
@@ -478,8 +484,12 @@ void FileTransferWidget::handleButton(QPushButton* btn)
 
 void FileTransferWidget::showPreview(const QString& filename)
 {
-    ui->previewButton->setIconFromFile(filename);
-    ui->previewButton->show();
+    if (settings.getImagePreview()) {
+        ui->previewButton->setIconFromFile(filename);
+        ui->previewButton->show();
+    } else {
+        ui->previewButton->hide();
+    }
 }
 
 void FileTransferWidget::onLeftButtonClicked()

--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -8,7 +8,6 @@
 #include <QTime>
 #include <QWidget>
 
-#include "src/chatlog/chatlinecontent.h"
 #include "src/core/toxfile.h"
 
 class CoreFile;

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -191,6 +191,7 @@ void Settings::loadGlobal()
         separateWindow = s.value("separateWindow", false).toBool();
         dontGroupWindows = s.value("dontGroupWindows", false).toBool();
         showIdenticons = s.value("showIdenticons", true).toBool();
+        imagePreview = s.value("imagePreview", true).toBool();
 
         const QString DEFAULT_SMILEYS = ":/smileys/EmojiOne/emoticons.xml";
         smileyPack = s.value("smileyPack", DEFAULT_SMILEYS).toString();
@@ -660,6 +661,7 @@ void Settings::saveGlobal()
         s.setValue("dontGroupWindows", dontGroupWindows);
         s.setValue("conferencePosition", conferencePosition);
         s.setValue("showIdenticons", showIdenticons);
+        s.setValue("imagePreview", imagePreview);
 
         s.setValue("smileyPack", smileyPack);
         s.setValue("emojiFontPointSize", emojiFontPointSize);
@@ -2014,6 +2016,19 @@ void Settings::setShowIdenticons(bool value)
 {
     if (setVal(showIdenticons, value)) {
         emit showIdenticonsChanged(value);
+    }
+}
+
+bool Settings::getImagePreview() const
+{
+    QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    return imagePreview;
+}
+
+void Settings::setImagePreview(bool newValue)
+{
+    if (setVal(imagePreview, newValue)) {
+        emit imagePreviewChanged(newValue);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -10,7 +10,6 @@
 #include "src/core/icoresettings.h"
 #include "src/core/idebugsettings.h"
 #include "src/core/toxencrypt.h"
-#include "src/core/toxfile.h"
 #include "src/persistence/iconferencesettings.h"
 #include "src/persistence/ifriendsettings.h"
 #include "src/persistence/inotificationsettings.h"
@@ -206,6 +205,7 @@ signals:
     void compactLayoutChanged(bool enabled);
     void sortingModeChanged(FriendListSortingMode mode);
     void showIdenticonsChanged(bool enabled);
+    void imagePreviewChanged(bool enabled);
 
     // ChatView
     void useEmoticonsChanged(bool enabled);
@@ -523,6 +523,9 @@ public:
     bool getShowIdenticons() const;
     void setShowIdenticons(bool value);
 
+    bool getImagePreview() const;
+    void setImagePreview(bool newValue);
+
     bool getAutoLogin() const;
     void setEnableConferencesColor(bool state);
     bool getEnableConferencesColor() const;
@@ -600,6 +603,7 @@ private:
     bool desktopNotify;
     bool notifySystemBackend;
     bool showWindow;
+    bool imagePreview;
     bool notifySound;
     bool notifyHide;
     bool busySound;

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -16,8 +16,6 @@
 #include <QTime>
 #include <QVector>
 
-#include "src/core/core.h"
-#include "src/core/coreav.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/persistence/smileypack.h"
@@ -77,6 +75,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
     bodyUI->notifySystemBackend->setEnabled(settings.getNotify() && settings.getDesktopNotify());
 
     bodyUI->showWindow->setChecked(settings.getShowWindow());
+    bodyUI->cbImagePreview->setChecked(settings.getImagePreview());
 
     bodyUI->cbConferencePosition->setChecked(settings.getConferencePosition());
     bodyUI->cbCompactLayout->setChecked(settings.getCompactLayout());
@@ -296,6 +295,11 @@ void UserInterfaceForm::on_busySound_stateChanged()
 void UserInterfaceForm::on_showWindow_stateChanged()
 {
     settings.setShowWindow(bodyUI->showWindow->isChecked());
+}
+
+void UserInterfaceForm::on_cbImagePreview_stateChanged()
+{
+    settings.setImagePreview(bodyUI->cbImagePreview->isChecked());
 }
 
 void UserInterfaceForm::on_conferenceOnlyNotifyWhenMentioned_stateChanged()

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -44,6 +44,7 @@ private slots:
     void on_notifyHide_stateChanged(int value);
     void on_busySound_stateChanged();
     void on_showWindow_stateChanged();
+    void on_cbImagePreview_stateChanged();
     void on_conferenceOnlyNotifyWhenMentioned_stateChanged();
     void on_cbCompactLayout_stateChanged();
     void on_cbSeparateWindow_stateChanged();

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -40,7 +40,7 @@
         <x>0</x>
         <y>0</y>
         <width>664</width>
-        <height>902</height>
+        <height>1079</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0,0">
@@ -274,6 +274,16 @@ Hide formatting characters:
             </property>
             <property name="text">
              <string>Open window</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbImagePreview">
+            <property name="toolTip">
+             <string comment="tooltip for Image preview setting">Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</string>
+            </property>
+            <property name="text">
+             <string>Image preview</string>
             </property>
            </widget>
           </item>

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -3199,6 +3199,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">استخدم الواجهة الخلفية للإشعارات الخاصة بالنظام إذا كانت متوفرة</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">عرض معاينات للصور المرسلة والمستلمة في الدردشات. قم بالتمرير فوق المعاينة المضمنة لعرض معاينة أكبر.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">معاينة الصورة</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -3114,6 +3114,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Выкарыстоўвайце бэкэнд апавяшчэнняў для канкрэтнай сістэмы, калі ён даступны</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Паказаць папярэдні прагляд адпраўленых і атрыманых малюнкаў у чатах. Навядзіце курсор мышы на ўбудаваны папярэдні прагляд, каб паказаць большы папярэдні прагляд.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Папярэдні прагляд выявы</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -3577,6 +3577,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⵏⵜⴻⵍ ⵏ ⵢⵉⵏⵉ ⵏ UI. ⵙⴻⵇⴷⴻⵛ ⴰⵢⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⵔⴻⵏⴹ ⴰⴹⵔⵉⵙ ⵏ ⵜⵍⴻⵎⵎⴰⵙⵜ.</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵙⴽⴻⵏⴷ ⵜⵉⵡⵡⵓⵔⴰ ⵏ ⵜⵓⴳⵏⵉⵡⵉⵏ ⵢⴻⵜⵜⵡⴰⵣⴻⵏ ⴷ ⵜⵉⴷ ⵢⴻⵜⵜⵡⴰⵇⴱⴰⵍ ⴷⴻⴳ ⵜⵎⴻⵙⵍⴰⵢⵉⵏ. ⵃⴰⴷⴻⵔ ⴰⴼⵓⵙⵉⴽ ⵖⴻⴼ ⵜⵎⵓⵖⵍⵉ ⵏ ⵓⵙⵎⴻⵍ ⴰⴽⴽⴻⵏ ⴰⴷ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵜⴰⵎⵓⵖⵍⵉ ⵜⴰⵎⴻⵇⵔⴰⵏⵜ.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵜⵓⴳⵏⴰ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -3009,6 +3009,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Използвайте специфичен за системата бекенд за уведомяване, ако има такъв</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Показване на визуализации за изпратени и получени изображения в чатове. Задръжте курсора на мишката върху вградения преглед, за да покажете по-голям преглед.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Визуализация на изображението</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -3639,6 +3639,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">উপলব্ধ থাকলে সিস্টেম-নির্দিষ্ট বিজ্ঞপ্তি ব্যাকএন্ড ব্যবহার করুন</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">চ্যাটে পাঠানো এবং প্রাপ্ত ছবিগুলির পূর্বরূপ দেখান। একটি বৃহত্তর প্রিভিউ প্রদর্শন করতে ইনলাইন প্রিভিউয়ের উপর হোভার করুন।</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ছবির পূর্বরূপ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -3034,6 +3034,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pokud je k dispozici, použijte systém upozornění</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zobrazovat náhledy odeslaných a přijatých obrázků v chatech. Umístěním ukazatele myši na vložený náhled zobrazíte větší náhled.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Náhled obrázku</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -3441,6 +3441,17 @@ Skjul formateringstegn:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Brug systemspecifik notifikations-backend, hvis tilgængelig</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vis forhåndsvisninger af sendte og modtagne billeder i chats. Hold markøren over den indbyggede forhåndsvisning for at få vist en større forhåndsvisning.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Billedforhåndsvisning</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -3008,6 +3008,17 @@ Formatierungszeichen ausblenden:
         <source>Use system-specific notification backend if available</source>
         <translation>Systemspezifisches Benachrichtigungs-Backend verwenden, falls verfügbar</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vorschauen für gesendete und empfangene Bilder in Chats anzeigen. Bewegen Sie den Mauszeiger über die Inline-Vorschau, um eine größere Vorschau anzuzeigen.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Bildvorschau</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -3143,6 +3143,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Χρησιμοποιήστε το backend ειδοποιήσεων για το συγκεκριμένο σύστημα, εάν είναι διαθέσιμο</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Εμφάνιση προεπισκοπήσεων για απεσταλμένες και ληφθείσες εικόνες σε συνομιλίες. Τοποθετήστε το δείκτη του ποντικιού πάνω από την ενσωματωμένη προεπισκόπηση για να εμφανιστεί μια μεγαλύτερη προεπισκόπηση.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Προεπισκόπηση εικόνας</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -3443,6 +3443,17 @@ Kaŝi formatajn signojn:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Uzu sistemo-specifan sciigan backend se disponebla</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Montru antaŭrigardojn por senditaj kaj ricevitaj bildoj en babilejoj. Ŝvebu super la enlinia antaŭrigardo por montri pli grandan antaŭrigardon.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Bilda Antaŭrigardo</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -2998,6 +2998,17 @@ Hide formatting characters:
         <source>Use system-specific notification backend if available</source>
         <translation>Utilizar el backend de notificación específico del sistema si está disponible</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Muestra vistas previas de imágenes enviadas y recibidas en los chats. Pase el cursor sobre la vista previa en línea para mostrar una vista previa más grande.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vista previa de imagen</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -3031,6 +3031,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Kasutage süsteemipõhist teavituste taustaprogrammi, kui see on saadaval</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Saate vestlustes kuvada saadetud ja vastuvõetud piltide eelvaateid. Suurema eelvaate kuvamiseks hõljutage kursorit tekstisisese eelvaate kohal.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pildi eelvaade</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -3100,6 +3100,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">در صورت موجود بودن از اعلانات خاص سیستم استفاده کنید</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">نمایش پیش نمایش برای تصاویر ارسالی و دریافتی در چت. ماوس را روی پیش‌نمایش درون خطی نگه دارید تا پیش‌نمایش بزرگ‌تری نمایش داده شود.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">پیش نمایش تصویر</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -3029,6 +3029,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Käytä järjestelmäkohtaista ilmoitustaustaa, jos sellainen on saatavilla</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Näytä lähetettyjen ja vastaanotettujen kuvien esikatselu chateissa. Vie hiiri upotetun esikatselun päälle nähdäksesi suuremman esikatselun.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kuvan esikatselu</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -3008,6 +3008,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Utiliser le backend de notification spécifique au système si disponible</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Afficher des aperçus des images envoyées et reçues dans les discussions. Passez la souris sur l&apos;aperçu en ligne pour afficher un aperçu plus grand.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Aperçu de l&apos;image</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -3102,6 +3102,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Use o backend de notificación específico do sistema se está dispoñible</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostrar vista previa das imaxes enviadas e recibidas nos chats. Pasa o rato sobre a vista previa en liña para mostrar unha vista previa máis grande.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vista previa da imaxe</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -3621,6 +3621,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">השתמש בקצה האחורי של התראות ספציפי למערכת אם זמין</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">הצג תצוגה מקדימה של תמונות שנשלחו והתקבלו בצ&apos;אטים. רחף מעל התצוגה המקדימה המוטבעת כדי להציג תצוגה מקדימה גדולה יותר.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">תצוגה מקדימה של תמונה</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -3098,6 +3098,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Koristite pozadinu obavijesti specifičnu za sustav ako je dostupna</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Prikaži preglede za poslane i primljene slike u razgovorima. Zadržite pokazivač iznad umetnutog pregleda za prikaz većeg pregleda.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pregled slike</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -3092,6 +3092,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Használjon rendszerspecifikus értesítési háttérprogramot, ha elérhető</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Az elküldött és fogadott képek előnézetének megjelenítése a csevegésben. Nagyobb előnézet megjelenítéséhez vigye az egérmutatót a soros előnézet fölé.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kép előnézete</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -3611,6 +3611,17 @@ Fela sniðstafi:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Notaðu kerfissértæka bakenda tilkynninga ef það er til staðar</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sýna forskoðun fyrir sendar og mótteknar myndir í spjalli. Farðu yfir innbyggðu forskoðunina til að sýna stærri forskoðun.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Forskoðun mynd</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -3008,6 +3008,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Utilizza il backend di notifica specifico del sistema, se disponibile</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostra le anteprime delle immagini inviate e ricevute nelle chat. Passa il mouse sopra l&apos;anteprima in linea per visualizzare un&apos;anteprima più grande.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Anteprima dell&apos;immagine</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -3147,6 +3147,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">利用可能な場合はシステム固有の通知バックエンドを使用する</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">チャットで送受信した画像のプレビューを表示します。インライン プレビューの上にマウスを移動すると、大きなプレビューが表示されます。</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">画像プレビュー</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -3593,6 +3593,17 @@ e.g. &quot;**text**&quot; will show as &quot;text&quot;, bold.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">samtci skari temci .i ko pilno ti tezu&apos;e lo nu cuxna lo manku tcini</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">.i ko viska lo se viska be lo se benji gi&apos;e cpacu lo pixra ne&apos;i lo nu casnu ko virnu lo nenri viska tezu&apos;e lo nu jarco lo barda se viska</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">pixra vitke</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -3626,6 +3626,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಲಭ್ಯವಿದ್ದರೆ ಸಿಸ್ಟಂ-ನಿರ್ದಿಷ್ಟ ಅಧಿಸೂಚನೆ ಬ್ಯಾಕೆಂಡ್ ಬಳಸಿ</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಚಾಟ್‌ಗಳಲ್ಲಿ ಕಳುಹಿಸಿದ ಮತ್ತು ಸ್ವೀಕರಿಸಿದ ಚಿತ್ರಗಳಿಗಾಗಿ ಪೂರ್ವವೀಕ್ಷಣೆಗಳನ್ನು ತೋರಿಸಿ. ದೊಡ್ಡ ಪೂರ್ವವೀಕ್ಷಣೆಯನ್ನು ಪ್ರದರ್ಶಿಸಲು ಇನ್‌ಲೈನ್ ಪೂರ್ವವೀಕ್ಷಣೆಯ ಮೇಲೆ ಸುಳಿದಾಡಿ.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಚಿತ್ರ ಪೂರ್ವವೀಕ್ಷಣೆ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -3460,6 +3460,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">가능한 경우 시스템별 알림 백엔드 사용</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">채팅에서 보내고 받은 이미지의 미리보기를 표시합니다. 인라인 미리보기 위로 마우스를 가져가면 더 큰 미리보기가 표시됩니다.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">이미지 미리보기</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -3650,6 +3650,17 @@ Opmaakteikens verberge:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Datumformaat:</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Veurbeelde toene veur verstuurde en ontvange aafbeeldinge in chats. Houw de muis euver de inline-veurbeeld um ‘n groetere veurbeeld weer te geve.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Aafbeeldingveurbeeld</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -3035,6 +3035,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Jei įmanoma, naudokite konkrečios sistemos pranešimų foną</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Rodyti išsiųstų ir gautų vaizdų peržiūras pokalbiuose. Užveskite pelės žymeklį virš tiesioginės peržiūros, kad būtų rodoma didesnė peržiūra.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vaizdo peržiūra</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -3115,6 +3115,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Izmantojiet sistēmai raksturīgu paziņojumu aizmugursistēmu, ja tāda ir pieejama</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Rādīt nosūtīto un saņemto attēlu priekšskatījumus tērzēšanas sarunās. Virziet kursoru virs iekļautā priekšskatījuma, lai parādītu lielāku priekšskatījumu.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Attēla priekšskatījums</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -3159,6 +3159,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Користете го резервниот дел за известувања специфичен за системот доколку е достапен</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Прикажи прегледи за испратени и примени слики во разговори. Лебдите над вградениот преглед за да се прикаже поголем преглед.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Преглед на слика</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -3013,6 +3013,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Bruk systemspesifikk varslingsstøtte hvis tilgjengelig</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vis forhåndsvisninger for sendte og mottatte bilder i chatter. Hold markøren over den innebygde forhåndsvisningen for å vise en større forhåndsvisning.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Forhåndsvisning av bilde</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -2999,6 +2999,17 @@ Opmaaktekens verbergen:
         <source>Use system-specific notification backend if available</source>
         <translation>Gebruik systeemspecifieke notificatie-backend indien beschikbaar</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Toon voorbeelden van verzonden en ontvangen afbeeldingen in chats. Beweeg over het inline voorbeeld om een ​​groter voorbeeld weer te geven.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Afbeeldingsvoorbeeld</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -2978,6 +2978,15 @@ Hide formatting characters:
         <source>Use system-specific notification backend if available</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -3043,6 +3043,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Jeśli jest dostępny, użyj systemu powiadomień specyficznego dla systemu</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pokaż podglądy wysłanych i odebranych obrazów na czatach. Najedź kursorem na podgląd wbudowany, aby wyświetlić większy podgląd.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Podgląd obrazu</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -3000,6 +3000,15 @@ Hide formatting characters:
         <source>UI color theme. Use this to select dark mode.</source>
         <translation type="unfinished">Colors o&apos; th&apos; helm. Use this ta choose dark mode.</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translation type="unfinished">Show a glimpse o&apos; sent &apos;n&apos; received images in chats. Hover over th&apos; inline preview ta display a larger &apos;un.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translation type="unfinished">Glimpse at th&apos; image</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -3029,6 +3029,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Use back-end de notificação específico do sistema, se disponível</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostre visualizações de imagens enviadas e recebidas em bate-papos. Passe o mouse sobre a visualização embutida para exibir uma visualização maior.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pré-visualização da imagem</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -3016,6 +3016,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Use back-end de notificação específico do sistema, se disponível</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostre visualizações de imagens enviadas e recebidas em bate-papos. Passe o mouse sobre a visualização embutida para exibir uma visualização maior.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pré-visualização da imagem</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -3011,6 +3011,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Utilizați backend-ul de notificare specific sistemului, dacă este disponibil</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Afișați previzualizări pentru imaginile trimise și primite în chat-uri. Treceți cursorul peste previzualizarea inline pentru a afișa o previzualizare mai mare.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Previzualizare imagine</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -3006,6 +3006,17 @@ Hide formatting characters:
         <source>Use system-specific notification backend if available</source>
         <translation>Использовать определенный системой бэкэнд уведомлений, если он доступен</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Показывать предварительный просмотр отправленных и полученных изображений в чатах. Наведите указатель мыши на встроенный предварительный просмотр, чтобы отобразить предварительный просмотр большего размера.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Предварительный просмотр изображения</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -3642,6 +3642,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">තිබේ නම් පද්ධති-විශේෂිත දැනුම්දීම් පසුබිම භාවිතා කරන්න</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">කතාබස් තුළ යැවූ සහ ලැබුණු පින්තූර සඳහා පෙරදසුන් පෙන්වන්න. විශාල පෙරදසුනක් පෙන්වීමට පේළිගත පෙරදසුන මත සැරිසරන්න.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">රූප පෙරදසුන</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -3022,6 +3022,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ak je to možné, použite systém upozornení</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zobrazovať ukážky odoslaných a prijatých obrázkov v rozhovoroch. Ak chcete zobraziť väčší náhľad, umiestnite kurzor myši na vložený náhľad.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ukážka obrázka</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -3282,6 +3282,17 @@ Skrij znake za oblikovanje:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Če je na voljo, uporabite zaledni sistem za obvestila</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Prikaži predogled poslanih in prejetih slik v klepetih. Premaknite miškin kazalec nad vgrajeni predogled, da prikažete večji predogled.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Predogled slike</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -3637,6 +3637,17 @@ Fshih karakteret e formatimit:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Përdorni bazën e njoftimeve specifike për sistemin nëse është e disponueshme</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Shfaq pamjet paraprake për imazhet e dërguara dhe të marra në biseda. Zhvendoseni mbi pamjen paraprake në linjë për të shfaqur një pamje paraprake më të madhe.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pamja paraprake e imazhit</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -3106,6 +3106,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Користите позадину за обавештења специфична за систем ако је доступна</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Прикажи прегледе за послате и примљене слике у ћаскањима. Пређите курсором преко уграђеног прегледа да бисте приказали већи преглед.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Преглед слике</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -2983,6 +2983,15 @@ Hide formatting characters:
         <source>Use system-specific notification backend if available</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -3042,6 +3042,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Använd systemspecifik aviseringsbackend om tillgängligt</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Visa förhandsvisningar av skickade och mottagna bilder i chattar. Håll muspekaren över den inbyggda förhandsgranskningen för att visa en större förhandsgranskning.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Bildförhandsgranskning</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -3644,6 +3644,17 @@ Ficha vibambo vya uumbizaji:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Tumia mandharinyuma ya arifa mahususi ya mfumo ikiwa inapatikana</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Onyesha muhtasari wa picha zilizotumwa na kupokewa kwenye gumzo. Elea juu ya onyesho la kuchungulia la ndani ili kuonyesha onyesho kubwa zaidi.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Onyesho la Kuchungulia Picha</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -3391,6 +3391,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">சிஸ்டம் சார்ந்த அறிவிப்பு பின்தளத்தில் இருந்தால் பயன்படுத்தவும்</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">அரட்டைகளில் அனுப்பப்பட்ட மற்றும் பெறப்பட்ட படங்களுக்கான மாதிரிக்காட்சிகளைக் காட்டு. பெரிய மாதிரிக்காட்சியைக் காட்ட, இன்லைன் மாதிரிக்காட்சியின் மேல் வட்டமிடுங்கள்.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">பட முன்னோட்டம்</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -3008,6 +3008,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Varsa sisteme özel bildirim arka ucunu kullanın</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sohbetlerde gönderilen ve alınan görsellerin önizlemelerini gösterin. Daha büyük bir önizleme görüntülemek için satır içi önizlemenin üzerine gelin.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Resim Önizleme</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -3155,6 +3155,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ئەگەر بار بولسا سىستېمىغا مۇناسىۋەتلىك ئۇقتۇرۇش ئارقا سۇپىسىنى ئىشلىتىڭ</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">پاراڭلاردا ئەۋەتىلگەن ۋە تاپشۇرۇۋالغان رەسىملەرنىڭ ئالدىن كۆزىتىشلىرىنى كۆرسىتىڭ. چوڭراق ئالدىن كۆرۈش ئۈچۈن ئىچكى كۆرۈنۈشنى بېسىپ ئۆتۈڭ.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">رەسىم ئالدىن كۆرۈش</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -3012,6 +3012,17 @@ Hide formatting characters:
         <source>UI color theme. Use this to select dark mode.</source>
         <translation>Колірна тема інтерфейсу. Використовуйте це для вибору темного режиму.</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Показувати попередній перегляд надісланих і отриманих зображень у чатах. Наведіть курсор на вбудований попередній перегляд, щоб відобразити попередній перегляд у більшому розмірі.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Попередній перегляд зображення</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -3618,6 +3618,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">اگر دستیاب ہو تو سسٹم کے لیے مخصوص نوٹیفکیشن بیک اینڈ استعمال کریں۔</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">چیٹس میں بھیجی گئی اور موصول ہونے والی تصاویر کے لیے پیش نظارہ دکھائیں۔ ایک بڑا پیش منظر دکھانے کے لیے ان لائن پیش نظارہ پر ہوور کریں۔</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">تصویری پیش نظارہ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -3014,6 +3014,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Sử dụng phụ trợ thông báo dành riêng cho hệ thống nếu có</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Hiển thị bản xem trước cho hình ảnh đã gửi và nhận trong cuộc trò chuyện. Di chuột qua bản xem trước nội tuyến để hiển thị bản xem trước lớn hơn.</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Xem trước hình ảnh</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2995,6 +2995,17 @@ Hide formatting characters:
         <source>Use system-specific notification backend if available</source>
         <translation>如果可用，使用系统特定的通知后端</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">显示聊天中发送和接收的图像的预览。将鼠标悬停在内联预览上可显示更大的预览。</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">图像预览</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -3506,6 +3506,17 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">使用系統特定的通知後端（如果可用）</translation>
     </message>
+    <message>
+        <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
+        <comment>tooltip for Image preview setting</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">顯示聊天中發送和接收的影像的預覽。將滑鼠懸停在內聯預覽上可顯示更大的預覽。</translation>
+    </message>
+    <message>
+        <source>Image preview</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">圖像預覽</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>


### PR DESCRIPTION
This is a security feature. In case there are problems with any of the image parsing in qTox or its dependent libraries, this enables users to disable the preview feature.

Future work: have this be a per-contact setting similar to auto-accepting files per-contact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/416)
<!-- Reviewable:end -->
