### PR TITLE
cleanup: Fix some more clang-tidy warnings.

### DIFF
--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -71,7 +71,7 @@ QString generateContent(const QHash<const Friend*, size_t>& friendNotifications,
                         const QHash<const Conference*, size_t>& conferenceNotifications,
                         QString lastMessage, const ToxPk& sender)
 {
-    assert(friendNotifications.size() > 0 || conferenceNotifications.size() > 0);
+    assert(!friendNotifications.empty() || !conferenceNotifications.empty());
 
     auto numChats = getNumChats(friendNotifications, conferenceNotifications);
     if (numChats > 1) {

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -368,15 +368,14 @@ void Nexus::updateWindowsArg(QWindow* closedWindow)
     else
         activeWindow = nullptr;
 
-    for (int i = 0; i < windowList.size(); ++i) {
-        if (closedWindow == windowList[i])
+    for (auto* window : windowList) {
+        if (closedWindow == window)
             continue;
 
-        QAction* action = windowActions->addAction(windowList[i]->title());
+        QAction* action = windowActions->addAction(window->title());
         action->setCheckable(true);
-        action->setChecked(windowList[i] == activeWindow);
-        connect(action, &QAction::triggered, this,
-                [this, window = windowList[i]] { onOpenWindow(window); });
+        action->setChecked(window == activeWindow);
+        connect(action, &QAction::triggered, this, [this, window] { onOpenWindow(window); });
         windowMenu->addAction(action);
         dockMenu->insertAction(dockLast, action);
     }

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -119,26 +119,26 @@ QVector<VideoMode> avfoundation::getDeviceModes(const QString& devName)
     if (index >= [devices count]) {
         // It's a desktop capture.
         return result;
-    } else {
-        AVCaptureDevice* device = [devices objectAtIndex:index];
+    }
 
-        if (device == nil) {
-            qWarning() << "Device not found:" << devName;
-            return result;
-        }
+    AVCaptureDevice* device = [devices objectAtIndex:index];
 
-        for (AVCaptureDeviceFormat* format in [device formats]) {
-            CMFormatDescriptionRef formatDescription = static_cast<CMFormatDescriptionRef>(
-                [format performSelector:@selector(formatDescription)]);
-            CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription);
+    if (device == nil) {
+        qWarning() << "Device not found:" << devName;
+        return result;
+    }
 
-            for (AVFrameRateRange* range in format.videoSupportedFrameRateRanges) {
-                VideoMode mode;
-                mode.width = dimensions.width;
-                mode.height = dimensions.height;
-                mode.fps = range.maxFrameRate;
-                result.append(mode);
-            }
+    for (AVCaptureDeviceFormat* format in [device formats]) {
+        CMFormatDescriptionRef formatDescription = static_cast<CMFormatDescriptionRef>(
+            [format performSelector:@selector(formatDescription)]);
+        CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription);
+
+        for (AVFrameRateRange* range in format.videoSupportedFrameRateRanges) {
+            VideoMode mode;
+            mode.width = dimensions.width;
+            mode.height = dimensions.height;
+            mode.fps = range.maxFrameRate;
+            result.append(mode);
         }
     }
 

--- a/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
+++ b/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
@@ -108,6 +108,7 @@ struct DBusPortalImage
     QImage image;
 };
 
+Q_DECL_UNUSED
 QDBusArgument& operator<<(QDBusArgument& argument, const DBusPortalImage& image)
 {
     argument.beginStructure();
@@ -118,6 +119,7 @@ QDBusArgument& operator<<(QDBusArgument& argument, const DBusPortalImage& image)
     return argument;
 }
 
+Q_DECL_UNUSED
 const QDBusArgument& operator>>(const QDBusArgument& argument, DBusPortalImage& image)
 {
     QString type;
@@ -142,6 +144,7 @@ struct DBusNotifyImage
     QImage image;
 };
 
+Q_DECL_UNUSED
 QDBusArgument& operator<<(QDBusArgument& argument, const DBusNotifyImage& image)
 {
     const QImage rgba = image.image.convertToFormat(QImage::Format_RGBA8888);
@@ -157,6 +160,7 @@ QDBusArgument& operator<<(QDBusArgument& argument, const DBusNotifyImage& image)
     return argument;
 }
 
+Q_DECL_UNUSED
 const QDBusArgument& operator>>(const QDBusArgument& argument, DBusNotifyImage& image)
 {
     int width;

--- a/test/model/friendmessagedispatcher_test.cpp
+++ b/test/model/friendmessagedispatcher_test.cpp
@@ -12,6 +12,7 @@
 #include <QtTest/QtTest>
 
 #include <deque>
+#include <memory>
 #include <set>
 
 #include <tox/tox.h> // tox_max_message_length
@@ -112,15 +113,14 @@ TestFriendMessageDispatcher::TestFriendMessageDispatcher() = default;
  */
 void TestFriendMessageDispatcher::init()
 {
-    f = std::unique_ptr<Friend>(new Friend(0, ToxPk()));
+    f = std::make_unique<Friend>(0, ToxPk());
     f->setStatus(Status::Status::Online);
-    messageSender = std::unique_ptr<MockFriendMessageSender>(new MockFriendMessageSender());
-    sharedProcessorParams = std::unique_ptr<MessageProcessor::SharedParams>(
-        new MessageProcessor::SharedParams(tox_max_message_length()));
+    messageSender = std::make_unique<MockFriendMessageSender>();
+    sharedProcessorParams = std::make_unique<MessageProcessor::SharedParams>(tox_max_message_length());
 
-    messageProcessor = std::unique_ptr<MessageProcessor>(new MessageProcessor(*sharedProcessorParams));
-    friendMessageDispatcher = std::unique_ptr<FriendMessageDispatcher>(
-        new FriendMessageDispatcher(*f, *messageProcessor, *messageSender));
+    messageProcessor = std::make_unique<MessageProcessor>(*sharedProcessorParams);
+    friendMessageDispatcher =
+        std::make_unique<FriendMessageDispatcher>(*f, *messageProcessor, *messageSender);
 
     connect(friendMessageDispatcher.get(), &FriendMessageDispatcher::messageSent, this,
             &TestFriendMessageDispatcher::onMessageSent);

--- a/test/model/notificationgenerator_test.cpp
+++ b/test/model/notificationgenerator_test.cpp
@@ -11,6 +11,7 @@
 
 #include <QObject>
 #include <QtTest/QtTest>
+#include <memory>
 
 namespace {
 class MockNotificationSettings : public INotificationSettings
@@ -131,11 +132,11 @@ private:
 
 void TestNotificationGenerator::init()
 {
-    friendList.reset(new FriendList());
-    notificationSettings.reset(new MockNotificationSettings());
-    notificationGenerator.reset(new NotificationGenerator(*notificationSettings, nullptr));
-    conferenceQuery.reset(new MockConferenceQuery());
-    coreIdHandler.reset(new MockCoreIdHandler());
+    friendList = std::make_unique<FriendList>();
+    notificationSettings = std::make_unique<MockNotificationSettings>();
+    notificationGenerator = std::make_unique<NotificationGenerator>(*notificationSettings, nullptr);
+    conferenceQuery = std::make_unique<MockConferenceQuery>();
+    coreIdHandler = std::make_unique<MockCoreIdHandler>();
 }
 
 void TestNotificationGenerator::testSingleFriendMessage()

--- a/test/model/sessionchatlog_test.cpp
+++ b/test/model/sessionchatlog_test.cpp
@@ -8,6 +8,7 @@
 #include "src/model/sessionchatlog.h"
 
 #include <QtTest/QtTest>
+#include <memory>
 
 namespace {
 const QString TEST_USERNAME = "qTox Tester #1";
@@ -66,10 +67,9 @@ private:
  */
 void TestSessionChatLog::init()
 {
-    friendList = std::unique_ptr<FriendList>(new FriendList());
-    conferenceList = std::unique_ptr<ConferenceList>(new ConferenceList());
-    chatLog =
-        std::unique_ptr<SessionChatLog>(new SessionChatLog(idHandler, *friendList, *conferenceList));
+    friendList = std::make_unique<FriendList>();
+    conferenceList = std::make_unique<ConferenceList>();
+    chatLog = std::make_unique<SessionChatLog>(idHandler, *friendList, *conferenceList);
 }
 
 /**

--- a/test/persistence/dbupgrade/dbTo11_test.cpp
+++ b/test/persistence/dbupgrade/dbTo11_test.cpp
@@ -55,9 +55,9 @@ void appendAddPeersQueries(std::vector<RawDatabase::Query>& setupQueries)
 
 void appendVerifyChatsQueries(std::vector<RawDatabase::Query>& verifyQueries)
 {
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM chats"),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); }});
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM chats"),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); });
 
     struct Functor
     {
@@ -69,14 +69,14 @@ void appendVerifyChatsQueries(std::vector<RawDatabase::Query>& verifyQueries)
         }
     };
 
-    verifyQueries.emplace_back(RawDatabase::Query{QStringLiteral("SELECT uuid FROM chats"), Functor()});
+    verifyQueries.emplace_back(QStringLiteral("SELECT uuid FROM chats"), Functor());
 }
 
 void appendVerifyAuthorsQueries(std::vector<RawDatabase::Query>& verifyQueries)
 {
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM authors"),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); }});
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM authors"),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); });
 
     struct Functor
     {
@@ -89,8 +89,7 @@ void appendVerifyAuthorsQueries(std::vector<RawDatabase::Query>& verifyQueries)
         }
     };
 
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT public_key FROM authors"), Functor()});
+    verifyQueries.emplace_back(QStringLiteral("SELECT public_key FROM authors"), Functor());
 }
 
 void appendAddAliasesQueries(std::vector<RawDatabase::Query>& setupQueries)
@@ -115,9 +114,9 @@ void appendAddAliasesQueries(std::vector<RawDatabase::Query>& setupQueries)
 
 void appendVerifyAliasesQueries(std::vector<RawDatabase::Query>& verifyQueries)
 {
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM aliases"),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); }});
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM aliases"),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); });
 
     struct Functor
     {
@@ -128,36 +127,35 @@ void appendVerifyAliasesQueries(std::vector<RawDatabase::Query>& verifyQueries)
         }
     };
 
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT display_name FROM aliases"), Functor()});
+    verifyQueries.emplace_back(QStringLiteral("SELECT display_name FROM aliases"), Functor());
 }
 
 void appendAddAChatMessagesQueries(std::vector<RawDatabase::Query>& setupQueries)
 {
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (1, 'T', 0, '%1')")
-            .arg(aPeerId)});
+            .arg(aPeerId));
     setupQueries.emplace_back(
         RawDatabase::Query{QStringLiteral("INSERT INTO text_messages (id, message_type, "
                                           "sender_alias, message) VALUES (1, 'T', '%1', ?)")
                                .arg(aAliasId),
                            {QStringLiteral("Message 1 from A to Self").toUtf8()}});
 
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (2, 'T', 0, '%1')")
-            .arg(aPeerId)});
+            .arg(aPeerId));
     setupQueries.emplace_back(
         RawDatabase::Query{QStringLiteral("INSERT INTO text_messages (id, message_type, "
                                           "sender_alias, message) VALUES (2, 'T', '%1', ?)")
                                .arg(aAliasDuplicateId),
                            {QStringLiteral("Message 2 from A to Self").toUtf8()}});
 
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (10, 'F', 0, '%1')")
-            .arg(aPeerDuplicateId)});
+            .arg(aPeerDuplicateId));
     setupQueries.emplace_back(RawDatabase::Query{
         QStringLiteral(
             "INSERT INTO file_transfers (id, message_type, sender_alias, file_restart_id, "
@@ -169,62 +167,63 @@ void appendAddAChatMessagesQueries(std::vector<RawDatabase::Query>& setupQueries
 
 void appendVerifyAChatMessagesQueries(std::vector<RawDatabase::Query>& verifyQueries)
 {
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM history WHERE chat_id = '%1'").arg(aChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); }});
-    verifyQueries.emplace_back(RawDatabase::Query{
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history WHERE chat_id = '%1'").arg(aChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); });
+    verifyQueries.emplace_back( //
         QStringLiteral("SELECT COUNT(*) FROM text_messages WHERE sender_alias = '%1'").arg(aAliasId),
-        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 2); }});
-    verifyQueries.emplace_back(RawDatabase::Query{
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 2); });
+    verifyQueries.emplace_back( //
         QStringLiteral("SELECT COUNT(*) FROM file_transfers WHERE sender_alias = '%1'").arg(aAliasId),
-        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); }});
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); });
 }
 
 void appendAddBChatMessagesQueries(std::vector<RawDatabase::Query>& setupQueries)
 {
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (3, 'T', 0, '%1')")
-            .arg(bPeerId)});
+            .arg(bPeerId));
     setupQueries.emplace_back(
         RawDatabase::Query{QStringLiteral("INSERT INTO text_messages (id, message_type, "
                                           "sender_alias, message) VALUES (3, 'T', '%1', ?)")
                                .arg(bAliasId),
                            {QStringLiteral("Message 1 from B to Self").toUtf8()}});
 
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (4, 'T', 0, '%1')")
-            .arg(bPeerId)});
+            .arg(bPeerId));
     setupQueries.emplace_back(
         RawDatabase::Query{QStringLiteral("INSERT INTO text_messages (id, message_type, "
                                           "sender_alias, message) VALUES (4, 'T', '%1', ?)")
                                .arg(selfAliasId),
                            {QStringLiteral("Message 1 from Self to B").toUtf8()}});
 
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (5, 'T', 0, '%1')")
-            .arg(bPeerId)});
+            .arg(bPeerId));
     setupQueries.emplace_back(
         RawDatabase::Query{QStringLiteral("INSERT INTO text_messages (id, message_type, "
                                           "sender_alias, message) VALUES (5, 'T', '%1', ?)")
                                .arg(selfAliasId),
                            {QStringLiteral("Pending message 1 from Self to B").toUtf8()}});
-    setupQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("INSERT INTO faux_offline_pending (id) VALUES (5)")});
+    setupQueries.emplace_back( //
+        QStringLiteral("INSERT INTO faux_offline_pending (id) VALUES (5)"));
 
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (8, 'S', 0, '%1')")
-            .arg(bPeerId)});
-    setupQueries.emplace_back(RawDatabase::Query{QStringLiteral(
-        "INSERT INTO system_messages (id, message_type, system_message_type) VALUES (8, 'S', 1)")});
+            .arg(bPeerId));
+    setupQueries.emplace_back( //
+        QStringLiteral("INSERT INTO system_messages (id, message_type, system_message_type) VALUES "
+                       "(8, 'S', 1)"));
 
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (9, 'F', 0, '%1')")
-            .arg(bPeerId)});
+            .arg(bPeerId));
     setupQueries.emplace_back(RawDatabase::Query{
         QStringLiteral(
             "INSERT INTO file_transfers (id, message_type, sender_alias, file_restart_id, "
@@ -236,48 +235,47 @@ void appendAddBChatMessagesQueries(std::vector<RawDatabase::Query>& setupQueries
 
 void appendVerifyBChatMessagesQueries(std::vector<RawDatabase::Query>& verifyQueries)
 {
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM history WHERE chat_id = '%1'").arg(bChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 5); }});
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM history JOIN text_messages ON "
-                                          "history.id = text_messages.id WHERE chat_id = '%1'")
-                               .arg(bChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); }});
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral(
-                               "SELECT COUNT(*) FROM history JOIN faux_offline_pending ON "
-                               "history.id = faux_offline_pending.id WHERE chat_id = '%1'")
-                               .arg(bChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); }});
-    verifyQueries.emplace_back(RawDatabase::Query{
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history WHERE chat_id = '%1'").arg(bChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 5); });
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history JOIN text_messages ON "
+                       "history.id = text_messages.id WHERE chat_id = '%1'")
+            .arg(bChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 3); });
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history JOIN faux_offline_pending ON "
+                       "history.id = faux_offline_pending.id WHERE chat_id = '%1'")
+            .arg(bChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); });
+    verifyQueries.emplace_back( //
         QStringLiteral("SELECT COUNT(*) FROM file_transfers WHERE sender_alias = '%1'").arg(selfAliasId),
-        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); }});
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM history JOIN system_messages ON "
-                                          "history.id = system_messages.id WHERE chat_id = '%1'")
-                               .arg(bChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); }});
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); });
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history JOIN system_messages ON "
+                       "history.id = system_messages.id WHERE chat_id = '%1'")
+            .arg(bChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); });
 }
 
 void appendAddCChatMessagesQueries(std::vector<RawDatabase::Query>& setupQueries)
 {
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (6, 'T', 0, '%1')")
-            .arg(cPeerId)});
+            .arg(cPeerId));
     setupQueries.emplace_back(
         RawDatabase::Query{QStringLiteral("INSERT INTO text_messages (id, message_type, "
                                           "sender_alias, message) VALUES (6, 'T', '%1', ?)")
                                .arg(selfAliasId),
                            {QStringLiteral("Message 1 from Self to B").toUtf8()}});
-    setupQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("INSERT INTO broken_messages (id) VALUES (6)")});
+    setupQueries.emplace_back( //
+        QStringLiteral("INSERT INTO broken_messages (id) VALUES (6)"));
 
-    setupQueries.emplace_back(RawDatabase::Query{
+    setupQueries.emplace_back( //
         QStringLiteral(
             "INSERT INTO history (id, message_type, timestamp, chat_id) VALUES (7, 'T', 0, '%1')")
-            .arg(cPeerId)});
+            .arg(cPeerId));
     setupQueries.emplace_back(
         RawDatabase::Query{QStringLiteral("INSERT INTO text_messages (id, message_type, "
                                           "sender_alias, message) VALUES (7, 'T', '%1', ?)")
@@ -287,19 +285,19 @@ void appendAddCChatMessagesQueries(std::vector<RawDatabase::Query>& setupQueries
 
 void appendVerifyCChatMessagesQueries(std::vector<RawDatabase::Query>& verifyQueries)
 {
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM history WHERE chat_id = '%1'").arg(cChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 2); }});
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM history JOIN broken_messages ON "
-                                          "history.id = broken_messages.id WHERE chat_id = '%1'")
-                               .arg(cChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); }});
-    verifyQueries.emplace_back(
-        RawDatabase::Query{QStringLiteral("SELECT COUNT(*) FROM history JOIN text_messages ON "
-                                          "history.id = text_messages.id WHERE chat_id = '%1'")
-                               .arg(cChatId),
-                           [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 2); }});
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history WHERE chat_id = '%1'").arg(cChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 2); });
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history JOIN broken_messages ON "
+                       "history.id = broken_messages.id WHERE chat_id = '%1'")
+            .arg(cChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 1); });
+    verifyQueries.emplace_back( //
+        QStringLiteral("SELECT COUNT(*) FROM history JOIN text_messages ON "
+                       "history.id = text_messages.id WHERE chat_id = '%1'")
+            .arg(cChatId),
+        [&](const QVector<QVariant>& row) { QVERIFY(row[0].toLongLong() == 2); });
 }
 
 void appendAddHistoryQueries(std::vector<RawDatabase::Query>& setupQueries)


### PR DESCRIPTION
Our clang-tidy run doesn't catch these, but clangd does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/425)
<!-- Reviewable:end -->
