### PR TITLE
cleanup: Remove useless translation strings.

### DIFF
--- a/src/chatlog/content/filetransferwidget.ui
+++ b/src/chatlog/content/filetransferwidget.ui
@@ -156,7 +156,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Filename</string>
+             <string notr="true">Filename</string>
             </property>
            </widget>
           </item>
@@ -225,7 +225,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>10Mb</string>
+                <string notr="true">10Mb</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -241,7 +241,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>0kb/s</string>
+                <string notr="true">0kb/s</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignCenter</set>
@@ -257,7 +257,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>ETA:10:10</string>
+                <string notr="true">ETA:10:10</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -1029,22 +1029,6 @@ so you can save the file on Windows.</source>
         <translation>النوع</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>اسم الملف</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>انتظار للارسال...</translation>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -987,26 +987,6 @@ so you can save the file on Windows.</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10 МБ</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0 КБ/сек</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Разліковы час заканчэння: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Імя файла</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Чаканне адпраўкі...</translation>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -1117,26 +1117,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">ⴳⴻⵜⵯⴷ</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵎⴱ</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/ⵙ</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -955,22 +955,6 @@ so you can save the file on Windows.</source>
         <translation>Формуляр</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Име на файл</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Чакане за изпращане...</translation>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -1144,26 +1144,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">ফর্ম</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ফাইলের নাম</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -957,22 +957,6 @@ takže můžete soubor uložit i v systému Windows.</translation>
         <translation>Rámec</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Jméno souboru</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čekáme na odeslání...</translation>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -1048,26 +1048,6 @@ så du kan gemme filen på Windows.</translation>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Filnavn</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Venter på at sende...</translation>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -950,26 +950,6 @@ um sie in Windows speichern zu können.</translation>
         <translation>Eingabemaske</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Dateiname</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Dateitransfer läuft...</translation>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -990,22 +990,6 @@ so you can save the file on Windows.</source>
         <translation>Φόρμα</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mβ</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0κβ/δ</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ΕΧΜ:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Όνομα αρχείου</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Αναμονή για αποστολή...</translation>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -1070,22 +1070,6 @@ do vi povas konservi la dosieron en Vindozo.</translation>
         <translation type="unfinished">Formo</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Restanta tempo:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Dosiernomo</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Atendante por sendi...</translation>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -949,22 +949,6 @@ para que puedas guardar el archivo en windows.</translation>
         <translation>Plantilla</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Nombre de archivo</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Envío en espera...</translation>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -955,22 +955,6 @@ ja sa saad seda faili nüüd Windowsis salvestada.</translation>
         <translation>Aken</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>EPA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Faili nimi</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Ootan, et saata...</translation>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -981,26 +981,6 @@ so you can save the file on Windows.</source>
         <translation>فرم</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10مگابایت</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0کیلوبیت بر ثانیه</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>زمان انجام کار: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>اسم فایل</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>در انتظار ارسال...</translation>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -954,22 +954,6 @@ joten voit tallentaa tiedoston Windowsissa.</translation>
         <translation>Kenttä</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10 Mt</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0 kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Tiedostonimi</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Odotetaan lähettämistä...</translation>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -954,22 +954,6 @@ afin que vous puissiez enregistrer le fichier sur windows.</translation>
         <translation>Formulaire</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10 Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0 Kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Temps restant estimé : 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Nom du fichier</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>En attente d&apos;envoi...</translation>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -982,26 +982,6 @@ para que poida gardar o ficheiro en Windows.</translation>
         <translation>Formulario</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Tempo estimado:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Nome de ficheiro</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Quérese enviar...</translation>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -1128,26 +1128,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">טוֹפֶס</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">זמן הגעה: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">שם הקובץ</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -983,22 +983,6 @@ tako da možete spremiti datoteku na Windows.</translation>
         <translation>Obrazac</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10 Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0 kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Naziv datoteke</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čekanje na slanje …</translation>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -979,22 +979,6 @@ so you can save the file on Windows.</source>
         <translation>Űrlap</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10MB</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kB/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Hátralévő idő:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Fájlnév</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Várakozás elküldésre...</translation>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -1129,26 +1129,6 @@ svo þú getur vistað skrána á Windows.</translation>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Skráarnafn</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -954,22 +954,6 @@ in modo da poter salvare il file su Windows.</translation>
         <translation>Modulo</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Nome file</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>In attesa di inviare...</translation>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -995,22 +995,6 @@ Windows にファイルを保存できるようになります。</translation>
         <translation>フォーム</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>完了までの時間: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>ファイル名</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>送信を待機しています…</translation>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -1124,26 +1124,6 @@ e&apos;u do ka&apos;e sfaile lo nu sfaile bu&apos;u la .Windows.zoi ke&apos;a nu
         <translation type="unfinished">fi&apos;o samci&apos;e</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">10MB</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">0 kbit/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">loi sfailcmene</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -1140,26 +1140,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">ಫಾರ್ಮ್</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಫೈಲ್ ಹೆಸರು</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -1042,26 +1042,6 @@ so you can save the file on Windows.</source>
         <translation>폼</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>파일이름</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>전송 대기...</translation>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -1152,26 +1152,6 @@ zodet geer ut bestand op Windows kin opsjlaon.</translation>
         <translation type="unfinished">Formulier</translation>
     </message>
     <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Bestandsnaom</translation>
