### PR TITLE
fix(tools): Use tag strings in release tarballs.

### DIFF
--- a/tools/create_tarballs.py
+++ b/tools/create_tarballs.py
@@ -46,7 +46,7 @@ def create_tarballs(tag: str, tmpdir: str) -> None:
                 "git",
                 "archive",
                 "--format=tar",
-                "--prefix=qTox-{tag}/",
+                f"--prefix=qTox-{tag}/",
                 tag,
                 f"--output={tarname}",
             ],


### PR DESCRIPTION
This fixes the root directory name in the release tarballs, which would have a literal '{tag}' instead of the actual tag string.

Closes: https://github.com/TokTok/qTox/issues/412

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/417)
<!-- Reviewable:end -->
