### PR TITLE
feat(About): Show update available in nightly builds.

### DIFF
--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -32,6 +32,13 @@ struct Version
     int patch;
 };
 
+QDebug& operator<<(QDebug& stream, const Version& version)
+{
+    stream.noquote()
+        << QStringLiteral("v%1.%2.%3").arg(version.major).arg(version.minor).arg(version.patch);
+    return stream.quote();
+}
+
 Version tagToVersion(const QString& tagName)
 {
     // capture tag name to avoid showing update available on dev builds which include hash as part of describe
@@ -150,17 +157,16 @@ void UpdateCheck::handleResponse(QNetworkReply* reply)
         qWarning() << "Currently running an untested/unstable version of qTox";
         emit versionIsUnstable();
         reply->deleteLater();
-        return;
     }
 
     const auto currentVer = tagToVersion(VersionInfo::gitDescribe());
     const auto availableVer = tagToVersion(latestVersion);
 
     if (isUpdateAvailable(currentVer, availableVer)) {
-        qInfo() << "Update available to version" << latestVersion;
+        qInfo() << "Update available from version" << currentVer << "to" << availableVer;
         emit updateAvailable(latestVersion, link);
     } else {
-        qInfo() << "qTox is up to date";
+        qInfo() << "qTox is up to date:" << currentVer;
         emit upToDate();
     }
 

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -165,7 +165,6 @@ void AboutForm::reloadTheme()
 
 void AboutForm::onUnstableVersion()
 {
-    bodyUI->updateStack->hide();
     bodyUI->unstableVersion->setVisible(true);
 }
 


### PR DESCRIPTION
When users run nightly builds, we still want to tell them when their nightly build has become older than the newest production release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/452)
<!-- Reviewable:end -->
