### PR TITLE
fix(Notify): Use notification categories on Linux

### DIFF
--- a/src/model/notificationdata.h
+++ b/src/model/notificationdata.h
@@ -12,5 +12,6 @@ struct NotificationData
 {
     QString title;
     QString message;
+    QString category;
     QPixmap pixmap;
 };

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -144,6 +144,26 @@ NotificationData NotificationGenerator::friendMessageNotification(const Friend* 
     ret.title = generateTitle(friendNotifications, conferenceNotifications, f);
     ret.message =
         generateContent(friendNotifications, conferenceNotifications, message, f->getPublicKey());
+    ret.category = "im.received";
+    ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
+
+    return ret;
+}
+
+NotificationData NotificationGenerator::incomingCallNotification(const Friend* f)
+{
+    friendNotifications[f]++;
+
+    NotificationData ret;
+
+    if (notificationSettings.getNotifyHide()) {
+        ret.title = tr("Incoming call");
+        return ret;
+    }
+
+    ret.title = generateTitle(friendNotifications, conferenceNotifications, f);
+    ret.message = generateContent(friendNotifications, conferenceNotifications, "", f->getPublicKey());
+    ret.category = "call.incoming";
     ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
 
     return ret;
@@ -195,6 +215,7 @@ NotificationData NotificationGenerator::fileTransferNotification(const Friend* f
         ret.message = filename + " (" + getHumanReadableSize(fileSize) + ")";
     }
 
+    ret.category = "transfer";
     ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
 
     return ret;
@@ -211,6 +232,7 @@ NotificationData NotificationGenerator::conferenceInvitationNotification(const F
 
     ret.title = tr("%1 invites you to join a conference.").arg(from->getDisplayedName());
     ret.message = "";
+    ret.category = "im";
     ret.pixmap = getSenderAvatar(profile, from->getPublicKey());
 
     return ret;
@@ -228,6 +250,7 @@ NotificationData NotificationGenerator::friendRequestNotification(const ToxPk& s
 
     ret.title = tr("Friend request received from %1").arg(sender.toString());
     ret.message = message;
+    ret.category = "im";
 
     return ret;
 }

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -16,14 +16,11 @@ QString generateContent(const QHash<const Conference*, size_t>& conferenceNotifi
 {
     assert(!conferenceNotifications.empty());
 
-    if (conferenceNotifications.size() == 1) {
-        auto it = conferenceNotifications.begin();
-        if (it == conferenceNotifications.end()) {
-            qFatal("Concurrency error: conference notifications got cleared while reading");
-        }
-        return it.key()->getPeerList()[sender] + ": " + lastMessage;
+    auto it = conferenceNotifications.begin();
+    if (it == conferenceNotifications.end()) {
+        qFatal("Concurrency error: conference notifications got cleared while reading");
     }
-    return lastMessage;
+    return it.key()->getPeerList()[sender] + ": " + lastMessage;
 }
 
 QPixmap getSenderAvatar(Profile* profile, const ToxPk& sender)

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -43,6 +43,7 @@ NotificationData NotificationGenerator::friendMessageNotification(const Friend* 
     friendNotifications[f]++;
 
     NotificationData ret;
+    ret.category = "im.received";
 
     if (notificationSettings.getNotifyHide()) {
         ret.title = tr("New message");
@@ -51,7 +52,6 @@ NotificationData NotificationGenerator::friendMessageNotification(const Friend* 
 
     ret.title = f->getDisplayedName();
     ret.message = message;
-    ret.category = "im.received";
     ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
 
     return ret;
@@ -62,16 +62,15 @@ NotificationData NotificationGenerator::incomingCallNotification(const Friend* f
     friendNotifications[f]++;
 
     NotificationData ret;
+    ret.category = "call.incoming";
 
     if (notificationSettings.getNotifyHide()) {
         ret.title = tr("Incoming call");
-        ret.category = "call.incoming";
         return ret;
     }
 
     ret.title = f->getDisplayedName();
     ret.message = tr("Incoming call");
-    ret.category = "call.incoming";
     ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
 
     return ret;
@@ -84,6 +83,7 @@ NotificationData NotificationGenerator::conferenceMessageNotification(const Conf
     conferenceNotifications[c]++;
 
     NotificationData ret;
+    ret.category = "transfer";
 
     if (notificationSettings.getNotifyHide()) {
         ret.title = tr("New conference message");
@@ -92,7 +92,6 @@ NotificationData NotificationGenerator::conferenceMessageNotification(const Conf
 
     ret.title = c->getDisplayedName();
     ret.message = generateContent(conferenceNotifications, message, sender);
-    ret.category = "im.received";
     ret.pixmap = getSenderAvatar(profile, sender);
 
     return ret;
@@ -105,6 +104,7 @@ NotificationData NotificationGenerator::fileTransferNotification(const Friend* f
     friendNotifications[f]++;
 
     NotificationData ret;
+    ret.category = "transfer";
 
     if (notificationSettings.getNotifyHide()) {
         ret.title = tr("Incoming file transfer");
@@ -114,7 +114,6 @@ NotificationData NotificationGenerator::fileTransferNotification(const Friend* f
     //: e.g. Bob - file transfer
     ret.title = tr("%1 - file transfer").arg(f->getDisplayedName());
     ret.message = filename + " (" + getHumanReadableSize(fileSize) + ")";
-    ret.category = "transfer";
     ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
 
     return ret;
@@ -123,6 +122,7 @@ NotificationData NotificationGenerator::fileTransferNotification(const Friend* f
 NotificationData NotificationGenerator::conferenceInvitationNotification(const Friend* from)
 {
     NotificationData ret;
+    ret.category = "im";
 
     if (notificationSettings.getNotifyHide()) {
         ret.title = tr("Conference invite received");
@@ -131,7 +131,6 @@ NotificationData NotificationGenerator::conferenceInvitationNotification(const F
 
     ret.title = tr("%1 invites you to join a conference.").arg(from->getDisplayedName());
     ret.message = "";
-    ret.category = "im";
     ret.pixmap = getSenderAvatar(profile, from->getPublicKey());
 
     return ret;
@@ -141,6 +140,7 @@ NotificationData NotificationGenerator::friendRequestNotification(const ToxPk& s
                                                                   const QString& message)
 {
     NotificationData ret;
+    ret.category = "im";
 
     if (notificationSettings.getNotifyHide()) {
         ret.title = tr("Friend request received");
@@ -149,7 +149,6 @@ NotificationData NotificationGenerator::friendRequestNotification(const ToxPk& s
 
     ret.title = tr("Friend request received from %1").arg(sender.toString());
     ret.message = message;
-    ret.category = "im";
 
     return ret;
 }

--- a/src/model/notificationgenerator.h
+++ b/src/model/notificationgenerator.h
@@ -33,6 +33,7 @@ public:
     NotificationGenerator& operator=(NotificationGenerator&&) = delete;
 
     NotificationData friendMessageNotification(const Friend* f, const QString& message);
+    NotificationData incomingCallNotification(const Friend* f);
     NotificationData conferenceMessageNotification(const Conference* c, const ToxPk& sender,
                                                    const QString& message);
     NotificationData fileTransferNotification(const Friend* f, const QString& filename,

--- a/src/platform/desktop_notifications/desktopnotify.cpp
+++ b/src/platform/desktop_notifications/desktopnotify.cpp
@@ -47,7 +47,7 @@ void DesktopNotify::notifyMessage(const NotificationData& notificationData)
     // Try system-backends first.
     if (d->settings.getNotifySystemBackend()) {
         if (d->dbus->showMessage(notificationData.title, notificationData.message,
-                                 notificationData.pixmap)) {
+                                 notificationData.category, notificationData.pixmap)) {
             return;
         }
     }

--- a/src/platform/desktop_notifications/desktopnotifybackend.h
+++ b/src/platform/desktop_notifications/desktopnotifybackend.h
@@ -15,8 +15,8 @@ class DesktopNotifyBackend : public QObject
 public:
     explicit DesktopNotifyBackend(QObject* parent);
     ~DesktopNotifyBackend() override;
-
-    bool showMessage(const QString& title, const QString& message, const QPixmap& pixmap);
+    bool showMessage(const QString& title, const QString& message, const QString& category,
+                     const QPixmap& pixmap);
 
 signals:
     void messageClicked();

--- a/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
+++ b/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
@@ -324,13 +324,13 @@ DesktopNotifyBackend::DesktopNotifyBackend(QObject* parent)
 DesktopNotifyBackend::~DesktopNotifyBackend() = default;
 
 bool DesktopNotifyBackend::showMessage(const QString& title, const QString& message,
-                                       const QPixmap& pixmap)
+                                       const QString& category, const QPixmap& pixmap)
 {
     // Try Notify first.
     if (d->notifyInterface.isValid()) {
         QVariantMap hints{
             {QStringLiteral("action-icons"), true},
-            {QStringLiteral("category"), QStringLiteral("im.received")},
+            {QStringLiteral("category"), category},
             {QStringLiteral("sender-pid"),
              QVariant::fromValue<quint64>(QCoreApplication::applicationPid())},
         };

--- a/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
+++ b/src/platform/desktop_notifications/desktopnotifybackend_dbus.cpp
@@ -342,7 +342,7 @@ bool DesktopNotifyBackend::showMessage(const QString& title, const QString& mess
             // app_name
             QApplication::applicationName(),
             // replaces_id
-            d->id,
+            static_cast<uint32_t>(0),
             // app_icon
             QStringLiteral("dialog-password"),
             // summary

--- a/src/platform/desktop_notifications/desktopnotifybackend_noop.cpp
+++ b/src/platform/desktop_notifications/desktopnotifybackend_noop.cpp
@@ -16,10 +16,11 @@ DesktopNotifyBackend::DesktopNotifyBackend(QObject* parent)
 DesktopNotifyBackend::~DesktopNotifyBackend() = default;
 
 bool DesktopNotifyBackend::showMessage(const QString& title, const QString& message,
-                                       const QPixmap& pixmap)
+                                       const QString& category, const QPixmap& pixmap)
 {
     std::ignore = title;
     std::ignore = message;
+    std::ignore = category;
     std::ignore = pixmap;
     // Always fail, fall back to QSystemTrayIcon.
     return false;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1566,10 +1566,16 @@ bool Widget::newFriendMessageAlert(const ToxPk& friendId, const QString& text, b
         widget->updateStatusLight();
         ui->friendList->trackWidget(settings, style, widget);
         if (notifier != nullptr) {
-            auto notificationData =
-                filename.isEmpty()
-                    ? notificationGenerator->friendMessageNotification(f, text)
-                    : notificationGenerator->fileTransferNotification(f, filename, filesize);
+            NotificationData notificationData;
+            if (filename.isEmpty()) {
+                if (text.isEmpty()) {
+                    notificationData = notificationGenerator->incomingCallNotification(f);
+                } else {
+                    notificationData = notificationGenerator->friendMessageNotification(f, text);
+                }
+            } else {
+                    notificationData = notificationGenerator->fileTransferNotification(f, filename, filesize);
+            }
             notifier->notifyMessage(notificationData);
         }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1048,7 +1048,11 @@ void Widget::setStatusMessage(const QString& statusMessage)
  */
 void Widget::playNotificationSound(IAudioSink::Sound sound, bool loop)
 {
-    if (!settings.getAudioOutDevEnabled()) {
+    bool isBusy = core->getStatus() == Status::Status::Busy;
+    bool busySound = settings.getBusySound();
+    bool notifySound = settings.getNotifySound();
+
+    if (!settings.getAudioOutDevEnabled() || !(notifySound && (!isBusy || busySound))) {
         // don't try to play sounds if audio is disabled
         return;
     }
@@ -1574,7 +1578,8 @@ bool Widget::newFriendMessageAlert(const ToxPk& friendId, const QString& text, b
                     notificationData = notificationGenerator->friendMessageNotification(f, text);
                 }
             } else {
-                    notificationData = notificationGenerator->fileTransferNotification(f, filename, filesize);
+                notificationData =
+                    notificationGenerator->fileTransferNotification(f, filename, filesize);
             }
             notifier->notifyMessage(notificationData);
         }
@@ -1674,11 +1679,8 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, 
                 }
                 eventFlag = true;
             }
-            const bool isBusy = core->getStatus() == Status::Status::Busy;
-            const bool busySound = settings.getBusySound();
-            const bool notifySound = settings.getNotifySound();
 
-            if (notifySound && sound && (!isBusy || busySound)) {
+            if (sound) {
                 playNotificationSound(IAudioSink::Sound::NewMessage);
             }
         }

--- a/test/model/notificationgenerator_test.cpp
+++ b/test/model/notificationgenerator_test.cpp
@@ -153,11 +153,11 @@ void TestNotificationGenerator::testMultipleFriendMessages()
     f.setName("friendName");
     notificationGenerator->friendMessageNotification(&f, "test");
     auto notificationData = notificationGenerator->friendMessageNotification(&f, "test2");
-    QCOMPARE(notificationData.title, "2 message(s) from friendName");
+    QCOMPARE(notificationData.title, "friendName");
     QCOMPARE(notificationData.message, "test2");
 
     notificationData = notificationGenerator->friendMessageNotification(&f, "test3");
-    QCOMPARE(notificationData.title, "3 message(s) from friendName");
+    QCOMPARE(notificationData.title, "friendName");
     QCOMPARE(notificationData.message, "test3");
 }
 
@@ -202,7 +202,7 @@ void TestNotificationGenerator::testMultipleConferenceMessages()
     notificationGenerator->conferenceMessageNotification(&g, sender, "test1");
 
     auto notificationData = notificationGenerator->conferenceMessageNotification(&g, sender2, "test2");
-    QCOMPARE(notificationData.title, "2 message(s) from conferenceName");
+    QCOMPARE(notificationData.title, "conferenceName");
     QCOMPARE(notificationData.message, "sender2: test2");
 }
 
@@ -217,8 +217,8 @@ void TestNotificationGenerator::testMultipleFriendSourceMessages()
     notificationGenerator->friendMessageNotification(&f, "test1");
     auto notificationData = notificationGenerator->friendMessageNotification(&f2, "test2");
 
-    QCOMPARE(notificationData.title, "2 message(s) from 2 chats");
-    QCOMPARE(notificationData.message, "friend1, friend2");
+    QCOMPARE(notificationData.title, "friend2");
+    QCOMPARE(notificationData.message, "test2");
 }
 
 void TestNotificationGenerator::testMultipleConferenceSourceMessages()
@@ -238,8 +238,8 @@ void TestNotificationGenerator::testMultipleConferenceSourceMessages()
     auto notificationData =
         notificationGenerator->conferenceMessageNotification(&g2, sender_g2, "test1");
 
-    QCOMPARE(notificationData.title, "2 message(s) from 2 chats");
-    QCOMPARE(notificationData.message, "conferenceName1, conferenceName2");
+    QCOMPARE(notificationData.title, "conferenceName2");
+    QCOMPARE(notificationData.message, "test1");
 }
 
 void TestNotificationGenerator::testMixedSourceMessages()
@@ -256,12 +256,12 @@ void TestNotificationGenerator::testMixedSourceMessages()
     notificationGenerator->friendMessageNotification(&f, "test1");
     auto notificationData = notificationGenerator->conferenceMessageNotification(&g, sender, "test2");
 
-    QCOMPARE("2 message(s) from 2 chats", notificationData.title);
-    QCOMPARE("conference, friend", notificationData.message);
+    QCOMPARE("conference", notificationData.title);
+    QCOMPARE("sender1: test2", notificationData.message);
 
     notificationData = notificationGenerator->fileTransferNotification(&f, "file", 0);
-    QCOMPARE("3 message(s) from 2 chats", notificationData.title);
-    QCOMPARE("conference, friend", notificationData.message);
+    QCOMPARE("friend - file transfer", notificationData.title);
+    QCOMPARE("file (0B)", notificationData.message);
 }
 
 void TestNotificationGenerator::testFileTransfer()
@@ -285,8 +285,8 @@ void TestNotificationGenerator::testFileTransferAfterMessage()
     auto notificationData =
         notificationGenerator->fileTransferNotification(&f, "file", 5 * 1024 * 1024 /* 5MB */);
 
-    QCOMPARE(notificationData.title, "2 message(s) from friend");
-    QCOMPARE(notificationData.message, "Incoming file transfer");
+    QCOMPARE(notificationData.title, "friend - file transfer");
+    QCOMPARE(notificationData.message, "file (5.00MiB)");
 }
 
 void TestNotificationGenerator::testConferenceInvitation()
@@ -309,7 +309,7 @@ void TestNotificationGenerator::testConferenceInviteUncounted()
     notificationGenerator->conferenceInvitationNotification(&f);
     auto notificationData = notificationGenerator->friendMessageNotification(&f, "test2");
 
-    QCOMPARE(notificationData.title, "2 message(s) from friend");
+    QCOMPARE(notificationData.title, "friend");
     QCOMPARE(notificationData.message, "test2");
 }
 
@@ -335,7 +335,7 @@ void TestNotificationGenerator::testFriendRequestUncounted()
     notificationGenerator->friendRequestNotification(sender, "request");
     auto notificationData = notificationGenerator->friendMessageNotification(&f, "test2");
 
-    QCOMPARE(notificationData.title, "2 message(s) from friend");
+    QCOMPARE(notificationData.title, "friend");
     QCOMPARE(notificationData.message, "test2");
 }
 
@@ -416,7 +416,7 @@ void TestNotificationGenerator::testSimpleMessageToggle()
 
     auto notificationData = notificationGenerator->friendMessageNotification(&f, "test2");
 
-    QCOMPARE(notificationData.title, "2 message(s) from friend");
+    QCOMPARE(notificationData.title, "friend");
     QCOMPARE(notificationData.message, "test2");
 }
 

--- a/test/model/notificationgenerator_test.cpp
+++ b/test/model/notificationgenerator_test.cpp
@@ -239,7 +239,7 @@ void TestNotificationGenerator::testMultipleConferenceSourceMessages()
         notificationGenerator->conferenceMessageNotification(&g2, sender_g2, "test1");
 
     QCOMPARE(notificationData.title, "conferenceName2");
-    QCOMPARE(notificationData.message, "test1");
+    QCOMPARE(notificationData.message, "sender1: test1");
 }
 
 void TestNotificationGenerator::testMixedSourceMessages()

--- a/test/model/notificationgenerator_test.cpp
+++ b/test/model/notificationgenerator_test.cpp
@@ -11,7 +11,6 @@
 
 #include <QObject>
 #include <QtTest/QtTest>
-#include <memory>
 
 namespace {
 class MockNotificationSettings : public INotificationSettings
@@ -224,19 +223,23 @@ void TestNotificationGenerator::testMultipleFriendSourceMessages()
 
 void TestNotificationGenerator::testMultipleConferenceSourceMessages()
 {
-    Conference g(0, ConferenceId(QByteArray(32, 0)), "conferenceName", false, "selfName",
-                 *conferenceQuery, *coreIdHandler, *friendList);
+    Conference g1(0, ConferenceId(QByteArray(32, 0)), "conferenceName1", false, "selfName",
+                  *conferenceQuery, *coreIdHandler, *friendList);
     Conference g2(1, ConferenceId(QByteArray(32, 1)), "conferenceName2", false, "selfName",
                   *conferenceQuery, *coreIdHandler, *friendList);
 
-    auto sender = conferenceQuery->getConferencePeerPk(0, 0);
-    g.updateUsername(sender, "sender1");
+    auto sender_g1 = conferenceQuery->getConferencePeerPk(0, 1);
+    g1.updateUsername(sender_g1, "sender1");
 
-    notificationGenerator->conferenceMessageNotification(&g, sender, "test1");
-    auto notificationData = notificationGenerator->conferenceMessageNotification(&g2, sender, "test1");
+    auto sender_g2 = conferenceQuery->getConferencePeerPk(1, 1);
+    g2.updateUsername(sender_g2, "sender1");
+
+    notificationGenerator->conferenceMessageNotification(&g1, sender_g1, "test1");
+    auto notificationData =
+        notificationGenerator->conferenceMessageNotification(&g2, sender_g2, "test1");
 
     QCOMPARE(notificationData.title, "2 message(s) from 2 chats");
-    QCOMPARE(notificationData.message, "conferenceName, conferenceName2");
+    QCOMPARE(notificationData.message, "conferenceName1, conferenceName2");
 }
 
 void TestNotificationGenerator::testMixedSourceMessages()

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -2041,6 +2041,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">تم تلقي طلب الصداقة من %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">مكالمة واردة</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2550,18 +2555,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">إعادة تنسيق النص...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 رسالة (رسائل) من %2 محادثة</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 رسالة (رسائل) من %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -1986,6 +1986,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Запыт сябра атрыманы ад %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Уваходны званок</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2482,18 +2487,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Перафармаціраванне тэксту...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 паведамленне(я) з %2 чатаў</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 паведамленне(я) ад %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -2283,6 +2283,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ ⵢⴻⵡⵡⴻⴹⴷ ⵙⴻⴳ %1.</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵜⵉⵖⵔⵉ ⵉⴷ ⵉⴽⴻⵞⵞⵎⴻⵏ</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2865,18 +2870,6 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵄⵉⵡⴻⴷ ⵏ ⵓⵙⴻⵖⵣⴻⴼ ⵏ ⵓⴹⵔⵉⵙ...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 ⵏ ⵢⵉⵣⴻⵏ (ⵏ) ⵙⴻⴳ %2 ⵏ ⵜⵎⴻⵙⵍⴰⵢⵉⵏ</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 ⵉⵣⴻⵏ (ⵏ) ⵙⴻⴳ %2.</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -1927,6 +1927,11 @@ Press Shift+F1 for more information.</source>
         <source>Friend request received from %1</source>
         <translation>Получена приятелска покана %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Входящо повикване</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2410,16 +2415,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Преформатиране на текст…</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 съобщение(я) от %2 чата</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 съобщение(я) от %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -2323,6 +2323,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 থেকে বন্ধুর অনুরোধ গৃহীত হয়েছে</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ইনকামিং কল</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2906,18 +2911,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">পাঠ্য পুনরায় ফর্ম্যাট করা হচ্ছে...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 চ্যাট থেকে %1 বার্তা(গুলি)</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 থেকে %1 বার্তা(গুলি)</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -1932,6 +1932,11 @@ Stiskněte Shift+F1 pro další informace.</translation>
         <source>Friend request received from %1</source>
         <translation>Přijata žádost o přidání od %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Příchozí hovor</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2415,16 +2420,6 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Přeformátování textu…</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 zpráva(y) ze %2 vláken</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 zpráva(y) od uživatele %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -2168,6 +2168,11 @@ Tryk på Shift+F1 for at få flere oplysninger.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Venneanmodning modtaget fra %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Indgående opkald</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2727,18 +2732,6 @@ Dette ID inkluderer NoSpam-koden (i blåt) og kontrolsummen (i gråt).</translat
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Omformaterer tekst...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 besked(er) fra %2 chats</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 besked(er) fra %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -1921,6 +1921,11 @@ Drücken Sie Umschalt+F1, um weitere Informationen zu erhalten.</translation>
         <source>Friend request received from %1</source>
         <translation>Freundschaftsanfrage von %1 erhalten</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Eingehender Anruf</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2405,16 +2410,6 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Neuformatierung des Texts...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 Nachricht(en) von %2 Chats</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 Nachricht(en) von %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -1994,6 +1994,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Λήφθηκε αίτημα φιλίας από το %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Εισερχόμενη κλήση</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2496,18 +2501,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Επαναμορφοποίηση κειμένου...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 μήνυμα(α) από %2 συνομιλίες</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 μήνυμα(α) από %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -2189,6 +2189,11 @@ Premu Shift+F1 por pliaj informoj.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Amikpeto ricevita de %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Envenanta voko</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2739,18 +2744,6 @@ Kunhavigu ĝin kun viaj amikoj por komenci babili.
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Reformata teksto...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 mesaĝo(j) el %2 babilejoj</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 mesaĝo(j) de %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -1918,6 +1918,11 @@ Presione Mayús+F1 para obtener más información.</translation>
         <source>Friend request received from %1</source>
         <translation>Solicitud de amistad recibida de%1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Llamada entrante</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2401,16 +2406,6 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformateando el texto...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 mensaje(s) de %2 chats</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 mensaje(s) de %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -1930,6 +1930,11 @@ Lisateabe saamiseks vajutage klahvikombinatsiooni Shift+F1.</translation>
         <source>Friend request received from %1</source>
         <translation>Sa said sõbrakutse kasutajalt %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sissetulev kõne</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2413,16 +2418,6 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Vormindan teksti uuesti...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 sõnum(it) %2 vestlusest</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 sõnum(it) kasutajalt %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -1973,6 +1973,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">درخواست دوستی از %1 دریافت شد</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">تماس ورودی</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2469,18 +2474,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">در حال قالب بندی مجدد متن...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 پیام از %2 گپ</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 پیام از %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -1928,6 +1928,11 @@ Saat lisätietoja painamalla Shift+F1.</translation>
         <source>Friend request received from %1</source>
         <translation>Kaveripyyntö saatu henkilöltä %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Saapuva puhelu</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2411,16 +2416,6 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Uudelleenmuotoillaan tekstiä...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 viesti(ä) %2 chatista</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 viesti(ä) %2 chatista</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -1926,6 +1926,11 @@ Appuyez sur Maj+F1 pour plus d&apos;informations.</translation>
         <source>Friend request received from %1</source>
         <translation>Demande d&apos;amitié reçue de %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Appel entrant</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2409,16 +2414,6 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformatage du texte ...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 message(s) de %2 chat(s)</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 message(s) de %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -1975,6 +1975,11 @@ Preme Maiús+F1 para obter máis información.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Solicitude de amizade recibida de %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chamada entrante</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2471,18 +2476,6 @@ Este ID inclúe o código NoSpam (en azul) e a suma de verificación (en gris).<
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Reformateando o texto...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 mensaxe(s) de %2 chats</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 mensaxe(s) de %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -2307,6 +2307,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">בקשת חברות התקבלה מ-%1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">שיחה נכנסת</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2889,18 +2894,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">פורמט מחדש את הטקסט...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 הודעות מ-%2 צ&apos;אטים</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 הודעות מאת %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -1975,6 +1975,11 @@ Pritisnite Shift+F1 za više informacija.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Zahtjev za prijateljstvo primljen od %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dolazni poziv</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2471,18 +2476,6 @@ Ovaj ID uključuje NoSpam kod (plavo) i kontrolni zbroj (sivo).</translation>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ponovno formatiranje teksta...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 poruka(e) iz %2 chatova</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 poruka(e) od %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -1969,6 +1969,11 @@ További információért nyomja meg a Shift+F1 billentyűkombinációt.</transl
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ismerős felkérés érkezett tőle: %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Bejövő hívás</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2465,18 +2470,6 @@ Ez az azonosító tartalmazza a NoSpam kódot (kék színnel) és az ellenőrző
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Szöveg újraformázása...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 üzenet %2 csevegéstől</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 üzenet a következőtől: %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -2299,6 +2299,11 @@ Ef þú tapar þessu lykilorði er engin leið til að endurheimta það.
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Vinabeiðni móttekin frá %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Móttekið símtal</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2880,18 +2885,6 @@ Deildu því með vinum þínum til að byrja að spjalla.
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Endursníða texta...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 skilaboð frá %2 spjalli</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 skilaboð frá %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -1926,6 +1926,11 @@ Premi Maiusc+F1 per ulteriori informazioni.</translation>
         <source>Friend request received from %1</source>
         <translation>Richiesta di amicizia ricevuta da %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chiamata in arrivo</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2409,16 +2414,6 @@ Questo ID include una sezione NoSpam (in colore blu) e il controllo checksum (in
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Riformattando il testo...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 messaggi da %2 chat</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 messaggi da %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -1998,6 +1998,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>%1 から友達リクエストが来ています</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">着信</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2500,18 +2505,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>テキストのフォーマットを再設定しています...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation>%2 チャットからの %1 メッセージ</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation>%2 からの %1 メッセージ</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -2288,6 +2288,11 @@ ko danre la bastyfygau+F1 tezu&apos;e lo ka datni zenba</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">fe lo pendo cpedu be fi la %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">lo nu te cmene fonjorne</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2870,18 +2875,6 @@ le samselcmi cu mapti le blanu zoi gy. NoSpam .gy. joi le checksum zoi gy. gray<
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">fanva lo lerseltcidu...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">la %1 notci fi&apos;o se krasi la %2. casnu</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 lo notci be fi&apos;i de %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -2313,6 +2313,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 ರಿಂದ ಸ್ನೇಹ ವಿನಂತಿಯನ್ನು ಸ್ವೀಕರಿಸಲಾಗಿದೆ</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಒಳಬರುವ ಕರೆ</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2895,18 +2900,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಪಠ್ಯವನ್ನು ಮರು ಫಾರ್ಮ್ಯಾಟ್ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 ಚಾಟ್‌ಗಳಿಂದ %1 ಸಂದೇಶ(ಗಳು).</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 ರಿಂದ %1 ಸಂದೇಶ(ಗಳು).</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -2172,6 +2172,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1로부터 친구 요청을 받았습니다</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">전화 수신</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2740,18 +2745,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">텍스트 형식을 다시 지정하는 중...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2개의 채팅에서 %1개의 메시지</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2의 메시지 %1개</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -2334,6 +2334,11 @@ Druk op Shift+F1 veur mie informatie.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Vrundverzeuk ontvange vaan %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Inkomende oproep</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2804,18 +2809,6 @@ Deze ID umvat de NoSpam-code (in blauw) en de checksum (in gries).</translation>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Teks herformatere...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 beriech(e) vaan %2 gesprekke</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 boodsjap(e) vaan %2</translation>
     </message>
     <message>
         <source>online</source>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -1934,6 +1934,11 @@ Plural:10–20,30,40,..</translatorcomment>
         <source>Friend request received from %1</source>
         <translation>Kontakto užklausa gauta iš %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Įeinantis skambutis</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2417,16 +2422,6 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Performatuojamas tekstas...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 žinutė (-ės) iš %2 pokalbių</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 žinutė (-ės) iš %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -1963,6 +1963,11 @@ Lai iegūtu papildinformāciju, nospiediet taustiņu kombināciju Shift+F1.</tra
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Draudzības pieprasījums saņemts no %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ienākošais zvans</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2461,18 +2466,6 @@ Kopīgojiet to ar draugiem, lai sāktu tērzēšanu.
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Notiek teksta pārformatēšana...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 ziņojums(-i) no %2 tērzēšanas</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 ziņojums(-i) no %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -2005,6 +2005,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Примено барање за пријателство од %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Дојдовен повик</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2507,18 +2512,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Се преформатира текст...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 порака(и) од %2 разговори</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 порака(и) од %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -1928,6 +1928,11 @@ Trykk Shift+F1 for mer informasjon.</translation>
         <source>Friend request received from %1</source>
         <translation type="unfinished">Venneforespørsel fra %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Innkommende samtale</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2411,16 +2416,6 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation type="unfinished">Reformaterer tekst …</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 melding(er) fra %2 sludringer</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 melding(er) fra %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -1917,6 +1917,11 @@ Druk op Shift+F1 voor meer informatie.</translation>
         <source>Friend request received from %1</source>
         <translation>Vriendschapsverzoek ontvangen van %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Inkomend gesprek</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2400,16 +2405,6 @@ Deze ID bevat de NoSpam-code (in het blauw) en de checksum (in het grijs).</tran
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Tekst opmaak...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 bericht(en) van %2 chats</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 bericht(en) van %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -1905,6 +1905,10 @@ Press Shift+F1 for more information.</source>
         <source>Friend request received from %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2384,16 +2388,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -1951,6 +1951,11 @@ Naciśnij Shift+F1, aby uzyskać więcej informacji.</translation>
         <source>Friend request received from %1</source>
         <translation>Otrzymano prośbę o dodanie do znajomych od %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Połączenie przychodzące</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2442,16 +2447,6 @@ To ID zawiera kod NoSpam (w kolorze niebieskim) oraz sumę kontrolną (w kolorze
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Przeformatowywanie tekstu...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 wiadomość(i) z %2 rozmów</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 wiadomość(i) od %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -1913,6 +1913,10 @@ Press Shift+F1 fer more information.</translation>
         <source>Friend request received from %1</source>
         <translation>Some bucko (%1) wants ta be hearties with ya</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2395,16 +2399,6 @@ This ID has th&apos; NoSpam code (in blue), &apos;n&apos; th&apos; checksum (in 
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation type="unfinished">Sprucin&apos; up th&apos; words...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation type="unfinished">%1 scroll(s) from %2 chatterboxes</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation type="unfinished">%1 scroll(s) from %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -1928,6 +1928,11 @@ Pressione Shift+F1 para obter mais informações.</translation>
         <source>Friend request received from %1</source>
         <translation>Pedido de amizade recebido de %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chamada recebida</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2411,16 +2416,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformatando o texto...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 mensagem(s) de %2 conversa(s)</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 mensagem(s) de %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -1930,6 +1930,11 @@ Pressione Shift+F1 para obter mais informações.</translation>
         <source>Friend request received from %1</source>
         <translation>Pedido de amizade recebido de %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chamada recebida</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2413,16 +2418,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformatando o texto...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 mensagem(s) de %2 bate-papo(s)</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 mensagem(s) de %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -1925,6 +1925,11 @@ Apăsați Shift+F1 pentru mai multe informații.</translation>
         <source>Friend request received from %1</source>
         <translation>Cerere de prietenie primită de la %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Apel primit</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2408,16 +2413,6 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Se reformatează textul...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 mesaj(e) de la %2 discuții</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 mesaj(e) de la %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -1924,6 +1924,11 @@ Press Shift+F1 for more information.</source>
         <source>Friend request received from %1</source>
         <translation>Получен запрос на добавление в друзья от %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Входящий звонок</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2407,16 +2412,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Переформатирование текста...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 сообщения(ий) из %2 чатов</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 сообщения(ий) от %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -2326,6 +2326,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">මිතුරු ඉල්ලීම %1 වෙතින් ලැබී ඇත</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">එන ඇමතුම</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2909,18 +2914,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">පෙළ නැවත හැඩතල ගැන්වීම...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 කතාබස් වලින් %1 පණිවිඩ(ය)</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 සිට %1 පණිවිඩ(ය)</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -1934,6 +1934,11 @@ Ak toto heslo stratíte, neexistuje spôsob, ako ho obnoviť.
         <source>Friend request received from %1</source>
         <translation>Žiadosť o priateľstvo prijatá od %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Prichádzajúci hovor</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2417,16 +2422,6 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Preformátovanie textu...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 správ(a) z %2 chatov</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 správ(a) z %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -2047,6 +2047,11 @@ Za več informacij pritisnite Shift+F1.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Prejeta prošnja za prijateljstvo od %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dohodni klic</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2590,18 +2595,6 @@ Ta ID vključuje kodo NoSpam (v modri barvi) in kontrolno vsoto (v sivi barvi).<
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Preoblikovanje besedila ...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 sporočilo(a) iz %2 klepetov</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 sporočila od %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -2321,6 +2321,11 @@ Shtypni Shift+F1 për më shumë informacion.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Kërkesa për miqësi u mor nga %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Telefonatë hyrëse</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2904,18 +2909,6 @@ Ky ID përfshin kodin NoSpam (në blu) dhe kontrollin (në gri).</translation>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Teksti po riformatohet...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 mesazh(a) nga %2 biseda</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 mesazh(a) nga %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -1979,6 +1979,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Захтев за пријатељство примљен од %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Долазни позив</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2475,18 +2480,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Преобликовање текста...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 порука(е) од %2 ћаскања</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 порука(е) од %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -1910,6 +1910,10 @@ Press Shift+F1 for more information.</source>
         <source>Friend request received from %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2389,16 +2393,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -1933,6 +1933,11 @@ Tryck på Skift+F1 för mer information.</translation>
         <source>Friend request received from %1</source>
         <translation>Vänförfrågan mottagen från %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Inkommande samtal</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2416,18 +2421,6 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Omformaterar text...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 meddelande(n) från %2 chattar</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 meddelande(n) från %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -2328,6 +2328,11 @@ Bonyeza Shift+F1 kwa maelezo zaidi.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ombi la urafiki limepokelewa kutoka kwa %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Simu inayoingia</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2911,18 +2916,6 @@ Kitambulisho hiki kinajumuisha msimbo wa NoSpam (wa bluu), na hundi (ya kijivu).
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inabadilisha maandishi...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Ujumbe %1 kutoka kwa gumzo %2</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Ujumbe %1 kutoka kwa %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -2105,6 +2105,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">நண்பர் கோரிக்கை %1 இலிருந்து பெறப்பட்டது</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">உள்வரும் அழைப்பு</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2674,18 +2679,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">உரையை மறுவடிவமைக்கிறது...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 அரட்டைகளில் இருந்து %1 செய்தி(கள்).</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 இலிருந்து %1 செய்தி(கள்).</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -1926,6 +1926,11 @@ Daha fazla bilgi için Shift+F1 tuşlarına basın.</translation>
         <source>Friend request received from %1</source>
         <translation>%1 kişisinden arkadaşlık isteği alındı</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Gelen arama</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2409,16 +2414,6 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Metin yeniden biçimlendiriliyor...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 ileti, %2 sohbetten</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 ileti, %2&apos;den</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -2002,6 +2002,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">دوست تەلىپى%1 دىن تاپشۇرۇۋېلىندى</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">كەلگەن تېلېفون</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2504,18 +2509,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">تېكىستنى ئىسلاھ قىلىش ...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 پاراڭدىن%1 ئۇچۇر (لار)</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%2 دىن%1 ئۇچۇر (لار)</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -1927,6 +1927,11 @@ Press Shift+F1 for more information.</source>
         <source>Friend request received from %1</source>
         <translation>Отримано запит на додавання в друзі від %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Вхідний дзвінок</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2413,16 +2418,6 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Переформатування тексту...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 повідомлення(ій) із %2 чатів</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 повідомлення(ій) від %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -2302,6 +2302,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 سے دوستی کی درخواست موصول ہوئی۔</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">آنے والی کال</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2885,18 +2890,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">متن کو دوبارہ فارمیٹ کیا جا رہا ہے...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 پیغامات %2 چیٹس سے</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 پیغام (پیغامات) %2 سے</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -1926,6 +1926,11 @@ Nhấn Shift+F1 để biết thêm thông tin.</translation>
         <source>Friend request received from %1</source>
         <translation>Đã nhận được yêu cầu kết bạn từ %1</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Cuộc gọi đến</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2409,16 +2414,6 @@ ID này bao gồm mã NoSpam (màu xanh lam) và checksum (màu xám).</translat
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Đang định dạng lại văn bản...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>%1 tin nhắn từ %2 cuộc trò chuyện</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>%1 tin nhắn từ %2</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1913,6 +1913,11 @@ Press Shift+F1 for more information.</source>
         <source>Friend request received from %1</source>
         <translation>从 %1 收到的加好友请求</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">来电</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2396,16 +2401,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>重新格式化文本...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translation>来自 %2 聊天室的 %1 消息</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translation>来自 %2 的 %1 消息</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2210,6 +2210,11 @@ Press Shift+F1 for more information.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">收到 %1 的好友請求</translation>
     </message>
+    <message>
+        <source>Incoming call</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">來電</translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -2783,18 +2788,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <comment>Waiting for text to be reformatted</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">正在重新格式化文字...</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2 chats</source>
-        <extracomment>e.g. 3 messages from 2 chats</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">來自 %2 則聊天的 %1 則訊息</translation>
-    </message>
-    <message>
-        <source>%1 message(s) from %2</source>
-        <extracomment>e.g. 2 messages from Bob</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">來自 %2 的 %1 訊息</translation>
     </message>
     <message>
         <source>Failed to send file &quot;%1&quot;</source>


### PR DESCRIPTION
With this change, events will notify using distinct categories. 

Incoming calls use `call.incoming`
Friend and conference messages use `im.received`
Friend requests and group invites use the generic `im`
File transfer requests use the generic `transfer`

Since call notifications used the same exact code paths as friend message notifications, I had to change some logic in the  newFriendMessageAlert function. It uses the notification body (`text`) being empty to determine that it is an incoming call.

Solves #424

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/427)
<!-- Reviewable:end -->
