### PR TITLE
cleanup: Enable most clang-tidy readability checks.

### DIFF
--- a/.ci-scripts/build-qtox-linux.sh
+++ b/.ci-scripts/build-qtox-linux.sh
@@ -131,6 +131,7 @@ ccache --show-stats
 
 if [ ! -z "${TIDY+x}" ]; then
   if [ ! -z "${TIDY_FIX+x}" ]; then
+    clang-tidy -list-checks
     run-clang-tidy -quiet -fix -format -p "$BUILD_DIR" \
       -exclude-header-filter '/usr/.*' \
       audio/include/ \

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,13 +15,21 @@ Checks: "-*
 , modernize-use-nullptr
 , modernize-use-override
 , performance-move-const-arg
-, readability-container-*
-, readability-else-after-return
-, readability-implicit-bool-conversion
-, readability-isolate-declaration
-, readability-make-member-function-const
-, readability-named-parameter
-, readability-inconsistent-declaration-parameter-name
+, readability-*
+, -readability-avoid-return-with-void-value
+, -readability-braces-around-statements
+, -readability-convert-member-functions-to-static
+, -readability-function-cognitive-complexity
+, -readability-identifier-length
+, -readability-magic-numbers
+, -readability-math-missing-parentheses
+, -readability-redundant-access-specifiers
+, -readability-redundant-member-init
+, -readability-simplify-boolean-expr
+, -readability-suspicious-call-argument
 "
 WarningsAsErrors: "*"
 HeaderFilterRegex: ".*"
+CheckOptions:
+  - key:   readability-uppercase-literal-suffix.NewSuffixes
+    value: f;d;u;L;Lu;LLu;uL;uLL

--- a/audio/include/audio/iaudiosink.h
+++ b/audio/include/audio/iaudiosink.h
@@ -64,7 +64,7 @@ public:
         CallEnd
     };
 
-    inline static QString getSound(Sound s)
+    static QString getSound(Sound s)
     {
         switch (s) {
         case Sound::Test:

--- a/audio/src/backend/openal.h
+++ b/audio/src/backend/openal.h
@@ -106,7 +106,7 @@ private:
     virtual bool initInput(const QString& deviceName);
     virtual bool initOutput(const QString& deviceName);
 
-    void cleanupBuffers(uint sourceId);
+    static void cleanupBuffers(uint sourceId);
     void cleanupSound();
 
     qreal getVolume();

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -251,7 +251,7 @@ int AppManager::startGui(QCommandLineParser& parser)
 
     // Windows platform plugins DLL hell fix
     QCoreApplication::addLibraryPath(QCoreApplication::applicationDirPath());
-    qapp->addLibraryPath("platforms");
+    QApplication::addLibraryPath("platforms");
 
     qDebug() << "Commit:" << VersionInfo::gitVersion();
     qDebug() << "Process ID:" << QCoreApplication::applicationPid();
@@ -381,14 +381,14 @@ int AppManager::run()
             });
     PosixSignalNotifier::watchUsrSignals();
 
-    qapp->setApplicationName("qTox");
-    qapp->setDesktopFileName("io.github.qtox.qTox");
-    qapp->setApplicationVersion(QStringLiteral("%1, git commit %2 (%3)")
-                                    .arg(VersionInfo::gitDescribe())
-                                    .arg(VersionInfo::gitVersion())
-                                    .arg(UpdateCheck::isCurrentVersionStable()
-                                             ? QStringLiteral("stable")
-                                             : QStringLiteral("unstable")));
+    QApplication::setApplicationName("qTox");
+    QApplication::setDesktopFileName("io.github.qtox.qTox");
+    QApplication::setApplicationVersion(QStringLiteral("%1, git commit %2 (%3)")
+                                            .arg(VersionInfo::gitDescribe())
+                                            .arg(VersionInfo::gitVersion())
+                                            .arg(UpdateCheck::isCurrentVersionStable()
+                                                     ? QStringLiteral("stable")
+                                                     : QStringLiteral("unstable")));
 
     // Install Unicode 6.1 supporting font
     // Keep this as close to the beginning of `main()` as possible, otherwise
@@ -437,13 +437,13 @@ int AppManager::run()
         updateCheck->checkForUpdate();
         connect(updateCheck, &UpdateCheck::updateCheckFailed, qapp.get(), &QApplication::quit);
         connect(updateCheck, &UpdateCheck::complete, this,
-                [this](QString currentVersion, QString latestVersion, const QUrl& link) {
+                [](QString currentVersion, QString latestVersion, const QUrl& link) {
                     const QString message =
                         QStringLiteral("Current version: %1\nLatest version: %2\n%3\n")
                             .arg(currentVersion, latestVersion, link.toString());
                     // Output to stdout.
                     QTextStream(stdout) << message;
-                    qapp->quit();
+                    QApplication::quit();
                 });
     } else {
         const int result = startGui(parser);
@@ -452,7 +452,7 @@ int AppManager::run()
         }
     }
 
-    return qapp->exec();
+    return QApplication::exec();
 }
 
 AppManager::~AppManager() = default;

--- a/src/appmanager.h
+++ b/src/appmanager.h
@@ -34,7 +34,7 @@ private slots:
     void cleanup();
 
 private:
-    void preConstructionInitialization();
+    static void preConstructionInitialization();
     std::unique_ptr<QApplication> qapp;
     std::unique_ptr<MessageBoxManager> messageBoxManager;
     std::unique_ptr<Settings> settings;

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -73,7 +73,7 @@ void renderMessageRaw(const QString& displayName, bool isSelf, bool colorizeName
     // correlate ChatMessages created here, however a logic bug could turn into
     // a crash due to this dangerous cast. The alternative would be to make
     // ChatLine a QObject which I didn't think was worth it.
-    auto chatMessage = static_cast<ChatMessage*>(chatLine.get());
+    auto* chatMessage = static_cast<ChatMessage*>(chatLine.get());
 
     if (chatMessage != nullptr) {
         if (chatLogMessage.state == MessageState::complete) {
@@ -850,7 +850,7 @@ void ChatWidget::handleSearchResult(SearchResult result, SearchDirection directi
         auto msg = (*chatLineStorage)[searchPos.logIdx];
         scrollToLine(msg);
 
-        auto text = qobject_cast<Text*>(msg->getContent(1));
+        auto* text = qobject_cast<Text*>(msg->getContent(1));
         text->selectText(result.exp, std::make_pair(result.start, result.len));
     };
 
@@ -1424,9 +1424,9 @@ void ChatWidget::renderFile(QString displayName, ToxFile file, bool isSelf, QDat
                                                              timestamp, documentCache, settings,
                                                              style, messageBoxManager);
     } else {
-        auto proxy = static_cast<ChatLineContentProxy*>(chatMessage->getContent(1));
+        auto* proxy = static_cast<ChatLineContentProxy*>(chatMessage->getContent(1));
         assert(proxy->getWidgetType() == ChatLineContentProxy::FileTransferWidgetType);
-        auto ftWidget = static_cast<FileTransferWidget*>(proxy->getWidget());
+        auto* ftWidget = static_cast<FileTransferWidget*>(proxy->getWidget());
         ftWidget->onFileTransferUpdate(file);
     }
 }
@@ -1474,7 +1474,7 @@ void ChatWidget::disableSearchText()
     }
 
     auto line = (*chatLineStorage)[searchPos.logIdx];
-    auto text = qobject_cast<Text*>(line->getContent(1));
+    auto* text = qobject_cast<Text*>(line->getContent(1));
     text->deselectText();
 }
 

--- a/src/chatlog/chatwidget.h
+++ b/src/chatlog/chatwidget.h
@@ -129,7 +129,7 @@ protected:
 
 private:
     void retranslateUi();
-    bool isActiveFileTransfer(ChatLine::Ptr l);
+    static bool isActiveFileTransfer(ChatLine::Ptr l);
     void handleMultiClickEvent();
     void moveSelectionRectUpIfSelected(int offset);
     void moveSelectionRectDownIfSelected(int offset);