-    </message>
-    <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
         <source>Location not writable</source>
         <comment>Title of permissions popup</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -957,22 +957,6 @@ tad dabar galite įrašyti failą Windows sistemoje.</translation>
         <translation>Forma</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10 Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0 KB/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Liko: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Failo pavadinimas</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Laukiama gavėjo...</translation>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -967,26 +967,6 @@ lai varētu saglabāt failus Windows operētājsistēmā.</translation>
         <translation>Forma</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Atlicis: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Faila nosaukums</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Gaida nosūtīšanu ...</translation>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -997,26 +997,6 @@ so you can save the file on Windows.</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Име на датотека</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Чека да се прати...</translation>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -956,22 +956,6 @@ slik at du kan lagre filen på Windows.</translation>
         <translation>Skjema</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Filnavn</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Venter på å sende...</translation>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -948,22 +948,6 @@ zodat u het bestand op Windows kunt opslaan.</translation>
         <translation>Formulier</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Verwachte resterende downloadtijd:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Bestandsnaam</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Wachten om te versturen…</translation>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -943,26 +943,6 @@ so you can save the file on Windows.</source>
         <translation>Formulier</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Bestandsnaam</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Wachten voor te versturen…</translation>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -966,22 +966,6 @@ więc możesz zapisać ten plik na systemie Windows.</translation>
         <translation>Od</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Nazwa</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>better translation?</translatorcomment>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -948,26 +948,6 @@ so ye can stash th&apos; file on Windows.</translation>
         <translation type="unfinished">Shape</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">10 Meg</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">Nothin&apos; comin&apos; in</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">Time o&apos; Arrival: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Parcel tag</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Awaitin&apos; approval...</translation>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -954,22 +954,6 @@ de forma que possa guardar o ficheiro no Windows.</translation>
         <translation>Formulário</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Tempo estimado:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Nome do ficheiro</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>A esperar para enviar...</translation>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -956,26 +956,6 @@ de forma que você possa salvar o arquivo no Windows.</translation>
         <translation>Formulário</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>T:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Nome do arquivo</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Esperando para enviar...</translation>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -953,26 +953,6 @@ astfel încât să puteți salva fișierul pe Windows.</translation>
         <translation>Formă</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>rămas:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Nume fișier</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Așteptați trimiterea...</translation>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -953,22 +953,6 @@ so you can save the file on Windows.</source>
         <translation>От</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0 КБ/c</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Осталось:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Имя файла</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Ожидание отправки...</translation>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -1147,26 +1147,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">පෝරමය</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ගොනු නාමය</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -959,26 +959,6 @@ so you can save the file on Windows.</translation>
         <translation>Formulář</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Názov súboru</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čaká sa na odoslanie...</translation>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -1005,22 +1005,6 @@ tako da lahko datoteko shranite v sistem Windows.</translation>
         <translation>Nastavitve</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Čas:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Ime datoteke</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čakanje na pošiljanje...</translation>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -1142,26 +1142,6 @@ kështu që mund ta ruani skedarin në Windows.</translation>
         <translation type="unfinished">Forma</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10 Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0 kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA: 10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Emri i skedarit</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -985,26 +985,6 @@ so you can save the file on Windows.</source>
         <translation>Образац</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Име датотеке</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Чекам на слање...</translation>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -946,26 +946,6 @@ so you can save the file on Windows.</source>
         <translation>Obrazac</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Ime fajla</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čekam na slanje...</translation>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -955,22 +955,6 @@ så att du kan spara filen i Windows.</translation>
         <translation>Formulär</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Filnamn</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Väntar på att skicka...</translation>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -1149,26 +1149,6 @@ kwa hivyo unaweza kuhifadhi faili kwenye Windows.</translation>
         <translation type="unfinished">Fomu</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Jina la faili</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -1017,26 +1017,6 @@ so you can save the file on Windows.</source>
         <translation>படிவம்</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ETA 10 10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>கோப்புப்பெயர்</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>அனுப்பக் காத்திருப்பிலுள்ளது...</translation>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -954,22 +954,6 @@ geçersiz karakterler _ olarak değiştirildi.</translation>
         <translation>Form</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Dosya adı</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Göndermek için bekliyor...</translation>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -995,26 +995,6 @@ so you can save the file on Windows.</source>
         <translation>جەدۋەل</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ھۆججەت ئىسمى</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>يوللاشنى ساقلاۋاتىدۇ...</translation>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -951,22 +951,6 @@ so you can save the file on Windows.</source>
         <translation></translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Мб</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0кб/с</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>Лишилось:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>Назва файлу</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Очікування передачі...</translation>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -1123,26 +1123,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">فارم</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">10 ایم بی</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">فائل کا نام</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -953,26 +953,6 @@ so you can save the file on Windows.</source>
         <translation>Biểu mẫu</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Tên tệp</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Đang gửi...</translation>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -945,22 +945,6 @@ so you can save the file on Windows.</source>
         <translation>表单</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translation>文件名</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>正在等待发送...</translation>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -1072,26 +1072,6 @@ so you can save the file on Windows.</source>
         <translation>表單</translation>
     </message>
     <message>
-        <source>10Mb</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>10Mb</translation>
-    </message>
-    <message>
-        <source>0kb/s</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>0kb/s</translation>
-    </message>
-    <message>
-        <source>ETA:10:10</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>ETA:10:10</translation>
-    </message>
-    <message>
-        <source>Filename</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>檔案名稱</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>等待傳送…</translation>


### PR DESCRIPTION
These are always overwritten by the actual UI logic, so we don't need to translate them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/420)
<!-- Reviewable:end -->
