### PR TITLE
fix: cmake POSITION_INDEPENDENT_CODE global setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ set(AUTORCC_OPTIONS ${AUTORCC_OPTIONS} -format-version 1)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 
 # Hardening flags (ASLR, warnings, etc)
-set(POSITION_INDEPENDENT_CODE True)
+set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 if(NOT WIN32 AND NOT HAIKU)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")


### PR DESCRIPTION
`set(POSITION_INDEPENDENT_CODE True)` statement won't have any affect because CMake won't interpret it as a valid variable or property that controls PIC.

If we want to apply `-fPIC` flag to all targets we must use `CMAKE_POSITION_INDEPENDENT_CODE` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/423)
<!-- Reviewable:end -->
