### PR TITLE
feat(Chat): Allow user to control chat log chunk size.

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -191,7 +191,6 @@ void Settings::loadGlobal()
         separateWindow = s.value("separateWindow", false).toBool();
         dontGroupWindows = s.value("dontGroupWindows", false).toBool();
         showIdenticons = s.value("showIdenticons", true).toBool();
-        imagePreview = s.value("imagePreview", true).toBool();
 
         const QString DEFAULT_SMILEYS = ":/smileys/EmojiOne/emoticons.xml";
         smileyPack = s.value("smileyPack", DEFAULT_SMILEYS).toString();
@@ -231,6 +230,9 @@ void Settings::loadGlobal()
                 style = "None";
         }
         nameColors = s.value("nameColors", false).toBool();
+        imagePreview = s.value("imagePreview", true).toBool();
+        chatMaxWindowSize = s.value("chatMaxWindowSize", 100).toInt();
+        chatWindowChunkSize = s.value("chatWindowChunkSize", 50).toInt();
     });
 
     inGroup(s, "Chat", [this, &s] {
@@ -661,7 +663,6 @@ void Settings::saveGlobal()
         s.setValue("dontGroupWindows", dontGroupWindows);
         s.setValue("conferencePosition", conferencePosition);
         s.setValue("showIdenticons", showIdenticons);
-        s.setValue("imagePreview", imagePreview);
 
         s.setValue("smileyPack", smileyPack);
         s.setValue("emojiFontPointSize", emojiFontPointSize);
@@ -676,6 +677,10 @@ void Settings::saveGlobal()
         s.setValue("themeColor", themeColor);
         s.setValue("style", style);
         s.setValue("nameColors", nameColors);
+        s.setValue("imagePreview", imagePreview);
+        s.setValue("chatMaxWindowSize", chatMaxWindowSize);
+        s.setValue("chatWindowChunkSize", chatWindowChunkSize);
+
         s.setValue("statusChangeNotificationEnabled", statusChangeNotificationEnabled);
         s.setValue("showConferenceJoinLeaveMessages", showConferenceJoinLeaveMessages);
         s.setValue("spellCheckingEnabled", spellCheckingEnabled);
@@ -2019,19 +2024,6 @@ void Settings::setShowIdenticons(bool value)
     }
 }
 
