### PR TITLE
fix(Clipboard): Improve "copy link to clipboard" on Linux.

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -645,7 +645,11 @@ void GenericChatForm::quoteSelectedText()
 void GenericChatForm::copyLink()
 {
     QString linkText = copyLinkAction->data().toString();
-    QApplication::clipboard()->setText(linkText);
+    auto* clipboard = QApplication::clipboard();
+    clipboard->setText(linkText, QClipboard::Clipboard);
+    if (clipboard->supportsSelection()) {
+        clipboard->setText(linkText, QClipboard::Selection);
+    }
 }
 
 void GenericChatForm::searchFormShow()


### PR DESCRIPTION
We now also put the link into the selection clipboard in addition to the `ctrl+v` clipboard. This is the middle-click-to-paste clipboard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/440)
<!-- Reviewable:end -->