--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -62,7 +62,7 @@ private:
     static bool tryRemoveFile(const QString& filepath);
 
     void updateWidget(const ToxFile& file);
-    void updateBackgroundColor(const ToxFile::FileStatus status);
+    void updateBackgroundColor(ToxFile::FileStatus status);
 
 private:
     CoreFile& coreFile;

--- a/src/conferencelist.cpp
+++ b/src/conferencelist.cpp
@@ -54,7 +54,7 @@ QList<Conference*> ConferenceList::getAllConferences()
 {
     QList<Conference*> res;
 
-    for (auto it : conferenceList)
+    for (auto* it : conferenceList)
         res.append(it);
 
     return res;
@@ -62,7 +62,7 @@ QList<Conference*> ConferenceList::getAllConferences()
 
 void ConferenceList::clear()
 {
-    for (auto conferenceptr : conferenceList)
+    for (auto* conferenceptr : conferenceList)
         delete conferenceptr;
     conferenceList.clear();
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -538,7 +538,7 @@ void Core::onConferenceMessage(Tox* tox, uint32_t conferenceId, uint32_t peerId,
 void Core::onConferencePeerListChange(Tox* tox, uint32_t conferenceId, void* vCore)
 {
     std::ignore = tox;
-    const auto core = static_cast<Core*>(vCore);
+    auto* const core = static_cast<Core*>(vCore);
     qDebug("Conference %u peerlist changed", conferenceId);
     // no saveRequest, this callback is called on every connection to conference peer, not just on brand new peers
     emit core->conferencePeerlistChanged(conferenceId);
@@ -1316,7 +1316,7 @@ QString Core::getFriendUsername(uint32_t friendNumber) const
     return ToxString(nameBuf.data(), nameSize).getQString();
 }
 
-uint64_t Core::getMaxMessageSize() const
+uint64_t Core::getMaxMessageSize()
 {
     /*
      * TODO: Remove this hack; the reported max message length we receive from c-toxcore

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -68,7 +68,7 @@ public:
     ~Core() override;
 
     static const QString TOX_EXT;
-    uint64_t getMaxMessageSize() const;
+    static uint64_t getMaxMessageSize();
     QString getPeerName(const ToxPk& id) const;
     QVector<uint32_t> getFriendList() const;
     ConferenceId getConferencePersistentId(uint32_t conferenceNumber) const override;
@@ -161,7 +161,7 @@ signals:
     void friendRemoved(uint32_t friendId);
     void friendLastSeenChanged(uint32_t friendId, const QDateTime& dateTime);
 
-    void emptyConferenceCreated(uint32_t conferencenumber, const ConferenceId conferenceId,
+    void emptyConferenceCreated(uint32_t conferencenumber, ConferenceId conferenceId,
                                 const QString& title = QString());
     void conferenceInviteReceived(const ConferenceInvite& inviteInfo);
     void conferenceMessageReceived(uint32_t conferencenumber, uint32_t peernumber,

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -887,7 +887,7 @@ void CoreAV::videoFrameCallback(ToxAV* toxAV, uint32_t friendNum, uint16_t w, ui
                                 int32_t yStride, int32_t uStride, int32_t vStride, void* vSelf)
 {
     std::ignore = toxAV;
-    auto self = static_cast<CoreAV*>(vSelf);
+    auto* self = static_cast<CoreAV*>(vSelf);
     // This callback should come from the CoreAV thread
     assert(QThread::currentThread() == self->coreAvThread.get());
     const QReadLocker locker{&self->callsLock};

--- a/src/friendlist.cpp
+++ b/src/friendlist.cpp
@@ -55,7 +55,7 @@ void FriendList::removeFriend(const ToxPk& friendPk, Settings& settings, bool fa
 
 void FriendList::clear()
 {
-    for (auto friendPtr : friendList)
+    for (auto* friendPtr : friendList)
         delete friendPtr;
     friendList.clear();
 }

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -33,7 +33,7 @@ const char* getCurUsername()
 
 QString getIpcKey()
 {
-    auto* user = getCurUsername();
+    const auto* user = getCurUsername();
     if (user == nullptr) {
         qWarning() << "Failed to get current username. Will use a global IPC.";
         user = "";

--- a/src/model/about/aboutfriend.h
+++ b/src/model/about/aboutfriend.h
@@ -21,7 +21,7 @@ class AboutFriend : public QObject, public IAboutFriend
     Q_OBJECT
 
 public:
-    AboutFriend(const Friend* f_, IFriendSettings* const settings, Profile& profile);
+    AboutFriend(const Friend* f_, IFriendSettings* settings, Profile& profile);
 
     QString getName() const override;
     QString getStatusMessage() const override;

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -255,7 +255,7 @@ void ChatHistory::onFileTransferBrokenUnbroken(const ToxPk& sender, const ToxFil
 void ChatHistory::onMessageReceived(const ToxPk& sender, const Message& message)
 {
     if (canUseHistory()) {
-        auto& chatId = chat.getPersistentId();
+        const auto& chatId = chat.getPersistentId();
         auto displayName = chat.getDisplayedName(sender);
         auto content = message.content;
         if (message.isAction) {
@@ -272,7 +272,7 @@ void ChatHistory::onMessageSent(DispatchedMessageId id, const Message& message)
 {
     if (canUseHistory()) {
         auto selfPk = coreIdHandler.getSelfPublicKey();
-        auto& chatId = chat.getPersistentId();
+        const auto& chatId = chat.getPersistentId();
 
         auto content = message.content;
         if (message.isAction) {

--- a/src/model/chatroom/conferenceroom.cpp
+++ b/src/model/chatroom/conferenceroom.cpp
@@ -63,20 +63,20 @@ void ConferenceRoom::inviteFriend(const ToxPk& pk)
 bool ConferenceRoom::possibleToOpenInNewWindow() const
 {
     const auto conferenceId = conference->getPersistentId();
-    const auto dialogs = dialogsManager->getConferenceDialogs(conferenceId);
+    auto* const dialogs = dialogsManager->getConferenceDialogs(conferenceId);
     return (dialogs == nullptr) || dialogs->chatroomCount() > 1;
 }
 
 bool ConferenceRoom::canBeRemovedFromWindow() const
 {
     const auto conferenceId = conference->getPersistentId();
-    const auto dialogs = dialogsManager->getConferenceDialogs(conferenceId);
+    auto* const dialogs = dialogsManager->getConferenceDialogs(conferenceId);
     return (dialogs != nullptr) && dialogs->hasChat(conferenceId);
 }
 
 void ConferenceRoom::removeConferenceFromDialogs()
 {
     const auto conferenceId = conference->getPersistentId();
-    auto dialogs = dialogsManager->getConferenceDialogs(conferenceId);
+    auto* dialogs = dialogsManager->getConferenceDialogs(conferenceId);
     dialogs->removeConference(conferenceId);
 }

--- a/src/model/chatroom/friendchatroom.cpp
+++ b/src/model/chatroom/friendchatroom.cpp
@@ -113,7 +113,7 @@ void FriendChatroom::inviteFriend(const Conference* conference)
 QVector<ConferenceToDisplay> FriendChatroom::getConferences() const
 {
     QVector<ConferenceToDisplay> conferences;
-    for (const auto conference : conferenceList.getAllConferences()) {
+    for (auto* const conference : conferenceList.getAllConferences()) {
         const auto name = getShortName(conference->getName());
         const ConferenceToDisplay conferenceToDisplay = {name, conference};
         conferences.push_back(conferenceToDisplay);
@@ -157,27 +157,27 @@ void FriendChatroom::resetEventFlags()
 bool FriendChatroom::possibleToOpenInNewWindow() const
 {
     const auto friendPk = frnd->getPublicKey();
-    const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
+    auto* const dialogs = dialogsManager->getFriendDialogs(friendPk);
     return (dialogs == nullptr) || dialogs->chatroomCount() > 1;
 }
 
 bool FriendChatroom::canBeRemovedFromWindow() const
 {
     const auto friendPk = frnd->getPublicKey();
-    const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
+    auto* const dialogs = dialogsManager->getFriendDialogs(friendPk);
     return (dialogs != nullptr) && dialogs->hasChat(friendPk);
 }
 
 bool FriendChatroom::friendCanBeRemoved() const
 {
     const auto friendPk = frnd->getPublicKey();
-    const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
+    auto* const dialogs = dialogsManager->getFriendDialogs(friendPk);
     return (dialogs == nullptr) || !dialogs->hasChat(friendPk);
 }
 
 void FriendChatroom::removeFriendFromDialogs()
 {
     const auto friendPk = frnd->getPublicKey();
-    auto dialogs = dialogsManager->getFriendDialogs(friendPk);
+    auto* dialogs = dialogsManager->getFriendDialogs(friendPk);
     dialogs->removeFriend(friendPk);
 }

--- a/src/model/conference.h
+++ b/src/model/conference.h
@@ -23,7 +23,7 @@ class Conference : public Chat
 {
     Q_OBJECT
 public:
-    Conference(int conferenceId_, const ConferenceId persistentConferenceId, QString name,
+    Conference(int conferenceId_, ConferenceId persistentConferenceId, QString name,
                bool isAvConference, QString selfName_, ICoreConferenceQuery& conferenceQuery_,
                ICoreIdHandler& idHandler_, FriendList& friendList);
     bool isAvConference() const;
@@ -40,7 +40,7 @@ public:
     void setMentionedFlag(bool f);
     bool getMentionedFlag() const;
 
-    void updateUsername(ToxPk pk, const QString newName);
+    void updateUsername(ToxPk pk, QString newName);
     void setName(const QString& newTitle) override;
     void setTitle(const QString& author, const QString& newTitle);
     QString getName() const;

--- a/src/model/debug/debugobjecttreemodel.cpp
+++ b/src/model/debug/debugobjecttreemodel.cpp
@@ -17,7 +17,7 @@ public:
         return int(children.size());
     }
 
-    int columnCount() const
+    static int columnCount()
     {
         return 3;
     }
@@ -115,7 +115,7 @@ QModelIndex DebugObjectTreeModel::index(int row, int column, const QModelIndex& 
     TreeItem* parentItem =
         parent.isValid() ? static_cast<TreeItem*>(parent.internalPointer()) : root_.get();
 
-    if (auto* childItem = parentItem->child(row))
+    if (const auto* childItem = parentItem->child(row))
         return createIndex(row, column, childItem);
     return {};
 }
@@ -145,8 +145,8 @@ int DebugObjectTreeModel::rowCount(const QModelIndex& parent) const
 int DebugObjectTreeModel::columnCount(const QModelIndex& parent) const
 {
     if (parent.isValid())
-        return static_cast<TreeItem*>(parent.internalPointer())->columnCount();
-    return root_->columnCount();
+        return DebugObjectTreeModel::TreeItem::columnCount();
+    return DebugObjectTreeModel::TreeItem::columnCount();
 }
 
 QVariant DebugObjectTreeModel::data(const QModelIndex& index, int role) const

--- a/src/model/exiftransform.cpp
+++ b/src/model/exiftransform.cpp
@@ -12,7 +12,7 @@
 namespace ExifTransform {
 Orientation getOrientation(QByteArray imageData)
 {
-    auto data = imageData.constData();
+    const auto* data = imageData.constData();
     auto size = imageData.size();
 
     ExifData* exifData = exif_data_new_from_data(reinterpret_cast<const unsigned char*>(data), size);

--- a/src/model/friendlist/friendlistmanager.h
+++ b/src/model/friendlist/friendlistmanager.h
@@ -53,7 +53,7 @@ private:
 
     void removeAll(IFriendListItem* item);
     bool cmpByName(const IFriendListItemPtr& itemA, const IFriendListItemPtr& itemB) const;
-    bool cmpByActivity(const IFriendListItemPtr& itemA, const IFriendListItemPtr& itemB);
+    static bool cmpByActivity(const IFriendListItemPtr& itemA, const IFriendListItemPtr& itemB);
 
     bool byName = true;
     bool hideCircles = false;

--- a/src/model/profile/profileinfo.h
+++ b/src/model/profile/profileinfo.h
@@ -51,8 +51,8 @@ public:
 
 private:
     IProfileInfo::SetAvatarResult createAvatarFromFile(QFile& file, QByteArray& avatar);
-    IProfileInfo::SetAvatarResult byteArrayToPng(QByteArray inData, QByteArray& outPng);
-    IProfileInfo::SetAvatarResult scalePngToAvatar(QByteArray& avatar);
+    static IProfileInfo::SetAvatarResult byteArrayToPng(QByteArray inData, QByteArray& outPng);
+    static IProfileInfo::SetAvatarResult scalePngToAvatar(QByteArray& avatar);
     Profile* const profile;
     Core* const core;
     Settings& settings;

--- a/src/net/bootstrapnodeupdater.cpp
+++ b/src/net/bootstrapnodeupdater.cpp
@@ -113,7 +113,6 @@ void jsonNodeToDhtServer(const QJsonObject& node, QList<DhtServer>& outList)
     server.ipv4 = ipv4_address;
     server.ipv6 = ipv6_address;
     outList.append(server);
-    return;
 }
 
 QList<DhtServer> jsonToNodeList(const QJsonDocument& nodeList)

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -24,7 +24,7 @@ public:
 
     explicit UpdateCheck(const Settings& settings_, QObject* parent = nullptr);
 
-    constexpr bool canCheck() const
+    static constexpr bool canCheck()
     {
 #ifdef UPDATE_CHECK_ENABLED
         return true;

--- a/src/persistence/db/rawdatabaseimpl.h
+++ b/src/persistence/db/rawdatabaseimpl.h
@@ -36,7 +36,7 @@ class RawDatabaseImpl final : QObject, public RawDatabase
 
 private:
     static void regexp(sqlite3_context* ctx, int argc, sqlite3_value** argv,
-                       const QRegularExpression::PatternOptions cs);
+                       QRegularExpression::PatternOptions cs);
 
     /**
      * @struct Transaction
@@ -109,7 +109,7 @@ protected slots:
 
 private:
     void compileAndExecute(Transaction& trans);
-    QString anonymizeQuery(const QByteArray& query);
+    static QString anonymizeQuery(const QByteArray& query);
     bool openEncryptedDatabaseAtLatestSupportedVersion(const QString& hexKey);
     bool updateSavedCipherParameters(const QString& hexKey, SqlCipherParams newParams);
     bool setCipherParameters(SqlCipherParams params, const QString& database = {});

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -407,7 +407,7 @@ QStringList Profile::getFilesByExt(QString extension, Paths& paths)
  * @brief Scan for profile, automatically importing them if needed.
  * @warning NOT thread-safe.
  */
-const QStringList Profile::getAllProfileNames(Paths& paths)
+QStringList Profile::getAllProfileNames(Paths& paths)
 {
     profiles.clear();
     const QStringList toxFiles = getFilesByExt("tox", paths);

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -64,7 +64,7 @@ public:
 
     bool rename(QString newName);
 
-    static const QStringList getAllProfileNames(Paths& paths);
+    static QStringList getAllProfileNames(Paths& paths);
 
     static QString getProfilePath(const QString& name, const Paths& paths);
     static bool exists(QString name, Paths& paths);

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -374,7 +374,7 @@ bool Settings::verifyProxySettings(const QCommandLineParser& parser)
         // TODO(Kriby): Sanity check IPv4/IPv6 addresses/hostnames?
 
         const int portNumber = proxySettingStrings[2].toInt();
-        if (!(portNumber >= 1 && portNumber <= 65535)) {
+        if (portNumber < 1 || portNumber > 65535) {
             qCritical() << "Invalid port number range: was" << portNumber << "but should be 1-65535.";
         }
     }

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -140,10 +140,8 @@ void SettingsSerializer::beginWriteArray(const QString& prefix, int size)
         if (size > 0)
             index->size = std::max(index->size, size);
     } else {
-        if (size < 0)
-            size = 0;
         array = arrays.size();
-        arrays.push_back({group, size, prefix, {}});
+        arrays.push_back({group, std::max(size, 0), prefix, {}});
         arrayIndex = -1;
     }
 }
@@ -483,8 +481,7 @@ void SettingsSerializer::readIni()
                 continue;
             groupsToKill.append(g);
 
-            if (groupArrayIndex > a.size)
-                a.size = groupArrayIndex;
+            a.size = std::max(a.size, groupArrayIndex);
 
             // Associate the values for this array index
             for (int vi = values.size() - 1; vi >= 0; vi--) {

--- a/src/persistence/settingsserializer.h
+++ b/src/persistence/settingsserializer.h
@@ -84,7 +84,7 @@ private:
     void readIni();
     void removeValue(const QString& key);
     void removeGroup(int group);
-    void writePackedVariant(QDataStream& dataStream, const QVariant& v);
+    static void writePackedVariant(QDataStream& dataStream, const QVariant& v);
 
 private:
     QString path;

--- a/src/persistence/toxsave.cpp
+++ b/src/persistence/toxsave.cpp
@@ -30,7 +30,7 @@ ToxSave::~ToxSave()
 
 bool ToxSave::toxSaveEventHandler(const QByteArray& eventData, void* userData)
 {
-    auto toxSave = static_cast<ToxSave*>(userData);
+    auto* toxSave = static_cast<ToxSave*>(userData);
 
     if (!eventData.endsWith(".tox")) {
         return false;

--- a/src/platform/posixsignalnotifier.cpp
+++ b/src/platform/posixsignalnotifier.cpp
@@ -56,7 +56,7 @@ constexpr std::initializer_list<int> usrSignals{SIGUSR1, SIGUSR2};
 constexpr std::initializer_list<int> crashSignals{SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGBUS, SIGSYS};
 
 // Give it 128 KiB, should be enough for what we're doing in the crash handler.
-static uint8_t alternate_stack[128 * 1024];
+uint8_t alternate_stack[128 * 1024];
 
 void installCrashHandler()
 {

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -19,10 +19,8 @@ extern "C"
 
 #include "src/persistence/settings.h"
 
-#include <QDebug>
 #include <QMutex>
 #include <QMutexLocker>
-#include <QScreen>
 #include <QVector>
 
 #include <utility>

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -141,7 +141,7 @@ private:
     class FrameBufferKey
     {
     public:
-        FrameBufferKey(const int width, const int height, const int pixFmt, const bool lineAligned);
+        FrameBufferKey(int width, int height, int pixFmt, bool lineAligned);
 
         // Explicitly state default constructor/destructor
 
@@ -175,13 +175,12 @@ private:
     };
 
 private:
-    static FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt, const int linesize);
-    static FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt,
-                                      const bool frameAligned);
+    static FrameBufferKey getFrameKey(const QSize& frameSize, int pixFmt, int linesize);
+    static FrameBufferKey getFrameKey(const QSize& frameSize, int pixFmt, bool frameAligned);
 
-    AVFrame* retrieveAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned);
-    AVFrame* generateAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned);
-    AVFrame* storeAVFrame(AVFrame* frame, const QSize& dimensions, const int pixelFormat);
+    AVFrame* retrieveAVFrame(const QSize& dimensions, int pixelFormat, bool requireAligned);
+    AVFrame* generateAVFrame(const QSize& dimensions, int pixelFormat, bool requireAligned);
+    AVFrame* storeAVFrame(AVFrame* frame, const QSize& dimensions, int pixelFormat);
 
     void deleteFrameBuffer();
 

--- a/src/widget/categorywidget.h
+++ b/src/widget/categorywidget.h
@@ -49,7 +49,7 @@ protected:
     void setContainerAttribute(Qt::WidgetAttribute attribute, bool enabled);
     QLayout* friendOnlineLayout() const;
     QLayout* friendOfflineLayout() const;
-    void emitChatroomWidget(QLayout* layout, int index);
+    static void emitChatroomWidget(QLayout* layout, int index);
 
 private:
     virtual void onSetName() {}

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -97,7 +97,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
             FriendListWidget* friendListWidget = static_cast<FriendListWidget*>(parentWidget());
             moveFriendWidgets(friendListWidget);
 
-            friendListWidget->removeCircleWidget(this);
+            FriendListWidget::removeCircleWidget(this);
 
             const int replacedCircle = settings.removeCircle(id);
 

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -145,9 +145,9 @@ void ContentDialog::closeEvent(QCloseEvent* event)
 FriendWidget* ContentDialog::addFriend(std::shared_ptr<FriendChatroom> chatroom, GenericChatForm* form)
 {
     const auto compact = settings.getCompactLayout();
-    auto frnd = chatroom->getFriend();
+    auto* frnd = chatroom->getFriend();
     const auto& friendPk = frnd->getPublicKey();
-    auto friendWidget =
+    auto* friendWidget =
         new FriendWidget(chatroom, compact, settings, style, messageBoxManager, profile);
     emit connectFriendWidget(*friendWidget);
     chatWidgets[friendPk] = friendWidget;
@@ -168,10 +168,10 @@ FriendWidget* ContentDialog::addFriend(std::shared_ptr<FriendChatroom> chatroom,
 ConferenceWidget* ContentDialog::addConference(std::shared_ptr<ConferenceRoom> chatroom,
                                                GenericChatForm* form)
 {
-    const auto g = chatroom->getConference();
+    auto* const g = chatroom->getConference();
     const auto& conferenceId = g->getPersistentId();
     const auto compact = settings.getCompactLayout();
-    auto conferenceWidget = new ConferenceWidget(chatroom, compact, settings, style);
+    auto* conferenceWidget = new ConferenceWidget(chatroom, compact, settings, style);
     chatWidgets[conferenceId] = conferenceWidget;
     conferenceLayout.addSortedWidget(conferenceWidget);
     chatForms[conferenceId] = form;
@@ -186,7 +186,7 @@ ConferenceWidget* ContentDialog::addConference(std::shared_ptr<ConferenceRoom> c
 
 void ContentDialog::removeFriend(const ToxPk& friendPk)
 {
-    auto chatroomWidget = qobject_cast<FriendWidget*>(chatWidgets[friendPk]);
+    auto* chatroomWidget = qobject_cast<FriendWidget*>(chatWidgets[friendPk]);
     disconnect(chatroomWidget->getFriend(), &Friend::aliasChanged, this,
                &ContentDialog::updateFriendWidget);
 
@@ -215,7 +215,7 @@ void ContentDialog::removeFriend(const ToxPk& friendPk)
 
 void ContentDialog::removeConference(const ConferenceId& conferenceId)
 {
-    auto chatroomWidget = qobject_cast<ConferenceWidget*>(chatWidgets[conferenceId]);
+    auto* chatroomWidget = qobject_cast<ConferenceWidget*>(chatWidgets[conferenceId]);
     // Need to find replacement to show here instead.
     if (activeChatroomWidget == chatroomWidget) {
         cycleChats(true, false);
@@ -597,13 +597,13 @@ void ContentDialog::activate(GenericChatroomWidget* widget)
 
 void ContentDialog::updateFriendStatus(const ToxPk& friendPk, Status::Status status)
 {
-    auto widget = qobject_cast<FriendWidget*>(chatWidgets.value(friendPk));
+    auto* widget = qobject_cast<FriendWidget*>(chatWidgets.value(friendPk));
     addFriendWidget(widget, status);
 }
 
 void ContentDialog::updateChatStatusLight(const ChatId& chatId)
 {
-    auto widget = chatWidgets.value(chatId);
+    auto* widget = chatWidgets.value(chatId);
     if (widget != nullptr) {
         widget->updateStatusLight();
     }
@@ -611,7 +611,7 @@ void ContentDialog::updateChatStatusLight(const ChatId& chatId)
 
 bool ContentDialog::isChatActive(const ChatId& chatId) const
 {
-    auto widget = chatWidgets.value(chatId);
+    auto* widget = chatWidgets.value(chatId);
     if (widget == nullptr) {
         return false;
     }
@@ -622,7 +622,7 @@ bool ContentDialog::isChatActive(const ChatId& chatId) const
 // TODO: Connect to widget directly
 void ContentDialog::setStatusMessage(const ToxPk& friendPk, const QString& message)
 {
-    auto widget = chatWidgets.value(friendPk);
+    auto* widget = chatWidgets.value(friendPk);
     if (widget != nullptr) {
         widget->setStatusMsg(message);
     }

--- a/src/widget/contentdialogmanager.cpp
+++ b/src/widget/contentdialogmanager.cpp
@@ -38,7 +38,7 @@ ContentDialog* ContentDialogManager::current()
 
 bool ContentDialogManager::chatWidgetExists(const ChatId& chatId)
 {
-    const auto dialog = chatDialogs.value(chatId, nullptr);
+    auto* const dialog = chatDialogs.value(chatId, nullptr);
     if (dialog == nullptr) {
         return false;
     }
@@ -50,7 +50,7 @@ FriendWidget* ContentDialogManager::addFriendToDialog(ContentDialog* dialog,
                                                       std::shared_ptr<FriendChatroom> chatroom,
                                                       GenericChatForm* form)
 {
-    auto friendWidget = dialog->addFriend(chatroom, form);
+    auto* friendWidget = dialog->addFriend(chatroom, form);
     const auto& friendPk = friendWidget->getFriend()->getPublicKey();
 
     ContentDialog* lastDialog = getFriendDialog(friendPk);
@@ -66,7 +66,7 @@ ConferenceWidget* ContentDialogManager::addConferenceToDialog(ContentDialog* dia
                                                               std::shared_ptr<ConferenceRoom> chatroom,
                                                               GenericChatForm* form)
 {
-    auto conferenceWidget = dialog->addConference(chatroom, form);
+    auto* conferenceWidget = dialog->addConference(chatroom, form);
     const auto& conferenceId = conferenceWidget->getConference()->getPersistentId();
 
     ContentDialog* lastDialog = getConferenceDialog(conferenceId);
@@ -80,7 +80,7 @@ ConferenceWidget* ContentDialogManager::addConferenceToDialog(ContentDialog* dia
 
 void ContentDialogManager::focusChat(const ChatId& chatId)
 {
-    auto dialog = focusDialog(chatId, chatDialogs);
+    auto* dialog = focusDialog(chatId, chatDialogs);
     if (dialog != nullptr) {
         dialog->focusChat(chatId);
     }
@@ -112,7 +112,7 @@ ContentDialog* ContentDialogManager::focusDialog(
 
 void ContentDialogManager::updateFriendStatus(const ToxPk& friendPk)
 {
-    auto dialog = chatDialogs.value(friendPk);
+    auto* dialog = chatDialogs.value(friendPk);
     if (dialog == nullptr) {
         return;
     }
@@ -128,7 +128,7 @@ void ContentDialogManager::updateFriendStatus(const ToxPk& friendPk)
 
 void ContentDialogManager::updateConferenceStatus(const ConferenceId& conferenceId)
 {
-    auto dialog = chatDialogs.value(conferenceId);
+    auto* dialog = chatDialogs.value(conferenceId);
     if (dialog == nullptr) {
         return;
     }
@@ -141,7 +141,7 @@ void ContentDialogManager::updateConferenceStatus(const ConferenceId& conference
 
 bool ContentDialogManager::isChatActive(const ChatId& chatId)
 {
-    const auto dialog = chatDialogs.value(chatId);
+    auto* const dialog = chatDialogs.value(chatId);
     if (dialog == nullptr) {
         return false;
     }

--- a/src/widget/contentdialogmanager.h
+++ b/src/widget/contentdialogmanager.h
@@ -47,8 +47,9 @@ private slots:
     void onDialogActivate();
 
 private:
-    ContentDialog* focusDialog(const ChatId& id,
-                               const QHash<std::reference_wrapper<const ChatId>, ContentDialog*>& list);
+    static ContentDialog*
+    focusDialog(const ChatId& id,
+                const QHash<std::reference_wrapper<const ChatId>, ContentDialog*>& list);
 
     ContentDialog* currentDialog = nullptr;
 

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -68,8 +68,8 @@ private:
     void retranslateUi();
     void addFriendRequestWidget(const QString& friendAddress_, const QString& message_);
     void removeFriendRequestWidget(QWidget* friendWidget);
-    void retranslateAcceptButton(QPushButton* acceptButton);
-    void retranslateRejectButton(QPushButton* rejectButton);
+    static void retranslateAcceptButton(QPushButton* acceptButton);
+    static void retranslateRejectButton(QPushButton* rejectButton);
     void deleteFriendRequest(const ToxId& toxId_);
     void setIdFromClipboard();
     QString getMessage() const;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -79,18 +79,18 @@ QString secondsToDHMS(quint32 duration)
 
     // I assume no one will ever have call longer than a month
     if (days != 0u) {
-        return cD + res.asprintf("%dd%02dh %02dm %02ds", days, hours, minutes, seconds);
+        return cD + QString::asprintf("%dd%02dh %02dm %02ds", days, hours, minutes, seconds);
     }
 
     if (hours != 0u) {
-        return cD + res.asprintf("%02dh %02dm %02ds", hours, minutes, seconds);
+        return cD + QString::asprintf("%02dh %02dm %02ds", hours, minutes, seconds);
     }
 
     if (minutes != 0u) {
-        return cD + res.asprintf("%02dm %02ds", minutes, seconds);
+        return cD + QString::asprintf("%02dm %02ds", minutes, seconds);
     }
 
-    return cD + res.asprintf("%02ds", seconds);
+    return cD + QString::asprintf("%02ds", seconds);
 }
 } // namespace
 

--- a/src/widget/form/conferenceinvitewidget.cpp
+++ b/src/widget/form/conferenceinvitewidget.cpp
@@ -63,7 +63,7 @@ void ConferenceInviteWidget::retranslateUi()
  * @brief Returns infomation about invitation - e.g., who and when sent
  * @return Invite information object
  */
-const ConferenceInvite ConferenceInviteWidget::getInviteInfo() const
+ConferenceInvite ConferenceInviteWidget::getInviteInfo() const
 {
     return inviteInfo;
 }

--- a/src/widget/form/conferenceinvitewidget.h
+++ b/src/widget/form/conferenceinvitewidget.h
@@ -22,7 +22,7 @@ class ConferenceInviteWidget : public QWidget
 public:
     ConferenceInviteWidget(QWidget* parent, ConferenceInvite invite, Settings& settings, Core& core);
     void retranslateUi();
-    const ConferenceInvite getInviteInfo() const;
+    ConferenceInvite getInviteInfo() const;
 
 signals:
     void accepted(const ConferenceInvite& invite);

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -260,7 +260,7 @@ QVariant Model::data(const QModelIndex& index, int role) const
     case Column::fileName:
         return files[row].fileName;
     case Column::contact: {
-        auto f = friendList.findFriend(friendList.id2Key(files[row].friendId));
+        auto* f = friendList.findFriend(friendList.id2Key(files[row].friendId));
         if (f == nullptr) {
             qWarning("Invalid friend for file transfer");
             return "Unknown";
@@ -374,7 +374,7 @@ bool Delegate::editorEvent(QEvent* event, QAbstractItemModel* model,
 {
     if (toFileTransferListColumn(index.column()) == Column::control) {
         if (event->type() == QEvent::MouseButtonPress) {
-            auto mouseEvent = reinterpret_cast<QMouseEvent*>(event);
+            auto* mouseEvent = reinterpret_cast<QMouseEvent*>(event);
             const auto pos = mouseEvent->pos();
             const auto posRect = pauseRect(option);
             const auto stRect = stopRect(option);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -516,7 +516,7 @@ void GenericChatForm::addSystemInfoMessage(const QDateTime& datetime, SystemMess
     chatLog.addSystemMessage(systemMessage);
 }
 
-QDateTime GenericChatForm::getTime(const ChatLine::Ptr& chatLine) const
+QDateTime GenericChatForm::getTime(const ChatLine::Ptr& chatLine)
 {
     if (chatLine) {
         Timestamp* const timestamp = qobject_cast<Timestamp*>(chatLine->getContent(2));
@@ -584,7 +584,7 @@ bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
     if (object != fileButton && object != fileFlyout)
         return false;
 
-    auto wObject = qobject_cast<QWidget*>(object);
+    auto* wObject = qobject_cast<QWidget*>(object);
     if ((wObject == nullptr) || !wObject->isEnabled())
         return false;
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -106,7 +106,7 @@ protected slots:
 
 private:
     void retranslateUi();
-    QDateTime getTime(const ChatLine::Ptr& chatLine) const;
+    static QDateTime getTime(const ChatLine::Ptr& chatLine);
 
 protected:
     void adjustFileMenuPosition();

--- a/src/widget/form/searchsettingsform.h
+++ b/src/widget/form/searchsettingsform.h
@@ -34,15 +34,15 @@ private:
     Style& style;
 
     void updateStartDateLabel();
-    void setUpdate(const bool isUpdate_);
+    void setUpdate(bool isUpdate_);
 
 private slots:
-    void onStartSearchSelected(const int index);
-    void onRegisterClicked(const bool checked);
-    void onWordsOnlyClicked(const bool checked);
-    void onRegularClicked(const bool checked);
+    void onStartSearchSelected(int index);
+    void onRegisterClicked(bool checked);
+    void onWordsOnlyClicked(bool checked);
+    void onRegularClicked(bool checked);
     void onChoiceDate();
 
 signals:
-    void updateSettings(const bool isUpdate);
+    void updateSettings(bool isUpdate);
 };

--- a/src/widget/form/setpassworddialog.h
+++ b/src/widget/form/setpassworddialog.h
@@ -20,8 +20,10 @@ public:
     {
         Rejected = QDialog::Rejected,
         Accepted = QDialog::Accepted,
-        Tertiary
+        Tertiary = Accepted + 1,
     };
+    static_assert(Rejected != Accepted && Accepted != Tertiary, "ReturnCode values must be unique");
+
     explicit SetPasswordDialog(QString body_, QString extraButton, QWidget* parent = nullptr);
     ~SetPasswordDialog() override;
     QString getPassword();

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -50,7 +50,7 @@ AboutForm::AboutForm(UpdateCheck& updateCheck_, QString contactInfo_, Style& sty
 {
     bodyUI->setupUi(this);
 
-    bodyUI->updateStack->setVisible(updateCheck.canCheck());
+    bodyUI->updateStack->setVisible(UpdateCheck::canCheck());
     bodyUI->unstableVersion->setVisible(false);
     connect(&updateCheck, &UpdateCheck::versionIsUnstable, this, &AboutForm::onUnstableVersion);
 
@@ -83,7 +83,7 @@ void AboutForm::replaceVersions()
     connect(&updateCheck, &UpdateCheck::upToDate, this, &AboutForm::onUpToDate);
     connect(&updateCheck, &UpdateCheck::updateCheckFailed, this, &AboutForm::onUpdateCheckFailed);
 
-    if (!updateCheck.canCheck()) {
+    if (!UpdateCheck::canCheck()) {
         qDebug() << "AboutForm not showing updates, qTox built without UPDATE_CHECK";
     }
 

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -191,11 +191,7 @@ void AdvancedForm::on_proxyAddr_editingFinished()
 
 void AdvancedForm::on_proxyPort_valueChanged(int port)
 {
-    if (port <= 0) {
-        port = 0;
-    }
-
-    settings.setProxyPort(port);
+    settings.setProxyPort(std::max(port, 0));
 }
 
 void AdvancedForm::on_proxyType_currentIndexChanged(int index)

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -43,7 +43,7 @@ private:
     void getVideoDevices();
 
     static int getModeSize(VideoMode mode);
-    void selectBestModes(QVector<VideoMode>& allVideoModes);
+    static void selectBestModes(QVector<VideoMode>& allVideoModes);
     void fillCameraModesComboBox();
     void fillScreenModesComboBox();
     void fillAudioQualityComboBox();

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -161,12 +161,12 @@ void FriendListWidget::sortByMode()
         QVector<IFriendListItem*> friendItems; // Items that are not included in the circle
         int posByName = 0;                     // Needed for scroll contacts
         // Linking a friend with a circle and setting scroll position
-        for (auto& i : itemsTmp) {
+        for (const auto& i : itemsTmp) {
             if (i->isFriend() && i->getCircleId() >= 0) {
                 CircleWidget* circleWgt = CircleWidget::getFromID(i->getCircleId());
                 if (circleWgt != nullptr) {
                     // Place a friend in the circle and continue
-                    FriendWidget* frndTmp = qobject_cast<FriendWidget*>((i.get())->getWidget());
+                    FriendWidget* frndTmp = qobject_cast<FriendWidget*>((i)->getWidget());
                     circleWgt->addFriendWidget(frndTmp, frndTmp->getFriend()->getStatus());
                     continue;
                 }
@@ -195,7 +195,7 @@ void FriendListWidget::sortByMode()
                 return a->getName().toUpper() < b->getName().toUpper();
             });
 
-            for (auto circle : circles) {
+            for (auto* circle : circles) {
 
                 const QVector<std::shared_ptr<IFriendListItem>> itemsInCircle =
                     getItemsFromCircle(circle);
@@ -236,7 +236,7 @@ void FriendListWidget::sortByMode()
 
         const QVector<std::shared_ptr<IFriendListItem>> itemsTmp = manager->getItems();
 
-        for (auto& i : itemsTmp) {
+        for (const auto& i : itemsTmp) {
             listLayout->addWidget(i->getWidget());
         }
 
@@ -252,12 +252,12 @@ void FriendListWidget::sortByMode()
         manager->applyFilter();
 
         // Insert widgets to CategoryWidget
-        for (auto& i : itemsTmp) {
+        for (const auto& i : itemsTmp) {
             if (i->isFriend()) {
                 const int timeIndex = static_cast<int>(getTimeBucket(i->getLastActivity()));
                 QWidget* widget = activityLayout->itemAt(timeIndex)->widget();
                 CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(widget);
-                FriendWidget* frnd = qobject_cast<FriendWidget*>((i.get())->getWidget());
+                FriendWidget* frnd = qobject_cast<FriendWidget*>((i)->getWidget());
                 if (!isVisible() || (isVisible() && frnd->isVisible())) {
                     categoryWidget->addFriendWidget(frnd, frnd->getFriend()->getStatus());
                 }

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -50,7 +50,7 @@ public:
     void removeFriendWidget(FriendWidget* w);
     void addCircleWidget(int id);
     void addCircleWidget(FriendWidget* widget = nullptr);
-    void removeCircleWidget(CircleWidget* widget);
+    static void removeCircleWidget(CircleWidget* widget);
     void searchChatRooms(const QString& searchString, bool hideOnline = false,
                          bool hideOffline = false, bool hideConferences = false);
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -57,7 +57,7 @@ FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom_, bool compa
     statusPic.setPixmap(QPixmap(Status::getIconPath(Status::Status::Offline)));
     statusPic.setMargin(3);
 
-    auto frnd = chatroom->getFriend();
+    auto* frnd = chatroom->getFriend();
     nameLabel->setText(frnd->getDisplayedName());
     // update alias when edited
     connect(nameLabel, &CroppingLabel::editFinished, frnd, &Friend::setAlias);
@@ -96,12 +96,12 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     QMenu menu;
 
     if (chatroom->possibleToOpenInNewWindow()) {
-        const auto openChatWindow = menu.addAction(tr("Open chat in new window"));
+        auto* const openChatWindow = menu.addAction(tr("Open chat in new window"));
         connect(openChatWindow, &QAction::triggered, this, [this]() { emit newWindowOpened(this); });
     }
 
     if (chatroom->canBeRemovedFromWindow()) {
-        const auto removeChatWindow = menu.addAction(tr("Remove chat from this window"));
+        auto* const removeChatWindow = menu.addAction(tr("Remove chat from this window"));
         connect(removeChatWindow, &QAction::triggered, this, &FriendWidget::removeChatWindow);
     }
 
@@ -109,28 +109,28 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     QMenu* inviteMenu =
         menu.addMenu(tr("Invite to conference", "Menu to invite a friend to a conference"));
     inviteMenu->setEnabled(chatroom->canBeInvited());
-    const auto newConferenceAction = inviteMenu->addAction(tr("To new conference"));
+    auto* const newConferenceAction = inviteMenu->addAction(tr("To new conference"));
     connect(newConferenceAction, &QAction::triggered, chatroom.get(),
             &FriendChatroom::inviteToNewConference);
     inviteMenu->addSeparator();
 
     for (const auto& conference : chatroom->getConferences()) {
-        const auto conferenceAction =
+        auto* const conferenceAction =
             inviteMenu->addAction(tr("Invite to conference '%1'").arg(conference.name));
         connect(conferenceAction, &QAction::triggered, this,
                 [this, conference] { chatroom->inviteFriend(conference.conference); });
     }
 
     const auto circleId = chatroom->getCircleId();
-    auto circleMenu =
+    auto* circleMenu =
         menu.addMenu(tr("Move to circle...", "Menu to move a friend into a different circle"));
 
-    const auto newCircleAction = circleMenu->addAction(tr("To new circle"));
+    auto* const newCircleAction = circleMenu->addAction(tr("To new circle"));
     connect(newCircleAction, &QAction::triggered, this, &FriendWidget::moveToNewCircle);
 
     if (circleId != -1) {
         const auto circleName = chatroom->getCircleName();
-        const auto removeCircleAction =
+        auto* const removeCircleAction =
             circleMenu->addAction(tr("Remove from circle '%1'").arg(circleName));
         connect(removeCircleAction, &QAction::triggered, this, &FriendWidget::removeFromCircle);
     }
@@ -143,11 +143,11 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
         circleMenu->addAction(action);
     }
 
-    const auto setAlias = menu.addAction(tr("Set alias..."));
+    auto* const setAlias = menu.addAction(tr("Set alias..."));
     connect(setAlias, &QAction::triggered, nameLabel, &CroppingLabel::editBegin);
 
     menu.addSeparator();
-    auto autoAccept =
+    auto* autoAccept =
         menu.addAction(tr("Auto accept files from this friend", "context menu entry"));
     autoAccept->setCheckable(true);
     autoAccept->setChecked(!chatroom->autoAcceptEnabled());
@@ -156,7 +156,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 
     if (chatroom->friendCanBeRemoved()) {
         const auto friendPk = chatroom->getFriend()->getPublicKey();
-        const auto removeAction =
+        auto* const removeAction =
             menu.addAction(tr("Remove friend", "Menu to remove the friend from the friend list"));
         connect(
             removeAction, &QAction::triggered, this,
@@ -164,7 +164,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     }
 
     menu.addSeparator();
-    const auto aboutWindow = menu.addAction(tr("Show details"));
+    auto* const aboutWindow = menu.addAction(tr("Show details"));
     connect(aboutWindow, &QAction::triggered, this, &FriendWidget::showDetails);
 
     const auto pos = event->globalPos();
@@ -189,9 +189,10 @@ getCircleAndFriendList(const Friend* frnd, FriendWidget* fw, Settings& settings)
 {
     const auto pk = frnd->getPublicKey();
     const auto circleId = settings.getFriendCircleID(pk);
-    auto circleWidget = CircleWidget::getFromID(circleId);
-    auto w = circleWidget != nullptr ? static_cast<QWidget*>(circleWidget) : static_cast<QWidget*>(fw);
-    auto friendList = qobject_cast<FriendListWidget*>(w->parentWidget());
+    auto* circleWidget = CircleWidget::getFromID(circleId);
+    auto* w =
+        circleWidget != nullptr ? static_cast<QWidget*>(circleWidget) : static_cast<QWidget*>(fw);
+    auto* friendList = qobject_cast<FriendListWidget*>(w->parentWidget());
     return std::make_tuple(circleWidget, friendList);
 }
 
@@ -199,7 +200,7 @@ getCircleAndFriendList(const Friend* frnd, FriendWidget* fw, Settings& settings)
 
 void FriendWidget::moveToNewCircle()
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     CircleWidget* circleWidget;
     FriendListWidget* friendList;
     std::tie(circleWidget, friendList) = getCircleAndFriendList(frnd, this, settings);
@@ -220,7 +221,7 @@ void FriendWidget::moveToNewCircle()
 
 void FriendWidget::removeFromCircle()
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     CircleWidget* circleWidget;
     FriendListWidget* friendList;
     std::tie(circleWidget, friendList) = getCircleAndFriendList(frnd, this, settings);
@@ -240,12 +241,12 @@ void FriendWidget::removeFromCircle()
 
 void FriendWidget::moveToCircle(int newCircleId)
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     const auto pk = frnd->getPublicKey();
     const auto oldCircleId = settings.getFriendCircleID(pk);
     auto& s = settings;
-    auto oldCircleWidget = CircleWidget::getFromID(oldCircleId);
-    auto newCircleWidget = CircleWidget::getFromID(newCircleId);
+    auto* oldCircleWidget = CircleWidget::getFromID(oldCircleId);
+    auto* newCircleWidget = CircleWidget::getFromID(newCircleId);
 
     if (newCircleWidget != nullptr) {
         newCircleWidget->addFriendWidget(this, frnd->getStatus());
@@ -275,10 +276,10 @@ void FriendWidget::changeAutoAccept(bool enable)
 }
 void FriendWidget::showDetails()
 {
-    const auto frnd = chatroom->getFriend();
-    const auto iAbout = new AboutFriend(frnd, &settings, profile);
+    auto* const frnd = chatroom->getFriend();
+    auto* const iAbout = new AboutFriend(frnd, &settings, profile);
     std::unique_ptr<IAboutFriend> about = std::unique_ptr<IAboutFriend>(iAbout);
-    const auto aboutUser =
+    auto* const aboutUser =
         new AboutFriendForm(std::move(about), settings, style, messageBoxManager, this);
     connect(aboutUser, &AboutFriendForm::historyRemoved, this, &FriendWidget::friendHistoryRemoved);
     aboutUser->show();
@@ -306,7 +307,7 @@ void FriendWidget::setActive(bool active_)
 
 void FriendWidget::updateStatusLight()
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     const bool event = frnd->getEventFlag();
     statusPic.setPixmap(QPixmap(Status::getIconPath(frnd->getStatus(), event)));
 
@@ -326,7 +327,7 @@ void FriendWidget::updateStatusLight()
 
 QString FriendWidget::getStatusString() const
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     const int status = static_cast<int>(frnd->getStatus());
     const bool event = frnd->getEventFlag();
 
@@ -359,7 +360,7 @@ bool FriendWidget::isConference() const
 
 bool FriendWidget::isOnline() const
 {
-    const auto frnd = getFriend();
+    const auto* const frnd = getFriend();
     return Status::isOnline(frnd->getStatus());
 }
 
@@ -375,7 +376,7 @@ QString FriendWidget::getNameItem() const
 
 QDateTime FriendWidget::getLastActivity() const
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     return settings.getFriendActivity(frnd->getPublicKey());
 }
 
@@ -401,7 +402,7 @@ void FriendWidget::resetEventFlags()
 
 void FriendWidget::onAvatarSet(const ToxPk& friendPk, const QPixmap& pic)
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     if (friendPk != frnd->getPublicKey()) {
         return;
     }
@@ -412,7 +413,7 @@ void FriendWidget::onAvatarSet(const ToxPk& friendPk, const QPixmap& pic)
 
 void FriendWidget::onAvatarRemoved(const ToxPk& friendPk)
 {
-    const auto frnd = chatroom->getFriend();
+    auto* const frnd = chatroom->getFriend();
     if (friendPk != frnd->getPublicKey()) {
         return;
     }

--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -157,13 +157,12 @@ QString Style::getThemeFolder(int themeColor)
     return fullPath % QDir::separator();
 }
 
-const QString Style::getStylesheet(const QString& filename, const Settings& settings,
-                                   const QFont& baseFont)
+QString Style::getStylesheet(const QString& filename, const Settings& settings, const QFont& baseFont)
 {
     return getStylesheet(filename, settings.getThemeColor(), baseFont);
 }
 
-const QString Style::getStylesheet(const QString& filename, int themeColor, const QFont& baseFont)
+QString Style::getStylesheet(const QString& filename, int themeColor, const QFont& baseFont)
 {
     const QString fullPath = getThemeFolder(themeColor) + filename;
     const std::pair<const QString, const QFont> cacheKey(fullPath, baseFont);
@@ -178,12 +177,12 @@ const QString Style::getStylesheet(const QString& filename, int themeColor, cons
     return newStylesheet;
 }
 
-const QString Style::getImagePath(const QString& filename, const Settings& settings)
+QString Style::getImagePath(const QString& filename, const Settings& settings)
 {
     return getImagePath(filename, settings.getThemeColor());
 }
 
-const QString Style::getImagePath(const QString& filename, int themeColor)
+QString Style::getImagePath(const QString& filename, int themeColor)
 {
     QString fullPath = getThemeFolder(themeColor) + filename;
 
@@ -233,7 +232,7 @@ QFont Style::getFont(Font font)
     return fonts.at(font);
 }
 
-const QString Style::resolve(const QString& filename, int themeColor, const QFont& baseFont)
+QString Style::resolve(const QString& filename, int themeColor, const QFont& baseFont)
 {
     const QString themePath = getThemeFolder(themeColor);
     QString fullPath = themePath + filename;

--- a/src/widget/style.h
+++ b/src/widget/style.h
@@ -70,14 +70,13 @@ public:
     static QPixmap scaleSvgImage(const QString& path, uint32_t width, uint32_t height);
 
     Style() = default;
-    const QString getStylesheet(const QString& filename, const Settings& settings,
-                                const QFont& baseFont = QFont());
-    const QString getStylesheet(const QString& filename, int themeColor,
-                                const QFont& baseFont = QFont());
-    const QString getImagePath(const QString& filename, const Settings& settings);
-    const QString getImagePath(const QString& filename, int themeColor);
+    QString getStylesheet(const QString& filename, const Settings& settings,
+                          const QFont& baseFont = QFont());
+    QString getStylesheet(const QString& filename, int themeColor, const QFont& baseFont = QFont());
+    QString getImagePath(const QString& filename, const Settings& settings);
+    QString getImagePath(const QString& filename, int themeColor);
     QColor getColor(ColorPalette entry);
-    const QString resolve(const QString& filename, int themeColor, const QFont& baseFont = QFont());
+    QString resolve(const QString& filename, int themeColor, const QFont& baseFont = QFont());
     void setThemeColor(int themeColor, int color);
     void setThemeColor(const QColor& color);
     void initPalette(int themeColor);

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -357,7 +357,7 @@ private slots:
     void testSetConferencesOnTop();
 
 private:
-    std::unique_ptr<FriendListManager> createManagerWithItems(const QVector<IFriendListItem*> itemsVec);
+    std::unique_ptr<FriendListManager> createManagerWithItems(QVector<IFriendListItem*> itemsVec);
 };
 
 void TestFriendListManager::testAddFriendListItem()
@@ -367,13 +367,13 @@ void TestFriendListManager::testAddFriendListItem()
     FriendItemsBuilder listBuilder;
 
     auto checkFunc = [&](const QVector<IFriendListItem*> itemsVec) {
-        for (auto item : itemsVec) {
+        for (auto* item : itemsVec) {
             manager->addFriendListItem(item);
         }
         QCOMPARE(manager->getItems().size(), itemsVec.size());
         QCOMPARE(spy.count(), itemsVec.size());
         spy.clear();
-        for (auto item : itemsVec) {
+        for (auto* item : itemsVec) {
             manager->removeFriendListItem(item);
         }
         QCOMPARE(manager->getItems().size(), 0);
@@ -433,7 +433,7 @@ void TestFriendListManager::testSortByActivity()
     QCOMPARE(manager->getPositionsChanged(), false);
     QCOMPARE(manager->getItems().size(), sortedVec.size());
     for (int i = 0; i < sortedVec.size(); ++i) {
-        auto fromManager = manager->getItems().at(i).get();
+        auto* fromManager = manager->getItems().at(i).get();
         auto fromSortedVec = sortedVec.at(i);
         QCOMPARE(fromManager->getNameItem(), fromSortedVec->getNameItem());
     }
@@ -601,7 +601,7 @@ TestFriendListManager::createManagerWithItems(const QVector<IFriendListItem*> it
 {
     std::unique_ptr<FriendListManager> manager = std::make_unique<FriendListManager>(0, this);
 
-    for (auto item : itemsVec) {
+    for (auto* item : itemsVec) {
         manager->addFriendListItem(item);
     }
 

--- a/test/platform/posixsignalnotifier_test.cpp
+++ b/test/platform/posixsignalnotifier_test.cpp
@@ -26,7 +26,7 @@ constexpr int TIMEOUT = 2;
 void TestPosixSignalNotifier::checkUsrSignalHandling()
 {
     PosixSignalNotifier& psn = PosixSignalNotifier::globalInstance();
-    psn.watchUsrSignals();
+    PosixSignalNotifier::watchUsrSignals();
     QSignalSpy spy(&psn, &PosixSignalNotifier::usrSignal);
     kill(getpid(), SIGUSR1);
 
@@ -51,7 +51,7 @@ void sighandler(int sig)
 void TestPosixSignalNotifier::checkIgnoreExtraSignals()
 {
     PosixSignalNotifier& psn = PosixSignalNotifier::globalInstance();
-    psn.watchSignal(SIGUSR1);
+    PosixSignalNotifier::watchSignal(SIGUSR1);
     QSignalSpy spy(&psn, &PosixSignalNotifier::terminatingSignal);
 
     // To avoid killing
@@ -69,7 +69,7 @@ void TestPosixSignalNotifier::checkIgnoreExtraSignals()
 void TestPosixSignalNotifier::checkTermSignalsHandling()
 {
     PosixSignalNotifier& psn = PosixSignalNotifier::globalInstance();
-    psn.watchCommonTerminatingSignals();
+    PosixSignalNotifier::watchCommonTerminatingSignals();
     QSignalSpy spy(&psn, &PosixSignalNotifier::terminatingSignal);
 
     const std::initializer_list<int> termSignals = {SIGHUP, SIGINT, SIGQUIT, SIGTERM};


### PR DESCRIPTION
Some exceptions that either potentially break Qt code or we don't like (like variable names needing to be at least 3 characters).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/467)
<!-- Reviewable:end -->