-bool Settings::getImagePreview() const
-{
-    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
-    return imagePreview;
-}
-
-void Settings::setImagePreview(bool newValue)
-{
-    if (setVal(imagePreview, newValue)) {
-        emit imagePreviewChanged(newValue);
-    }
-}
-
 int Settings::getCircleCount() const
 {
     const QMutexLocker<QRecursiveMutex> locker{&bigLock};
@@ -2190,6 +2182,45 @@ void Settings::setEnableConferencesColor(bool state)
 bool Settings::getEnableConferencesColor() const
 {
     return nameColors;
+}
+
+bool Settings::getImagePreview() const
+{
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    return imagePreview;
+}
+
+void Settings::setImagePreview(bool newValue)
+{
+    if (setVal(imagePreview, newValue)) {
+        emit imagePreviewChanged(newValue);
+    }
+}
+
+int Settings::getChatMaxWindowSize() const
+{
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    return chatMaxWindowSize;
+}
+
+void Settings::setChatMaxWindowSize(int value)
+{
+    if (setVal(chatMaxWindowSize, value)) {
+        emit chatMaxWindowSizeChanged(value);
+    }
+}
+
+int Settings::getChatWindowChunkSize() const
+{
+    const QMutexLocker<QRecursiveMutex> locker{&bigLock};
+    return chatWindowChunkSize;
+}
+
+void Settings::setChatWindowChunkSize(int value)
+{
+    if (setVal(chatWindowChunkSize, value)) {
+        emit chatWindowChunkSizeChanged(value);
+    }
 }
 
 /**

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -191,7 +191,6 @@ signals:
 
     // GUI
     void autoLoginChanged(bool enabled);
-    void nameColorsChanged(bool enabled);
     void separateWindowChanged(bool enabled);
     void showSystemTrayChanged(bool enabled);
     bool minimizeOnCloseChanged(bool enabled);
@@ -206,7 +205,10 @@ signals:
     void compactLayoutChanged(bool enabled);
     void sortingModeChanged(FriendListSortingMode mode);
     void showIdenticonsChanged(bool enabled);
+    void nameColorsChanged(bool enabled);
     void imagePreviewChanged(bool enabled);
+    void chatMaxWindowSizeChanged(int max);
+    void chatWindowChunkSizeChanged(int chunk);
 
     // ChatView
     void useEmoticonsChanged(bool enabled);
@@ -527,6 +529,14 @@ public:
     bool getImagePreview() const;
     void setImagePreview(bool newValue);
 
+    // Maximum number of rendered messages at any given time
+    int getChatMaxWindowSize() const;
+    void setChatMaxWindowSize(int value);
+
+    // Amount of messages to purge when removing messages
+    int getChatWindowChunkSize() const;
+    void setChatWindowChunkSize(int value);
+
     bool getAutoLogin() const;
     void setEnableConferencesColor(bool state);
     bool getEnableConferencesColor() const;
@@ -604,12 +614,14 @@ private:
     bool desktopNotify;
     bool notifySystemBackend;
     bool showWindow;
-    bool imagePreview;
     bool notifySound;
     bool notifyHide;
     bool busySound;
     bool conferenceAlwaysNotify;
     bool nameColors;
+    bool imagePreview;
+    int chatMaxWindowSize;
+    int chatWindowChunkSize;
 
     bool forceTCP;
     bool enableLanDiscovery;

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -75,6 +75,9 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
     bodyUI->notifySystemBackend->setEnabled(settings.getNotify() && settings.getDesktopNotify());
 
     bodyUI->showWindow->setChecked(settings.getShowWindow());
+
+    bodyUI->chatLogMaxTxt->setValue(settings.getChatMaxWindowSize());
+    bodyUI->chatLogChunkTxt->setValue(settings.getChatWindowChunkSize());
     bodyUI->cbImagePreview->setChecked(settings.getImagePreview());
 
     bodyUI->cbConferencePosition->setChecked(settings.getConferencePosition());
@@ -297,11 +300,6 @@ void UserInterfaceForm::on_showWindow_stateChanged()
     settings.setShowWindow(bodyUI->showWindow->isChecked());
 }
 
-void UserInterfaceForm::on_cbImagePreview_stateChanged()
-{
-    settings.setImagePreview(bodyUI->cbImagePreview->isChecked());
-}
-
 void UserInterfaceForm::on_conferenceOnlyNotifyWhenMentioned_stateChanged()
 {
     // Note: UI is boolean inverted from settings to maintain setting file backwards compatibility
@@ -394,4 +392,21 @@ void UserInterfaceForm::on_useNameColors_stateChanged(int value)
 void UserInterfaceForm::on_notifyHide_stateChanged(int value)
 {
     settings.setNotifyHide(value != 0);
+}
+
+void UserInterfaceForm::on_cbImagePreview_stateChanged()
+{
+    settings.setImagePreview(bodyUI->cbImagePreview->isChecked());
+}
+
+void UserInterfaceForm::on_chatLogChunkTxt_valueChanged(int value)
+{
+    settings.setChatWindowChunkSize(value);
+}
+
+void UserInterfaceForm::on_chatLogMaxTxt_valueChanged(int value)
+{
+    // Chunk size should not be very close to the maximum size.
+    bodyUI->chatLogChunkTxt->setMaximum(value - 20);
+    settings.setChatMaxWindowSize(value);
 }

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -44,7 +44,6 @@ private slots:
     void on_notifyHide_stateChanged(int value);
     void on_busySound_stateChanged();
     void on_showWindow_stateChanged();
-    void on_cbImagePreview_stateChanged();
     void on_conferenceOnlyNotifyWhenMentioned_stateChanged();
     void on_cbCompactLayout_stateChanged();
     void on_cbSeparateWindow_stateChanged();
@@ -55,6 +54,9 @@ private slots:
     void on_txtChatFont_currentFontChanged(const QFont& f);
     void on_txtChatFontSize_valueChanged(int px);
     void on_useNameColors_stateChanged(int value);
+    void on_cbImagePreview_stateChanged();
+    void on_chatLogMaxTxt_valueChanged(int value);
+    void on_chatLogChunkTxt_valueChanged(int value);
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -40,7 +40,7 @@
         <x>0</x>
         <y>0</y>
         <width>664</width>
-        <height>1079</height>
+        <height>993</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0,0">
@@ -69,7 +69,7 @@
            <number>9</number>
           </property>
           <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
+           <widget class="QLabel" name="lblChatFont">
             <property name="text">
              <string>Base font:</string>
             </property>
@@ -164,6 +164,70 @@ Hide formatting characters:
            <widget class="QCheckBox" name="useNameColors">
             <property name="text">
              <string>Use colored nicknames in conferences</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QCheckBox" name="cbImagePreview">
+            <property name="toolTip">
+             <string comment="tooltip for Image preview setting">Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</string>
+            </property>
+            <property name="text">
+             <string>Image preview</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="chatLogMaxLbl">
+              <property name="toolTip">
+               <string>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</string>
+              </property>
+              <property name="text">
+               <string>Maximum chat log view size</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="chatLogMaxTxt">
+              <property name="minimum">
+               <number>50</number>
+              </property>
+              <property name="maximum">
+               <number>500</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="chatLogChunkLbl">
+              <property name="toolTip">
+               <string>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</string>
+              </property>
+              <property name="text">
+               <string>Chat log chunk size</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="chatLogChunkTxt">
+              <property name="minimum">
+               <number>20</number>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Chat log:</string>
             </property>
            </widget>
           </item>
@@ -274,16 +338,6 @@ Hide formatting characters:
             </property>
             <property name="text">
              <string>Open window</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbImagePreview">
-            <property name="toolTip">
-             <string comment="tooltip for Image preview setting">Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</string>
-            </property>
-            <property name="text">
-             <string>Image preview</string>
             </property>
            </widget>
           </item>

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -3194,6 +3194,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">معاينة الصورة</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">الحد الأقصى لعدد الرسائل (لكل محادثة) التي تم تحميلها من سجل الدردشة. قم
+بتقليل هذا لتحسين الأداء. قد يؤدي الرقم المنخفض جدًا هنا إلى اختفاء شريط
+التمرير.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">الحد الأقصى لحجم عرض سجل
+الدردشة</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">عدد الرسائل التي سيتم تحميلها من سجل الدردشة عند التمرير. قد يؤدي الرقم
+المنخفض جدًا هنا إلى اختفاء شريط التمرير.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">حجم قطعة سجل
+الدردشة</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">سجل
+الدردشة:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -3106,6 +3106,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Папярэдні прагляд выявы</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максімальная колькасць паведамленняў (за размову), загружаных з гісторыі
+чатаў. Паменшыце гэта, каб палепшыць прадукцыйнасць. Занадта нізкая лічба
+можа прывесці да знікнення паласы пракруткі.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максімальны памер прагляду
+журнала чата</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Колькасць паведамленняў для загрузкі з гісторыі чата пры прагортцы.
+Занадта нізкая лічба можа прывесці да знікнення паласы пракруткі.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Памер блока журнала
+чата</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Журнал
+чата:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -3568,6 +3568,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵜⵓⴳⵏⴰ</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⴰⵎⴹⴰⵏ ⴰⵄⵍⴰⵢⴰⵏ ⵏ ⵢⵉⵣⴻⵏ (ⵉ ⵢⴰⵍ ⴰⵎⵙⴰⵡⴰⵍ) ⵢⴻⵜⵜⵡⴰⵛⴰⵔⴳⴻⵏ ⵙⴻⴳ ⵓⵎⴻⵣⵔⵓⵢ ⵏ
+ⵜⵎⴻⵙⵍⵉⵡⵜ. ⵙⵏⴻⵇⵙ ⴰⵢⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⵍⵀⵓⴹ ⴰⵅⴻⴷⴷⵉⵎ. ⴰⵎⴹⴰⵏ ⴷ ⴰⵎⴻⵥⵢⴰⵏ ⴰⵟⴰⵙ ⴷⴰⴳⵉ
+ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵙⵙⵉⵡⴻⴹ ⴰⴷ ⵢⴻⴼⴼⴻⵖ ⵓⴹⵔⵉⵙ ⵏ ⵓⵙⵎⴻⵍ.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ ⵜⴰⵎⴻⵇⵇⵔⴰⵏⵜ ⵏ ⵓⵎⵓⵖ
+ⵏ ⵓⵖⵎⵉⵙ ⵏ ⵓⵎⴻⵙⵍⴰⵢ</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⴰⵎⴹⴰⵏ ⵏ ⵢⵉⵣⴻⵏ ⴰⵔⴰ ⵜⵉⴷⵜⴻⵙⵙⵓⴼⵖⴻⴹ ⵙⴻⴳ ⵓⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵎⵉ ⴰⵔⴰ ⵜⵉⴷⵜⴻⵙⵙⵓⴼⵖⴻⴹ.
+ⴰⵎⴹⴰⵏ ⴷ ⴰⵎⴻⵥⵢⴰⵏ ⴰⵟⴰⵙ ⴷⴰⴳⵉ ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵙⵙⵉⵡⴻⴹ ⴰⴷ ⵢⴻⴼⴼⴻⵖ ⵓⴹⵔⵉⵙ ⵏ ⵓⵙⵎⴻⵍ.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ ⵏ ⵓⵃⵔⵉⵛ ⵏ
+ⵓⵖⵎⵉⵙ ⵏ ⵓⵎⴻⵙⵍⴰⵢ</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⴰⵖⵎⵉⵙ ⵏ
+ⵓⵎⴻⵙⵍⴰⵢ:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -3005,6 +3005,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Визуализация на изображението</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимален брой съобщения (на разговор), заредени от хронологията на
+чата. Намалете това, за да подобрите производителността. Твърде малък
+брой тук може да доведе до изчезване на лентата за превъртане.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимален размер на
+изгледа на журнала за чат</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Брой съобщения за зареждане от историята на чата при превъртане. Твърде
+малък брой тук може да доведе до изчезване на лентата за превъртане.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Размер на част от
+дневника на чата</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Дневник
+на чата:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -3630,6 +3630,37 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ছবির পূর্বরূপ</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">চ্যাটের ইতিহাস থেকে সর্বাধিক সংখ্যক বার্তা (প্রতি কথোপকথন) লোড করা
+হয়েছে। কর্মক্ষমতা উন্নত করতে এটি হ্রাস করুন। এখানে খুব কম সংখ্যার কারণে
+স্ক্রোল বার অদৃশ্য হয়ে যেতে পারে।</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">সর্বোচ্চ চ্যাট লগ ভিউ সাইজ</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">স্ক্রল করার সময় চ্যাটের ইতিহাস থেকে লোড করা বার্তার সংখ্যা। এখানে খুব কম
+সংখ্যার কারণে স্ক্রোল বার অদৃশ্য হয়ে যেতে পারে।</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">চ্যাট লগ খণ্ড আকার</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">চ্যাট লগ:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -3030,6 +3030,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Náhled obrázku</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximální počet zpráv (na konverzaci) načtených z historie chatu. Snižte
+toto pro zlepšení výkonu. Příliš nízké číslo zde může způsobit zmizení
+posuvníku.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximální velikost
+zobrazení protokolu chatu</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Počet zpráv, které se mají načíst z historie chatu při posouvání. Příliš
+nízké číslo zde může způsobit zmizení posuvníku.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Velikost bloku
+protokolu chatu</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Protokol
+chatu:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -3432,6 +3432,39 @@ Skjul formateringstegn:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Billedforhåndsvisning</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalt antal beskeder (pr. samtale) indlæst fra chathistorik. Reducer
+dette for at forbedre ydeevnen. Et for lavt tal her kan få rullebjælken
+til at forsvinde.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimal
+chatlogvisningsstørrelse</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Antal beskeder, der skal indlæses fra chathistorikken, når du ruller. Et
+for lavt tal her kan få rullebjælken til at forsvinde.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chat log chunk
+størrelse</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chatlog:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -3000,6 +3000,39 @@ Formatierungszeichen ausblenden:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Bildvorschau</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale Anzahl von Nachrichten (pro Konversation), die aus dem
+Chatverlauf geladen werden. Verringern Sie diesen Wert, um die Leistung
+zu verbessern. Eine zu niedrige Zahl kann dazu führen, dass die
+Bildlaufleiste verschwindet.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale Größe der Chat-Protokollansicht</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Anzahl der Nachrichten, die beim Scrollen aus dem Chatverlauf geladen
+werden sollen. Eine zu niedrige Zahl kann dazu führen, dass die
+Bildlaufleiste verschwindet.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Blockgröße des Chat-Protokolls</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chatprotokoll:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -3138,6 +3138,44 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Προεπισκόπηση εικόνας</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μέγιστος αριθμός μηνυμάτων (ανά συνομιλία) που φορτώθηκαν από το ιστορικό
+συνομιλιών. Μειώστε το για να βελτιώσετε την απόδοση. Ένας πολύ χαμηλός
+αριθμός εδώ μπορεί να προκαλέσει την εξαφάνιση της γραμμής κύλισης.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μέγιστο μέγεθος προβολής
+αρχείου καταγραφής
+συνομιλίας</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Αριθμός μηνυμάτων προς φόρτωση από το ιστορικό συνομιλιών κατά την κύλιση.
+Ένας πολύ χαμηλός αριθμός εδώ μπορεί να προκαλέσει την εξαφάνιση της
+γραμμής κύλισης.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μέγεθος κομματιού
+αρχείου καταγραφής
+συνομιλίας</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ημερολόγι
+ο συνομιλ
+ίας:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -3438,6 +3438,40 @@ Kaŝi formatajn signojn:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Bilda Antaŭrigardo</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimuma nombro da mesaĝoj (po konversacio) ŝargita de babilhistorio.
+Malpliigu ĉi tion por plibonigi rendimenton. Tro malalta nombro ĉi tie
+povas malaperi la rulumbreton.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimuma babilregistra
+vidogrando</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nombro da mesaĝoj por ŝargi el la babilhistorio dum rulumado. Tro malalta
+nombro ĉi tie povas malaperi la rulumbreton.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Grandeco de peceto
+de babilejo</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Babilprot
+okolo:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -2994,6 +2994,44 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Vista previa de imagen</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de mensajes (por conversación) cargados desde el historial
+de chat. Disminuya esto para mejorar el rendimiento. Un número demasiado
+bajo aquí puede hacer que desaparezca la barra de desplazamiento.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamaño máximo de
+visualización del registro
+de chat</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número de mensajes a cargar desde el historial de chat al desplazarse. Un
+número demasiado bajo aquí puede hacer que desaparezca la barra de
+desplazamiento.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamaño del
+fragmento del
+registro de chat</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Registro
+de conver
+saciones:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -3027,6 +3027,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pildi eelvaade</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vestlusajaloost laaditud maksimaalne sõnumite arv (vestluse kohta).
+Toimivuse parandamiseks vähendage seda. Liiga väike arv võib põhjustada
+kerimisriba kadumise.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimaalne vestluslogi
+vaate suurus</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kerimisel vestlusajaloost laaditavate sõnumite arv. Liiga väike arv võib
+põhjustada kerimisriba kadumise.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vestluslogi tükki
+suurus</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vestluse
+logi:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -3092,6 +3092,39 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">پیش نمایش تصویر</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">حداکثر تعداد پیام (در هر مکالمه) بارگیری شده از تاریخچه چت. برای بهبود
+عملکرد، این را کاهش دهید. یک عدد خیلی کم در اینجا ممکن است باعث ناپدید
+شدن نوار پیمایش شود.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">حداکثر اندازه نمایش گزارش
+چت</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">تعداد پیام‌هایی که هنگام پیمایش از تاریخچه چت بارگیری می‌شوند. یک عدد خیلی
+کم در اینجا ممکن است باعث ناپدید شدن نوار پیمایش شود.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">اندازه قطعه گزارش
+چت</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">گزارش چت:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -3025,6 +3025,39 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Kuvan esikatselu</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chat-historiasta ladattujen viestien enimmäismäärä (keskustelua kohden).
+Vähennä tätä tehokkuuden parantamiseksi. Liian pieni luku saattaa
+aiheuttaa vierityspalkin katoamisen.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Keskustelulokin näkymän
+enimmäiskoko</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chat-historiasta ladattavien viestien määrä vierittäessä. Liian pieni luku
+saattaa aiheuttaa vierityspalkin katoamisen.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chat-lokipalan koko</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chat-
+loki:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -3004,6 +3004,45 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aperçu de l&apos;image</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nombre maximum de messages (par conversation) chargés à partir de
+l&apos;historique des discussions. Diminuez-le pour améliorer les
+performances. Un nombre trop faible ici peut entraîner la disparition de
+la barre de défilement.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Taille maximale
+d&apos;affichage du journal de
+discussion</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nombre de messages à charger à partir de l&apos;historique des discussions lors
+du défilement. Un nombre trop faible ici peut entraîner la disparition de
+la barre de défilement.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Taille du segment
+du journal de
+discussion</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Journal
+de discus
+sion&#xa0;:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -3094,6 +3094,42 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Vista previa da imaxe</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de mensaxes (por conversa) cargadas do historial de chat.
+Diminúe isto para mellorar o rendemento. Un número demasiado baixo aquí
+pode facer que a barra de desprazamento desapareza.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamaño máximo de
+visualización do rexistro
+de chat</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número de mensaxes para cargar do historial de chat ao desprazarse. Un
+número demasiado baixo aquí pode facer que a barra de desprazamento
+desapareza.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamaño do fragmento
+do rexistro de chat</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Rexistro
+de chat:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -3612,6 +3612,38 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">תצוגה מקדימה של תמונה</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">מספר מקסימלי של הודעות (לכל שיחה) שנטענו מהיסטוריית הצ&apos;אט. הקטן את זה כדי
+לשפר את הביצועים. מספר נמוך מדי כאן עלול לגרום לפס הגלילה להיעלם.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">גודל תצוגת יומן צ&apos;אט
+מקסימלי</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">מספר ההודעות לטעינה מהיסטוריית הצ&apos;אט בעת גלילה. מספר נמוך מדי כאן עלול
+לגרום לפס הגלילה להיעלם.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">גודל נתח יומן צ&apos;אט</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">יומן
+צ&apos;אט:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -3094,6 +3094,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pregled slike</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalan broj poruka (po razgovoru) učitanih iz povijesti razgovora.
+Smanjite ovo za poboljšanje performansi. Premali broj ovdje može
+uzrokovati nestanak trake za pomicanje.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalna veličina
+prikaza dnevnika chata</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Broj poruka za učitavanje iz povijesti razgovora prilikom pomicanja.
+Premali broj ovdje može uzrokovati nestanak trake za pomicanje.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Veličina dijela
+dnevnika razgovora</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dnevnik r
+azgovora:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -3088,6 +3088,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Kép előnézete</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">A csevegési előzményekből betölthető üzenetek maximális száma
+(beszélgetésenként). Csökkentse ezt a teljesítmény javítása érdekében.
+Túl alacsony szám esetén a görgetősáv eltűnhet.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximális csevegési napló
+nézet mérete</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">A görgetéskor a csevegési előzményekből betöltendő üzenetek száma. Túl
+alacsony szám esetén a görgetősáv eltűnhet.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Csevegési
+naplódarab mérete</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Csevegési
+napló:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -3602,6 +3602,40 @@ Fela sniðstafi:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Forskoðun mynd</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Hámarksfjöldi skilaboða (á hvert samtal) hlaðið úr spjallferli. Minnkaðu
+þetta til að bæta árangur. Of lág tala hér getur valdið því að
+skrunstikan hverfur.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Hámarksstærð
+spjallskrárskoðunar</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Fjöldi skeyta til að hlaða úr spjallferlinum þegar skrunað er. Of lág tala
+hér getur valdið því að skrunstikan hverfur.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Stærð
+spjalldagskrár</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Spjallskr
+á:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -3004,6 +3004,44 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Anteprima dell&apos;immagine</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numero massimo di messaggi (per conversazione) caricati dalla cronologia
+chat. Diminuirlo per migliorare le prestazioni. Un numero troppo basso
+potrebbe far scomparire la barra di scorrimento.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dimensione massima della
+visualizzazione del
+registro della chat</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numero di messaggi da caricare dalla cronologia chat durante lo
+scorrimento. Un numero troppo basso potrebbe far scomparire la barra di
+scorrimento.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dimensioni del
+blocco del registro
+della chat</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Registro
+della
+chat:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -3152,6 +3152,35 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>画像プレビュー</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">チャット履歴からロードされるメッセージ (会話あたり)
+の最大数。パフォーマンスを向上させるには、これを減らします。ここの数値が小さすぎると、スクロール バーが消えてしまう可能性があります。</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">チャットログの最大表示サイズ</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">スクロール時にチャット履歴から読み込むメッセージの数。ここの数値が小さすぎると、スクロール バーが消えてしまう可能性があります。</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">チャットログのチャンクサイズ</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">チャットログ:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -3584,6 +3584,37 @@ e.g. &quot;**text**&quot; will show as &quot;text&quot;, bold.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">pixra vitke</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">so&apos;i notci pe&apos;a fe lo nuncasnu
+ko jdika lo nu xamgu lo nunselpla dukse cmalu vi ka&apos;e rinka lo nu
+lo rokci bajra ku canci</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ni&apos;o ni&apos;o ni&apos;o ni&apos;o ni&apos;o sei casnu be lo xokau casnu</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">loi notci poi jai se cpedu fai lo nu cfagau fi lo nu casnu citri dukse cmalu
+lo nu vi cmima cu rinka lo nu lo rokci bajra cu canci</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ni&apos;o ni&apos;o ni&apos;o ni&apos;o ni&apos;o ni&apos;o ni&apos;o sei casnu be lo xotli cukta</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">fi&apos;o casnu log:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -3617,6 +3617,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಚಿತ್ರ ಪೂರ್ವವೀಕ್ಷಣೆ</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಚಾಟ್ ಇತಿಹಾಸದಿಂದ ಗರಿಷ್ಠ ಸಂಖ್ಯೆಯ ಸಂದೇಶಗಳನ್ನು (ಪ್ರತಿ ಸಂಭಾಷಣೆಗೆ) ಲೋಡ್
+ಮಾಡಲಾಗಿದೆ. ಕಾರ್ಯಕ್ಷಮತೆಯನ್ನು ಸುಧಾರಿಸಲು ಇದನ್ನು ಕಡಿಮೆ ಮಾಡಿ. ಇಲ್ಲಿ ತುಂಬಾ
+ಕಡಿಮೆ ಸಂಖ್ಯೆಯು ಸ್ಕ್ರಾಲ್ ಬಾರ್ ಕಣ್ಮರೆಯಾಗಲು ಕಾರಣವಾಗಬಹುದು.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಗರಿಷ್ಠ ಚಾಟ್ ಲಾಗ್ ವೀಕ್ಷಣೆ
+ಗಾತ್ರ</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಸ್ಕ್ರೋಲಿಂಗ್ ಮಾಡುವಾಗ ಚಾಟ್ ಇತಿಹಾಸದಿಂದ ಲೋಡ್ ಮಾಡಬೇಕಾದ ಸಂದೇಶಗಳ ಸಂಖ್ಯೆ. ಇಲ್ಲಿ
+ತುಂಬಾ ಕಡಿಮೆ ಸಂಖ್ಯೆಯು ಸ್ಕ್ರಾಲ್ ಬಾರ್ ಕಣ್ಮರೆಯಾಗಲು ಕಾರಣವಾಗಬಹುದು.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಚಾಟ್ ಲಾಗ್ ಚಂಕ್
+ಗಾತ್ರ</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಚಾಟ್
+ಲಾಗ್:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -3451,6 +3451,35 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">이미지 미리보기</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">채팅 기록에서 로드된 최대 메시지 수(대화당)입니다. 성능을 향상시키려면 이 값을 줄이세요. 숫자가 너무 낮으면 스크롤 막대가
+사라질 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">최대 채팅 로그 보기 크기</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">스크롤할 때 채팅 기록에서 로드할 메시지 수입니다. 숫자가 너무 낮으면 스크롤 막대가 사라질 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">채팅 로그 청크 크기</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">채팅 로그:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -3641,6 +3641,40 @@ Opmaakteikens verberge:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aafbeeldingveurbeeld</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximum aantal boodsjappe (per gesprek) gelaoje oet de chatgesjiedenis.
+Verminder dit um de prestaties te verbetere. ‘n Te lieg getal hei kin de
+scrollbalk verdwijne.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale
+chatlogweergavegrootte</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Aontal boodsjappe die motte were gelaoje oet de chatgesjiedenis bij ‘t
+scrolle. ‘n Te lieg getal hei kin de scrollbalk verdwijne.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Grootte vaan de
+stukke vaan ‘t
+chatlogboek</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chatlog:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -3031,6 +3031,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Vaizdo peržiūra</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Didžiausias pranešimų skaičius (vienam pokalbiui), įkeltas iš pokalbių
+istorijos. Sumažinkite tai, kad pagerintumėte našumą. Dėl per mažo
+skaičiaus slinkties juosta gali išnykti.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalus pokalbių
+žurnalo peržiūros dydis</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pranešimų, kuriuos reikia įkelti iš pokalbių istorijos slenkant, skaičius.
+Dėl per mažo skaičiaus slinkties juosta gali išnykti.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pokalbių žurnalo
+gabalo dydis</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pokalbių
+žurnalas:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -3107,6 +3107,41 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Attēla priekšskatījums</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimālais ziņojumu skaits (vienā sarunā), kas ielādēts no tērzēšanas
+vēstures. Samaziniet to, lai uzlabotu veiktspēju. Pārāk mazs skaitlis var
+izraisīt ritjoslas pazušanu.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimālais tērzēšanas
+žurnāla skata lielums</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ritināšanas laikā no tērzēšanas vēstures ielādējamo ziņojumu skaits. Pārāk
+mazs skaitlis var izraisīt ritjoslas pazušanu.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tērzēšanas žurnāla
+gabala lielums</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tērzēšana
+s
+žurnāls:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -3150,6 +3150,43 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Преглед на слика</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимален број пораки (по разговор) вчитани од историјата на разговор.
+Намалете го ова за да ги подобрите перформансите. Премалиот број овде
+може да предизвика исчезнување на лентата за лизгање.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална големина на
+приказ на дневникот за
+разговор</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Број на пораки што треба да се вчитаат од историјата на разговор при
+лизгање. Премалиот број овде може да предизвика исчезнување на лентата за
+лизгање.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Големина на парче
+дневник на разговор</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Дневник
+на разгов
+ори:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -3009,6 +3009,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Forhåndsvisning av bilde</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalt antall meldinger (per samtale) lastet inn fra chatteloggen.
+Reduser dette for å forbedre ytelsen. Et for lavt tall her kan føre til
+at rullefeltet forsvinner.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimal
+chatloggvisningsstørrelse</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Antall meldinger som skal lastes fra chatteloggen når du ruller. Et for
+lavt tall her kan føre til at rullefeltet forsvinner.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chat logg chunk
+størrelse</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chat-
+logg:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -2995,6 +2995,41 @@ Opmaaktekens verbergen:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Afbeeldingsvoorbeeld</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximaal aantal berichten (per gesprek) geladen vanuit de
+chatgeschiedenis. Verlaag dit om de prestaties te verbeteren. Een te laag
+getal hier kan ervoor zorgen dat de schuifbalk verdwijnt.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale weergavegrootte
+van chatlogboek</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Aantal berichten dat moet worden geladen uit de chatgeschiedenis tijdens
+het scrollen. Een te laag getal hier kan ervoor zorgen dat de schuifbalk
+verdwijnt.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Grootte van het
+chatlogboek</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chatlogbo
+ek:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -2967,6 +2967,29 @@ Hide formatting characters:
         <source>Image preview</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -3039,6 +3039,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Podgląd obrazu</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksymalna liczba wiadomości (na rozmowę) załadowanych z historii czatów.
+Zmniejsz tę wartość, aby poprawić wydajność. Zbyt mała liczba może
+spowodować zniknięcie paska przewijania.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksymalny rozmiar widoku
+dziennika czatu</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Liczba wiadomości do załadowania z historii czatów podczas przewijania.
+Zbyt mała liczba może spowodować zniknięcie paska przewijania.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Rozmiar fragmentu
+dziennika czatu</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dziennik
+czatu:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -411,7 +411,7 @@ Take heed, fer higher qualities demand clearer skies and use more bandwidth. If 
     <message>
         <source>Tox ID</source>
         <extracomment>Tox ID of the person you&apos;re sending a friend request to</extracomment>
-        <translation type="unfinished">Tox ID</translation>
+        <translation type="unfinished">Seafarer&apos;s Mark</translation>
     </message>
     <message>
         <source>Message</source>
@@ -822,7 +822,7 @@ so ye can stash th&apos; file on Windows.</translation>
     </message>
     <message>
         <source>copy peer ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pick Up Matey&apos;s ID</translation>
     </message>
 </context>
 <context>
@@ -2987,6 +2987,32 @@ Hide formatting characters:
     <message>
         <source>Image preview</source>
         <translation type="unfinished">Glimpse at th&apos; image</translation>
+    </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translation type="unfinished">Most messages (per chat) loaded from th&apos; chat history.
+Lower this ta make it faster. A number too low here may cause th&apos;
+scroll bar ta vanish.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translation type="unfinished">Biggest Message Log Size</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translation type="unfinished">Number o&apos; messages ta load from th&apos; chat history when scrollin&apos;. A number too low
+here may cause th&apos; scroll bar ta vanish.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translation type="unfinished">Th&apos; Message Log:</translation>
     </message>
 </context>
 <context>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -3025,6 +3025,44 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pré-visualização da imagem</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de mensagens (por conversa) carregadas do histórico de
+chat. Diminua isso para melhorar o desempenho. Um número muito baixo aqui
+pode fazer com que a barra de rolagem desapareça.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamanho máximo de
+visualização do registro
+de bate-papo</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número de mensagens a serem carregadas do histórico de bate-papo ao rolar.
+Um número muito baixo aqui pode fazer com que a barra de rolagem
+desapareça.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamanho do bloco de
+registro de bate-
+papo</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Registro
+de bate-
+papo:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -3008,6 +3008,44 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pré-visualização da imagem</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de mensagens (por conversa) carregadas do histórico de
+chat. Diminua isso para melhorar o desempenho. Um número muito baixo aqui
+pode fazer com que a barra de rolagem desapareça.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamanho máximo de
+visualização do registro
+de bate-papo</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número de mensagens a serem carregadas do histórico de bate-papo ao rolar.
+Um número muito baixo aqui pode fazer com que a barra de rolagem
+desapareça.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tamanho do bloco de
+registro de bate-
+papo</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Registro
+de bate-
+papo:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -3003,6 +3003,42 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Previzualizare imagine</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numărul maxim de mesaje (pe conversație) încărcate din istoricul de chat.
+Reduceți acest lucru pentru a îmbunătăți performanța. Un număr prea mic
+aici poate face ca bara de defilare să dispară.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dimensiunea maximă a
+vizualizării jurnalului de
+chat</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numărul de mesaje de încărcat din istoricul de chat la defilare. Un număr
+prea mic aici poate face ca bara de defilare să dispară.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dimensiunea
+blocului de jurnal
+de chat</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Jurnal de
+chat:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -3002,6 +3002,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Предварительный просмотр изображения</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальное количество сообщений (за разговор), загруженных из истории
+чата. Уменьшите это значение, чтобы улучшить производительность. Слишком
+маленькое значение здесь может привести к исчезновению полосы прокрутки.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальный размер
+просмотра журнала чата</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Количество сообщений, загружаемых из истории чата при прокрутке. Слишком
+маленькое значение здесь может привести к исчезновению полосы прокрутки.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Размер фрагмента
+журнала чата</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Журнал
+чата:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -3633,6 +3633,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">රූප පෙරදසුන</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">කතාබස් ඉතිහාසයෙන් පූරණය කරන ලද උපරිම පණිවිඩ ගණන (සංවාදයකට) කාර්ය සාධනය
+වැඩි දියුණු කිරීම සඳහා මෙය අඩු කරන්න. මෙහි ඉතා අඩු සංඛ්‍යාවක් අනුචලන
+තීරුව අතුරුදහන් වීමට හේතු විය හැක.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">උපරිම කතාබස් ලොග් දසුන්
+ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">අනුචලනය කිරීමේදී කතාබස් ඉතිහාසයෙන් පූරණය කළ යුතු පණිවිඩ ගණන. මෙහි ඉතා අඩු
+සංඛ්‍යාවක් අනුචලන තීරුව අතුරුදහන් වීමට හේතු විය හැක.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">කතාබස් ලොග් කුට්ටි
+ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">කතාබස්
+ලොගය:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -3014,6 +3014,41 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ukážka obrázka</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximálny počet správ (na konverzáciu) načítaných z histórie rozhovoru.
+Znížte túto hodnotu, aby ste zlepšili výkon. Príliš nízke číslo môže
+spôsobiť zmiznutie posúvača.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximálna veľkosť
+zobrazenia denníka
+rozhovoru</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Počet správ, ktoré sa majú načítať z histórie rozhovoru pri posúvaní.
+Príliš nízke číslo môže spôsobiť zmiznutie posúvača.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Veľkosť časti
+denníka rozhovoru</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Denník ro
+zhovoru:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -3277,6 +3277,40 @@ Skrij znake za oblikovanje:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Predogled slike</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Največje število sporočil (na pogovor), naloženih iz zgodovine klepetov.
+Zmanjšajte to vrednost, da izboljšate delovanje. Prenizko število tukaj
+lahko povzroči, da drsni trak izgine.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Največja velikost pogleda
+dnevnika klepeta</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Število sporočil, ki se naložijo iz zgodovine klepetov med premikanjem.
+Prenizko število tukaj lahko povzroči, da drsni trak izgine.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Velikost kosa
+dnevnika klepeta</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dnevnik
+klepeta:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -3628,6 +3628,43 @@ Fshih karakteret e formatimit:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pamja paraprake e imazhit</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numri maksimal i mesazheve (për bisedë) të ngarkuar nga historiku i
+bisedës. Uleni këtë për të përmirësuar performancën. Një numër shumë i
+ulët këtu mund të shkaktojë zhdukjen e shiritit të lëvizjes.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Madhësia maksimale e
+pamjes së regjistrit të
+bisedës</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numri i mesazheve për t&apos;u ngarkuar nga historiku i bisedës gjatë lëvizjes.
+Një numër shumë i ulët këtu mund të shkaktojë zhdukjen e shiritit të
+lëvizjes.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Madhësia e pjesës
+së regjistrit të
+bisedës</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ditari i
+bisedës:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -3098,6 +3098,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Преглед слике</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максималан број порука (по конверзацији) учитаних из историје ћаскања.
+Смањите ово да бисте побољшали перформансе. Пренизак број овде може
+довести до нестанка траке за померање.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална величина
+приказа дневника ћаскања</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Број порука за учитавање из историје ћаскања приликом померања. Пренизак
+број овде може довести до нестанка траке за померање.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Величина дела
+дневника ћаскања</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Дневник
+ћаскања:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -2972,6 +2972,29 @@ Hide formatting characters:
         <source>Image preview</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -3038,6 +3038,39 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Bildförhandsgranskning</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximalt antal meddelanden (per konversation) laddade från
+chatthistoriken. Minska detta för att förbättra prestandan. Ett för lågt
+nummer här kan göra att rullningslisten försvinner.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximal visningsstorlek
+för chattlogg</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Antal meddelanden som ska laddas från chatthistoriken när du rullar. Ett
+för lågt nummer här kan göra att rullningslisten försvinner.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chattloggstorlek</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Chattlogg
+:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -3635,6 +3635,41 @@ Ficha vibambo vya uumbizaji:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Onyesho la Kuchungulia Picha</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idadi ya juu zaidi ya ujumbe (kwa kila mazungumzo) iliyopakiwa kutoka
+kwenye historia ya gumzo. Punguza hii ili kuboresha utendaji. Nambari ya
+chini sana hapa inaweza kusababisha upau wa kusogeza kutoweka.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Upeo wa ukubwa wa
+mwonekano wa logi</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idadi ya ujumbe wa kupakia kutoka kwa historia ya gumzo wakati wa
+kusogeza. Nambari ya chini sana hapa inaweza kusababisha upau wa kusogeza
+kutoweka.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ukubwa wa logi ya
+gumzo</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">logi ya
+gumzo:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -3382,6 +3382,41 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">பட முன்னோட்டம்</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">அரட்டை வரலாற்றில் இருந்து ஏற்றப்பட்ட செய்திகளின் அதிகபட்ச எண்ணிக்கை (ஒரு
+உரையாடலுக்கு). செயல்திறனை மேம்படுத்த இதை குறைக்கவும். இங்கு மிகக் குறைந்த
+எண் இருந்தால், ஸ்க்ரோல் பார் காணாமல் போகலாம்.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">அதிகபட்ச அரட்டை பதிவு
+காட்சி அளவு</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ஸ்க்ரோலிங் செய்யும் போது அரட்டை வரலாற்றில் இருந்து ஏற்ற வேண்டிய
+செய்திகளின் எண்ணிக்கை. இங்கு மிகக் குறைந்த எண் இருந்தால், ஸ்க்ரோல் பார்
+காணாமல் போகலாம்.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">அரட்டை பதிவு துண்டு
+அளவு</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">அரட்டை
+பதிவு:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -3004,6 +3004,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Resim Önizleme</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sohbet geçmişinden yüklenen maksimum mesaj sayısı (konuşma başına).
+Performansı artırmak için bunu azaltın. Burada çok düşük bir sayı
+kaydırma çubuğunun kaybolmasına neden olabilir.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimum sohbet günlüğü
+görüntüleme boyutu</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kaydırırken sohbet geçmişinden yüklenecek mesaj sayısı. Burada çok düşük
+bir sayı kaydırma çubuğunun kaybolmasına neden olabilir.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sohbet günlüğü
+yığın boyutu</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sohbet
+günlüğü:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -3146,6 +3146,40 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">رەسىم ئالدىن كۆرۈش</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">پاراڭلىشىش تارىخىدىن يۈكلەنگەن ئەڭ كۆپ ئۇچۇر (ھەر بىر سۆھبەت). ئىقتىدارنى
+ياخشىلاش ئۈچۈن بۇنى ئازايتىڭ. بۇ يەردىكى بەك ئاز سان سىيرىلما تاياقچە
+يوقاپ كېتىشى مۇمكىن.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ئەڭ چوڭ پاراڭ خاتىرىسىنى
+كۆرۈش چوڭلۇقى</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">دومىلىغاندا پاراڭلىشىش تارىخىدىن يۈكلىنىدىغان ئۇچۇرلارنىڭ سانى. بۇ يەردىكى
+بەك ئاز سان سىيرىلما تاياقچە يوقاپ كېتىشى مۇمكىن.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">پاراڭ خاتىرىسىنىڭ
+چوڭ-كىچىكلىكى</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">پاراڭ
+خاتىرىسى:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -3008,6 +3008,41 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Попередній перегляд зображення</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальна кількість повідомлень (на розмову), завантажених з історії
+чату. Зменште це значення, щоб покращити продуктивність. Занадто низьке
+значення може спричинити зникнення смуги прокрутки.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальний розмір
+перегляду журналу чату</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Кількість повідомлень для завантаження з історії чату під час
+прокручування. Занадто низьке значення може спричинити зникнення смуги
+прокрутки.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Розмір блоку
+журналу чату</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Журнал
+чату:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -3609,6 +3609,38 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">تصویری پیش نظارہ</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">پیغامات کی زیادہ سے زیادہ تعداد (فی گفتگو) چیٹ کی سرگزشت سے لوڈ کی گئی
+ہے۔ کارکردگی کو بہتر بنانے کے لیے اسے کم کریں۔ یہاں بہت کم تعداد اسکرول
+بار کے غائب ہونے کا سبب بن سکتی ہے۔</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">زیادہ سے زیادہ چیٹ لاگ
+دیکھنے کا سائز</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">اسکرول کرتے وقت چیٹ کی سرگزشت سے لوڈ ہونے والے پیغامات کی تعداد۔ یہاں بہت
+کم تعداد اسکرول بار کے غائب ہونے کا سبب بن سکتی ہے۔</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">چیٹ لاگ حصہ کا سائز</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">چیٹ لاگ:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -3006,6 +3006,41 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Xem trước hình ảnh</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Số tin nhắn tối đa (mỗi cuộc hội thoại) được tải từ lịch sử trò chuyện.
+Giảm điều này để cải thiện hiệu suất. Con số quá thấp ở đây có thể khiến
+thanh cuộn biến mất.</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kích thước xem nhật ký trò
+chuyện tối đa</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Số lượng tin nhắn cần tải từ lịch sử trò chuyện khi cuộn. Con số quá thấp
+ở đây có thể khiến thanh cuộn biến mất.</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kích thước đoạn
+nhật ký trò chuyện</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nhật ký
+trò
+chuyện:</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2991,6 +2991,34 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">图像预览</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">从聊天历史记录加载的最大消息数（每个对话）。减少此值以提高性能。这里的数字太低可能会导致滚动条消失。</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">最大聊天日志视图大小</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">滚动时从聊天历史记录加载的消息数。这里的数字太低可能会导致滚动条消失。</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">聊天日志块大小</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">聊天记录：</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -3497,6 +3497,34 @@ Hide formatting characters:
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">圖像預覽</translation>
     </message>
+    <message>
+        <source>Maximum number of messages (per conversation) loaded from chat history.
+Decrease this to improve performance. A too low number here may cause the
+scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">從聊天歷史記錄載入的最大訊息數（每個對話）。減少此值以提高效能。這裡的數字太低可能會導致滾動條消失。</translation>
+    </message>
+    <message>
+        <source>Maximum chat log view size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">最大聊天日誌視圖大小</translation>
+    </message>
+    <message>
+        <source>Number of messages to load from the chat history when scrolling. A too low
+number here may cause the scroll bar to disappear.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">滾動時從聊天歷史記錄載入的訊息數。這裡的數字太低可能會導致滾動條消失。</translation>
+    </message>
+    <message>
+        <source>Chat log chunk size</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">聊天日誌塊大小</translation>
+    </message>
+    <message>
+        <source>Chat log:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">聊天記錄：</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>


### PR DESCRIPTION
Also decreased default chat log size by 3x. There's no need to have such large numbers of loaded chat history. 50/20 is a good number that works for me. I've set the defaults a bit higher in case users have really tiny fonts and large windows. Now, performance of resizing the window is acceptable to me.

<img width="531" alt="image" src="https://github.com/user-attachments/assets/872aeb27-f955-4ed3-bc23-50b6f8714d95" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/447)
<!-- Reviewable:end -->
