### PR TITLE
chore: Add emojis to the issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: 🐞 Bug Report
 description: File a bug report.
 title: "[Bug]: "
 labels: ["bug"]

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: 🚀 Feature Request
 description: File a feature request.
 title: "[FR]: "
 labels: ["enhancement"]


### PR DESCRIPTION
GitHub UI says you can add issue types. "type:" doesn't work. I don't know how to do it then.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/464)
<!-- Reviewable:end -->
