### PR TITLE
feat(Debug): Allow user to limit the copied log size.

### DIFF
--- a/src/model/debug/debuglogmodel.cpp
+++ b/src/model/debug/debuglogmodel.cpp
@@ -4,10 +4,15 @@
 
 #include "debuglogmodel.h"
 
+#include "util/ranges.h"
+
 #include <QColor>
 #include <QRegularExpression>
 
 namespace {
+const QString timeFormat = QStringLiteral("HH:mm:ss.zzz");
+const QString dateTimeFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss.zzz");
+
 QtMsgType parseMsgType(const QString& type)
 {
     if (type == "Debug") {
@@ -47,46 +52,6 @@ QString renderMsgType(QtMsgType type)
     return QStringLiteral("Unknown");
 }
 
-QList<DebugLogModel::LogEntry> parse(const QStringList& logs)
-{
-    // Regex extraction of log entry
-    // [12:35:16.634 UTC] (default) src/core/core.cpp:370 : Debug: Connected to a TCP relay
-    //  ^                  ^        ^                 ^     ^      ^
-    //  time              category  file              line  type   message
-    static const QRegularExpression re(
-        R"(\[([0-9:.]*) UTC\](?: \(([^)]*)\))? (.*?):(\d+) : ([^:]+): (.*))");
-
-    QList<DebugLogModel::LogEntry> result;
-    for (const QString& log : logs) {
-        const auto match = re.match(log);
-        if (!match.hasMatch()) {
-            qWarning() << "Failed to parse log entry:" << log;
-            continue;
-        }
-
-        DebugLogModel::LogEntry entry;
-        entry.index = result.size();
-        entry.time = match.captured(1);
-        entry.category = match.captured(2);
-        if (entry.category.isEmpty()) {
-            entry.category = QStringLiteral("default");
-        }
-        entry.file = match.captured(3);
-        entry.line = match.captured(4).toInt();
-        entry.type = parseMsgType(match.captured(5));
-        entry.message = match.captured(6);
-        result.append(entry);
-    }
-    return result;
-}
-
-QString render(const DebugLogModel::LogEntry& entry)
-{
-    return QStringLiteral("[%1 UTC] (%2) %3:%4 : %5: %6")
-        .arg(entry.time, entry.category, entry.file, QString::number(entry.line),
-             renderMsgType(entry.type), entry.message);
-}
-
 bool filterAccepts(DebugLogModel::Filter filter, QtMsgType type)
 {
     switch (filter) {
@@ -106,6 +71,61 @@ bool filterAccepts(DebugLogModel::Filter filter, QtMsgType type)
     return false;
 }
 } // namespace
+
+QList<DebugLogModel::LogEntry> DebugLogModel::parse(const QStringList& logs)
+{
+    // Regex extraction of log entry
+    // [12:35:16.634 UTC] (default) src/core/core.cpp:370 : Debug: Connected to a TCP relay
+    //  ^                  ^        ^                 ^     ^      ^
+    //  time              category  file              line  type   message
+    static const QRegularExpression re(
+        R"(\[([0-9:.]*) UTC\](?: \(([^)]*)\))? (.*?):(\d+) : ([^:]+): (.*))");
+
+    // Assume the last log entry is today.
+    const QDateTime now = QDateTime::currentDateTime().toUTC();
+    QDate lastDate = now.date();
+    QTime lastTime = now.time();
+
+    QList<DebugLogModel::LogEntry> result;
+    for (const QString& log : qtox::views::reverse(logs)) {
+        const auto match = re.match(log);
+        if (!match.hasMatch()) {
+            qWarning() << "Failed to parse log entry:" << log;
+            continue;
+        }
+
+        // Reconstruct the likely date of the log entry.
+        const QTime entryTime = QTime::fromString(match.captured(1), timeFormat);
+        if (entryTime > lastTime) {
+            lastDate = lastDate.addDays(-1);
+        }
+        lastTime = entryTime;
+
+        DebugLogModel::LogEntry entry;
+        entry.index = result.size();
+        entry.time = QDateTime{lastDate, entryTime};
+        entry.category = match.captured(2);
+        if (entry.category.isEmpty()) {
+            entry.category = QStringLiteral("default");
+        }
+        entry.file = match.captured(3);
+        entry.line = match.captured(4).toInt();
+        entry.type = parseMsgType(match.captured(5));
+        entry.message = match.captured(6);
+        result.append(entry);
+    }
+
+    std::reverse(result.begin(), result.end());
+    return result;
+}
+
+QString DebugLogModel::render(const DebugLogModel::LogEntry& entry, bool includeDate)
+{
+    return QStringLiteral("[%1 UTC] (%2) %3:%4 : %5: %6")
+        .arg(includeDate ? entry.time.toString(dateTimeFormat) : entry.time.toString(timeFormat),
+             entry.category, entry.file, QString::number(entry.line), renderMsgType(entry.type),
+             entry.message);
+}
 
 DebugLogModel::DebugLogModel(QObject* parent)
     : QAbstractListModel(parent)

--- a/src/model/debug/debuglogmodel.h
+++ b/src/model/debug/debuglogmodel.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QDateTime>
 #include <QLoggingCategory>
 
 class DebugLogModel : public QAbstractListModel
@@ -29,7 +30,7 @@ public:
         /// Index in the original log list.
         int index;
 
-        QString time;
+        QDateTime time;
         QString category;
         QString file;
         int line;
@@ -51,6 +52,21 @@ public:
      * @brief Given the index in the filtered list, return the index in the original list.
      */
     int originalIndex(const QModelIndex& index) const;
+
+    /**
+     * @brief Parse a list of log lines into LogEntry objects.
+     */
+    static QList<LogEntry> parse(const QStringList& logs);
+
+    /**
+     * @brief Render a LogEntry object into a string.
+     */
+    static QString render(const LogEntry& entry, bool includeDate = false);
+
+    static QString renderWithDate(const LogEntry& entry)
+    {
+        return render(entry, true);
+    }
 
 private:
     void recomputeFilter();

--- a/src/widget/form/debug/debuglog.cpp
+++ b/src/widget/form/debug/debuglog.cpp
@@ -94,7 +94,6 @@ DebugLogForm::~DebugLogForm()
 
 void DebugLogForm::showEvent(QShowEvent* event)
 {
-    qDebug() << "Loading logs for debug log view";
     debugLogModel_->reload(loadLogs(paths_));
 
     GenericForm::showEvent(event);

--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -94,6 +94,63 @@
              </layout>
             </item>
             <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <item>
+               <widget class="QSpinBox" name="maxLogLines">
+                <property name="toolTip">
+                 <string>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</string>
+                </property>
+                <property name="suffix">
+                 <string> lines</string>
+                </property>
+                <property name="minimum">
+                 <number>10</number>
+                </property>
+                <property name="maximum">
+                 <number>5000</number>
+                </property>
+                <property name="value">
+                 <number>1000</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="maxLogAgeLabel">
+                <property name="toolTip">
+                 <string>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</string>
+                </property>
+                <property name="text">
+                 <string>Max age:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QTimeEdit" name="maxLogAge">
+                <property name="time">
+                 <time>
+                  <hour>0</hour>
+                  <minute>30</minute>
+                  <second>0</second>
+                 </time>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
              <widget class="QCheckBox" name="cbEnableDebug">
               <property name="text">
                <string>Enable Debug Tools (developers only)</string>

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -624,6 +624,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">تمكين أدوات التصحيح (للمطورين فقط)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">الحد الأقصى لعدد الأسطر التي سيتم نسخها إلى الحافظة عند الضغط على &quot;نسخ سجل التصحيح&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> خطوط</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">الحد الأقصى للسن (في الساعات/الدقائق) من خطوط السجل للنسخ في الحافظة عند الضغط على &quot;Copy Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">أقصى سن:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -597,6 +597,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Уключыць інструменты адладкі (толькі для распрацоўшчыкаў)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максімальная колькасць радкоў, каб скапіяваць у буфер абмену пры націску &quot;Скапіруйце часопіс адладкі&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> ліній</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максімальны ўзрост (у гадзінах/хвілінах) радкоў часопісаў, каб скапіяваць у буфер абмену пры націску &quot;Скапіруйце часопіс адладкі&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максімальны ўзрост:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -679,6 +679,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵡⴰⵢⴰ ⵢⴻⵜⵜⴰⴵⴵⴰ, ⴰⵎⴻⴷⵢⴰ, Tox ⵖⴻⴼ Tor. ⵢⴻⵔⵏⴰⴷ ⵍⵃⴻⴱⵙ ⵉ ⵓⵥⴻⴹⴹⴰ ⵏ Tox ⴷ ⴰⵛⵓ ⴽⴰⵏ, ⵉⵀⵉ ⵙⴼⴻⴹ ⴽⴰⵏ ⵎⵉ ⴰⵔⴰ ⵉⵍⴰⵇ.</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⴰⵎⴹⴰⵏ ⴰⵅⴰⵜⴰⵔ ⵏ ⵉⵣⵔⵉⵔⵉⴳⵏ ⵃⵎⴰ ⴰⴷ ⵏⵙⴽⵛⵎ ⴳ ⵓⴽⵍⵓ ⵍⵍⵉⴳ ⴷⴰ ⵉⵜⵜⵓⵙⵎⵔⴰⵙ &quot;Copy Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> ⵉⵖⴻⵣⵔⴰⵏ</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵍⴻⵄⵎⴻⵔ ⴰⵎⴻⵇⵇⵔⴰⵏ (ⵙ ⵜⵙⴰⵄⵜⵉⵏ/ⵜⴻⴷⵇⵉⵇⵉⵏ) ⵏ ⵢⵉⴼⴻⵔⴷⵉⵙⴻⵏ ⵏ ⵓⵖⵎⵉⵙ ⴰⵔⴰ ⵜⴻⵙⵏⵓⵍⴼⵓⴹ ⴷⴻⴳ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵎⵉ ⴰⵔⴰ ⵜⵜⴻⵟⵟⴼⴻⴹ &quot;Snulfuḍ ⴰⵖⵎⵉⵙ ⵏ ⵓⵙⵎⴻⵍ&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵍⴻⵄⵎⴻⵔ ⴰⵎⴻⵇⵇⵔⴰⵏ:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -577,6 +577,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Инструменти за отстраняване на дефекти (за разработчици)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимален брой редове за копиране в клипборда при натискане на „Копиране на журнала за отстраняване на грешки“.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> линии</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална възраст (в часове/минути) на редовете в регистрационния файл за копиране в клипборда при натискане на „Копиране на журнала за отстраняване на грешки“.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална възраст:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -693,6 +693,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ডিবাগ টুল সক্ষম করুন (শুধুমাত্র বিকাশকারীরা)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;অনুলিপি ডিবাগ লগ&quot; টিপানোর সময় ক্লিপবোর্ডে অনুলিপি করার জন্য সর্বাধিক সংখ্যক লাইন।</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> লাইন</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;অনুলিপি ডিবাগ লগ&quot; টিপানোর সময় ক্লিপবোর্ডে অনুলিপি করতে সর্বাধিক বয়স (ঘন্টা/মিনিটে) লগ লাইনের অনুলিপি করতে।</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">সর্বাধিক বয়স:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -577,6 +577,26 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Povolit nástroje ladění (pouze pro vývojáře)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximální počet řádků, které se mají kopírovat do schránky při stisknutí „Kopírovat protokol ladění“.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> řádky</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximální věk (v hodinách/minutách) linek protokolu pro kopírování do schránky při stisknutí „Kopírovat protokol debug“.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max Age:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -631,6 +631,26 @@ hvilket kan føre til problemer med videoopkald.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aktiver fejlretningsværktøjer (kun udviklere)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalt antal linjer, der skal kopieres til udklipsholderen, når du trykker på &quot;Kopier fejlretningslog&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linjer</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimal alder (i timer/minutter) af loglinjer, der skal kopieres til udklipsholderen, når du trykker på &quot;Kopi -debug -log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max alder:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -574,6 +574,26 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
         <source>Enable Debug Tools (developers only)</source>
         <translation>Debug-Tools einschalten (nur Entwickler)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale Anzahl der Zeilen, die in die Zwischenablage kopiert werden sollen, wenn Sie auf „Debug-Protokoll kopieren“ klicken.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation> Zeilen</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximales Alter (in Stunden/Minuten) der Protokollzeilen, die in die Zwischenablage kopiert werden sollen, wenn Sie auf „Debug-Protokoll kopieren“ klicken.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximales Alter:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -603,6 +603,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ενεργοποίηση εργαλείων εντοπισμού σφαλμάτων (μόνο για προγραμματιστές)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μέγιστος αριθμός γραμμών για αντιγραφή στο πρόχειρο όταν πατάτε &quot;Αντιγραφή αρχείου καταγραφής εντοπισμού σφαλμάτων&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> γραμμές</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μέγιστη ηλικία (σε ώρες/λεπτά) γραμμών καταγραφής για αντιγραφή στο πρόχειρο όταν πατάτε &quot;Αντιγραφή αρχείου καταγραφής εντοπισμού σφαλμάτων&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μέγιστη ηλικία:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -654,6 +654,26 @@ kio povas konduki al problemoj kun videovokoj.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ebligu Sencimigajn Ilojn (nur programistoj)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimuma nombro da linioj por kopii en la tondujo premante &quot;Kopii Sencimigan Protokolon&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linioj</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimuma aĝo (en horoj/minutoj) de logaj linioj por kopii en la klipo kiam oni premas &quot;Kopiu Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max Age:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -575,6 +575,26 @@ lo que puede provocar problemas en las videollamadas.</translation>
         <source>Enable Debug Tools (developers only)</source>
         <translation>Activar herramientas de depuración (solo para desarrolladores)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de líneas para copiar en el portapapeles al presionar &quot;Copiar registro de depuración&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> pauta</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Antigüedad máxima (en horas/minutos) de las líneas de registro para copiar en el portapapeles al presionar &quot;Copiar registro de depuración&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Edad máxima:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -576,6 +576,26 @@ mis võib põhjustada probleeme videokõnedega.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Silumistööriistade lubamine (ainult arendajatele)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;Kopeerige silumislogi&quot; vajutamisel lõikelauale maksimaalne arv ridasid.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> read</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Lõikepuhvrisse kopeeritavate logiridade maksimaalne vanus (tundides/minutites), kui vajutate nuppu &quot;Kopeeri silumislogi&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max vanus:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -595,6 +595,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">فعال کردن ابزار Debug Tools (فقط توسعه دهندگان)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">حداکثر تعداد خطوط برای کپی در کلیپ بورد هنگام فشار دادن &quot;Copy Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> خط</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">حداکثر سن (به ساعت/دقیقه) خطوط گزارش برای کپی در کلیپ بورد هنگام فشار دادن &quot;Copy Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">حداکثر سن:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -576,6 +576,26 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ota virheenkorjaustyökalut käyttöön (vain kehittäjät)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Leikepöydälle kopioitavien rivien enimmäismäärä, kun painetaan &quot;Kopioi virheenkorjausloki&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> rivit</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Suurin ikä (tunteina/minuutteina) lokiviivoja kopioidaksesi leikepöydälle painamalla &quot;Kopioi Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max Age:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -576,6 +576,26 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Activer les outils de débogage (développeurs uniquement)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nombre maximum de lignes à copier dans le presse-papiers en appuyant sur &quot;Copier le journal de débogage&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> lignes</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Âge maximum (en heures/minutes) des lignes de journal à copier dans le presse-papiers en appuyant sur &quot;Copier le journal de débogage&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Âge maximum:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -596,6 +596,26 @@ o que pode provocar problemas coas videochamadas.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Activar ferramentas de depuración (só para programadores)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de liñas para copiar no portapapeis ao premer &quot;Copiar rexistro de depuración&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> liñas</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">A idade máxima (en horas/minutos) das liñas de rexistro para copiar no portapapeis ao premer &quot;Copiar rexistro de depuración&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idade máxima:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -677,6 +677,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">הפעל כלי ניפוי באגים (למפתחים בלבד)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">המספר המרבי של השורות להעתקה בלוח הלוח כאשר לוחצים על &quot;העתק יומן באגים&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> קווים</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">הגיל המרבי (בשעות/דקות) של שורות יומן להעתקה ללוח בעת לחיצה על &quot;העתק יומן ניפוי באגים&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">גיל מקסימום:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -597,6 +597,26 @@ Ponekad vaša veza možda nije dovoljno dobra da podnese višu kvalitetu videa,
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Omogući alate za otklanjanje pogrešaka (samo za programere)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalan broj redaka za kopiranje u međuspremnik kada se pritisne &quot;Kopiraj dnevnik otklanjanja pogrešaka&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> crta</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalna starost (u satima/minutama) redaka dnevnika za kopiranje u međuspremnik kada se pritisne &quot;Kopiraj dnevnik otklanjanja pogrešaka&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max Age:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -595,6 +595,26 @@ ami problémákat okozhat a videohívásokkal kapcsolatban.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Hibakereső eszközök engedélyezése (csak fejlesztőknek)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">A vágólapra másolható sorok maximális száma, amikor megnyomja a &quot;Hibakeresési napló másolása&quot; gombot.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> vonalak</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">A vágólapra másolható naplósorok maximális kora (órában/percben), amikor megnyomja a &quot;Hibakeresési napló másolása&quot; gombot.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max életkor:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -679,6 +679,26 @@ sem getur leitt til vandræða með myndsímtöl.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Virkja villuleitarverkfæri (aðeins forritarar)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Hámarksfjöldi lína til að afrita á klemmuspjaldið þegar ýtt er á „Afritaðu kembiforrit“.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> línur</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Hámarksaldur (á klukkustundum/mínútum) af timburlínum til að afrita á klemmuspjaldið þegar ýtt er á „Afritaðu kembiforrit“.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Hámarksaldur:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -576,6 +576,26 @@ il che può portare a problemi con le videochiamate.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Abilita strumenti di debug (solo sviluppatori)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numero massimo di righe da copiare negli appunti quando si preme &quot;Copia il registro di debug&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linee</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Età massima (in ore/minuti) delle righe di registro da copiare negli appunti quando si preme &quot;Copia il registro di debug&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Età massima:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -605,6 +605,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>デバッグツールを有効にする (開発者のみ)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">「デバッグログのコピー」を押したときにクリップボードにコピーされる最大行数。</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> 線</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">「コピーデバッグログ」を押すと、クリップボードにコピーするログラインの最大年齢（時間/分）。</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">最大年齢：</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -688,6 +688,26 @@ so&apos;o roi lo nu do jungau cu na banzu xamgu lo ka zgana lo nu zgana lo vidni
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">fau na akti ti cumki e&apos;u la toks pe la tort ki&apos;u nai ko&apos;a jmina lo kargu be la toks. net gi&apos;e ku&apos;i toljundi ca lo nu sarcu</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">so&apos;i loi lerni poi sarcu lo nu fukpi fi lo bifygau ca lo nu danre lu kopi la debug logu li&apos;u</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> lerseltcidu</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">lo tcika be li cacra/mentu ku lo logji linji noi sarji lo nu fukyzgau lo bixycpa ca lo nu danre lu kopi la debug logu li&apos;u</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">li makcu nanca:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -691,6 +691,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಡೀಬಗ್ ಪರಿಕರಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ (ಡೆವಲಪರ್‌ಗಳು ಮಾತ್ರ)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;ನಕಲಿಸಿ ಡೀಬಗ್ ಲಾಗ್&quot; ಅನ್ನು ಒತ್ತುವಾಗ ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಲು ಗರಿಷ್ಠ ಸಂಖ್ಯೆಯ ಸಾಲುಗಳು.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> ಸಾಲುಗಳು</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;ಡೀಬಗ್ ಲಾಗ್ ನಕಲಿಸಿ&quot; ಅನ್ನು ಒತ್ತಿದಾಗ ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಲು ಲಾಗ್ ಲೈನ್‌ಗಳ ಗರಿಷ್ಠ ವಯಸ್ಸು (ಗಂಟೆಗಳು/ನಿಮಿಷಗಳಲ್ಲಿ).</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಗರಿಷ್ಠ ವಯಸ್ಸು:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -621,6 +621,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">디버그 도구 활성화(개발자 전용)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;디버그 로그 복사&quot;를 누를 때 클립보드에 복사할 최대 줄 수입니다.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> 윤곽</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;디버그 로그 복사&quot;를 누를 때 클립보드에 복사할 로그 줄의 최대 수명(시간/분)입니다.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">최대 연령 :</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -699,6 +699,26 @@ wat kin leie tot probleme mit videogesprekke.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Reset nao de standaardinstellinge</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximaal aantal regels um in ‘t klembord te kopiëre es geer op &quot;Debug Log kopiëre&quot; weurt ingedruk.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> lijne</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale leeftied (in oere/minute) vaan loglijne um in ‘t klembord te kopiëre bij ‘Coppy Debug Log’.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max leeftied:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -577,6 +577,26 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Įgalinti derinimo įrankius (tik kūrėjams)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Didžiausias eilučių, kurias reikia nukopijuoti į mainų sritį, skaičius paspaudus „Kopijuoti derinimo žurnalą“.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linijos</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalus žurnalo linijų amžius (valandomis/minutėmis), kad galėtumėte nukopijuoti į mainų sritį, paspausdami „Kopijuoti derinimo žurnalą“.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalus amžius:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -580,6 +580,26 @@ kas var radīt videozvanu problēmas.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Iespējot atkļūdošanas rīkus (tikai izstrādātājiem)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimālais rindu skaits, ko kopēt starpliktuvē, nospiežot &quot;Kopēt atkļūdošanas žurnālu&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> līnijas</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimālais žurnāla līniju vecums (stundās/minūtēs), ko kopēt starpliktuvē, nospiežot &quot;Kopēt atkļūdošanas žurnālu&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimālais vecums:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -604,6 +604,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Овозможи алатки за отстранување грешки (само за програмери)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимален број на линии за копирање во таблата со исечоци при притискање на „Копирај дневник за дебагирање“.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> линии</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална возраст (во часови/минути) на линии на дневници за копирање во таблата со исечоци при притискање на „Copy Debug Log“.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална возраст:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -577,6 +577,26 @@ noe som kan forårsake problemer i videosamtaler.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aktiver feilsøkingsverktøy (bare utviklere)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimalt antall linjer å kopiere til utklippstavlen når du trykker &quot;Kopier feilsøkingslogg&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linjer</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksimal alder (i timer/minutter) på logglinjer som skal kopieres til utklippstavlen når du trykker på &quot;Kopier feilsøkingslogg&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maks alder:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -574,6 +574,26 @@ wat kan leiden tot problemen met videogesprekken.</translation>
         <source>Enable Debug Tools (developers only)</source>
         <translation>Debugtools inschakelen (alleen voor ontwikkelaars)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximaal aantal regels om naar het klembord te kopiëren bij het drukken op &quot;Debug logboek kopiëren&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> lijnen</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale leeftijd (in uren/minuten) van logregels die naar het klembord moeten worden gekopieerd wanneer op &quot;Copy Debug Log&quot; wordt gedrukt.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximale leeftijd:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -568,6 +568,22 @@ which may lead to problems with video calls.</source>
         <source>Enable Debug Tools (developers only)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -583,6 +583,26 @@ co może powodować problemy z rozmowami wideo.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Włącz narzędzia debugowania (tylko programiści)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksymalna liczba linii do skopiowania do schowka podczas nacisku „Kopiuj dziennik debugowania”.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> kwestia</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksymalny wiek (w godzinach/minutach) linii dziennika do skopiowania do schowka podczas nacisku „Kopiuj dziennik debugowania”.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maksymalny wiek:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -557,20 +557,36 @@ Take heed, fer higher qualities demand clearer skies and use more bandwidth. If 
     </message>
     <message>
         <source>Enable LAN discovery</source>
-        <translation type="unfinished">Find other ships nearby</translation>
+        <translation>Find other ships nearby</translation>
     </message>
     <message>
         <source>Enable Debug Tools (developers only)</source>
-        <translation type="unfinished">Enable Debug Tools (fer th&apos; shipwrights only)</translation>
+        <translation>Enable Debug Tools (fer th&apos; shipwrights only)</translation>
     </message>
     <message>
         <source>Connection settings</source>
-        <translation type="unfinished">How ye connect</translation>
+        <translation>How ye connect</translation>
     </message>
     <message>
         <source>Disabling this allows, e.g., Tox over Tor. It adds load to the Tox network however, so uncheck only when necessary.</source>
         <extracomment>force tcp checkbox tooltip</extracomment>
         <translation>Disablin&apos; this allows Toxin&apos; over Tor, but it adds load to yer Toxmates. Be thoughtful.</translation>
+    </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translation>Limit o&apos; lines to copy when pressin&apos; &quot;Pick up Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translation> lines</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translation>Oldest age (in hours/minutes) o&apos; log lines to copy when pressin&apos; &quot;Pick up Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translation>Oldest age:</translation>
     </message>
 </context>
 <context>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -576,6 +576,26 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Habilitar ferramentas de depuração (somente desenvolvedores)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de linhas para copiar para a área de transferência ao pressionar &quot;Copy Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linhas</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idade máxima (em horas/minutos) de linhas de log para copiar na área de transferência ao pressionar &quot;Copy Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idade máxima:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -576,6 +576,26 @@ o que pode levar a problemas com as videochamadas.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Habilitar ferramentas de depuração (somente desenvolvedores)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Número máximo de linhas a serem copiadas para a área de transferência ao pressionar &quot;Copiar log de depuração&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linhas</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idade máxima (em horas/minutos) das linhas de log a serem copiadas para a área de transferência ao pressionar &quot;Copiar log de depuração&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idade máxima:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -575,6 +575,26 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
         <source>Enable Debug Tools (developers only)</source>
         <translation>Activați instrumentele de depanare (numai pentru dezvoltatori)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numărul maxim de linii de copiat în clipboard atunci când apăsați „Copy Debug Log”.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linii</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vârsta maximă (în ore/minute) a liniilor de jurnal pentru a copia în clipboard atunci când apăsați „Copiați jurnalul de depanare”.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vârsta maximă:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -576,6 +576,26 @@ which may lead to problems with video calls.</source>
         <source>Enable Debug Tools (developers only)</source>
         <translation>Включить Инструменты Отладки (только для разработчиков)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальное количество строк для копирования в буфер обмена при нажатии «Журнал отладки копирования».</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> линии</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальный возраст (в часах/минутах) строк журнала, которые можно скопировать в буфер обмена при нажатии «Копировать журнал отладки».</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальный возраст:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -696,6 +696,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">නිදොස් කිරීමේ මෙවලම් සබල කරන්න (සංවර්ධකයින් පමණි)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;පිටපත් ඩ්රග් ලොග්&quot; එබූ විට ක්ලිප් පුවරුවට පිටපත් කිරීමට උපරිම පේළි ගණන.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> රේඛා</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;නිදොස් ලොගය පිටපත් කරන්න&quot; එබූ විට පසුරු පුවරුවට පිටපත් කිරීමට ලොග් රේඛාවල උපරිම වයස (පැය/විනාඩි වලින්).</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">උපරිම වයස:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -577,6 +577,26 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Povoliť nástroje na ladenie (len pre vývojárov)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximálny počet riadkov na skopírovanie do schránky pri stlačení „Kopírujte debug protokol“.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> čiarka</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximálny vek (v hodinách/minútach) riadkov denníka, ktoré sa majú skopírovať do schránky pri stlačení tlačidla „Kopírovať denník ladenia“.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximálny vek:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -610,6 +610,26 @@ kar lahko povzroči težave z video klici.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Omogoči orodja za odpravljanje napak (samo za razvijalce)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Največje število vrstic za kopiranje v odložišče, ko pritisnete &quot;Kopiraj dnevnik odpravljanja napak&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> črte</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Največja starost (v urah/minutah) dnevnikov, ki jih lahko kopirate v odložišče, ko pritisnete &quot;Kopiraj dnevnik napak&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Največja starost:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -691,6 +691,26 @@ gjë që mund të çojë në probleme me video thirrjet.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aktivizo mjetet e korrigjimit (vetëm për zhvilluesit)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Numri maksimal i rreshtave për t&apos;u kopjuar në kujtesën e fragmenteve kur shtypni &quot;Copy Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> linjat</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mosha maksimale (në orë/minuta) e linjave log për të kopjuar në clipboard kur shtypni &quot;Kopjoni Log Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mosha Max:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -597,6 +597,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Омогући алате за отклањање грешака (само за програмере)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимални број линија за копирање у међуспремник приликом притиска &quot;Копирајте дневник за уклањање погрешака&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> линије</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална старост (у сатима/минутима) редова дневника за копирање у међуспремник када се притисне „Копирај дневник отклањања грешака“.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимална старост:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -569,6 +569,22 @@ which may lead to problems with video calls.</source>
         <source>Enable Debug Tools (developers only)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -576,6 +576,26 @@ vilket kan leda till problem med videosamtal.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aktivera felsökningsverktyg (endast utvecklare)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximalt antal rader för att kopiera till urklippet när du trycker på &quot;Kopieringsfelsökningslogg&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> rader</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Maximal ålder (i timmar/minuter) av loglinjer för att kopiera till urklippet när du trycker på &quot;Kopieringsfelsökningslogg&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max ålder:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -698,6 +698,26 @@ ambayo inaweza kusababisha matatizo na simu za video.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Washa Zana za Utatuzi (wasanidi pekee)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Idadi ya juu ya mistari ya kunakili kwenye clipboard wakati wa kubonyeza &quot;Nakala ya Debug Log&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> mistari</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Umri wa juu zaidi (katika saa/dakika) wa mistari ya kumbukumbu ili kunakili kwenye ubao wa kunakili unapobofya &quot;Nakili Rekodi ya Utatuzi&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Umri wa juu zaidi:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -619,6 +619,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>பிழைத்திருத்த கருவிகளை இயக்கவும் (டெவலப்பர்கள் மட்டும்)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;பிழைத்திருத்தப் பதிவை நகலெடு&quot; என்பதை அழுத்தும் போது, ​​கிளிப்போர்டில் நகலெடுக்க வேண்டிய வரிகளின் அதிகபட்ச எண்ணிக்கை.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> வரிகள்</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;பிழைத்திருத்தப் பதிவை நகலெடு&quot; என்பதை அழுத்தும் போது கிளிப்போர்டில் நகலெடுக்க பதிவு வரிகளின் அதிகபட்ச வயது (மணி/நிமிடங்களில்).</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">அதிகபட்ச வயது:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -578,6 +578,26 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Hata Ayıklama Araçlarını Etkinleştir (yalnızca geliştiriciler)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;Hata Ayıklama Günlüğünü Kopyala&quot;ya basıldığında panoya kopyalanacak maksimum satır sayısı.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> çizgiler</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;Hata Ayıklama Günlüğünü Kopyala&quot; düğmesine basıldığında panoya kopyalanacak günlük satırlarının maksimum yaşı (saat/dakika cinsinden).</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Max Age:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -604,6 +604,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ھەل قىلىش قوراللىرىنى قوزغىتىڭ (ئاچقۇچىلارلا)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">«خاتالىق خاتىرىسىنى كۆچۈرۈش» نى باسقاندا چاپلاش تاختىسىغا كۆچۈرمەكچى بولغان ئەڭ كۆپ قۇر.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> قۇر</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ئەڭ يۇقىرى ياش (بىر نەچچە سائەت / مىنۇت) لىنىيىسى (سائەتلىك / مىنۇتلۇق ۋاقىت) ئارقىلىق «بىر نەچچە سائەت / مىنۇتلۇق ۋاقىت» نى چېكىپ, «بىر نەچچە سائەت / مىنۇتلۇق ۋاقىت» نى چېكىپ, چاپلاش تاختىسى ئارقىلىق چاپلاش تاختىسىغا يۆتكىلىدۇ.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ئەڭ چوڭ يېشى:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -575,6 +575,26 @@ which may lead to problems with video calls.</source>
         <source>Enable Debug Tools (developers only)</source>
         <translation>Увімкнути Інструменти Відладки (тільки для розробників)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальна кількість рядків для копіювання в буфер обміну при натисканні &quot;Копіювати журнал налагодження&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> лінії</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальний вік (у години/хвилини) рядків журналу для копіювання в буфер обміну при натисканні &quot;Копіювати журнал налагодження&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Максимальний вік:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -672,6 +672,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ڈیبگ ٹولز کو فعال کریں (صرف ڈویلپرز)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;کاپی ڈیبگ لاگ&quot; دبانے پر کلپ بورڈ میں کاپی کرنے کے لیے لائنوں کی زیادہ سے زیادہ تعداد۔</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> لائنیں</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">&quot;کاپی ڈیبگ لاگ&quot; دبانے پر کلپ بورڈ میں کاپی کرنے کے لیے لاگ لائنوں کی زیادہ سے زیادہ عمر (گھنٹوں/منٹ میں)۔</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">زیادہ سے زیادہ عمر:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -575,6 +575,26 @@ có thể dẫn đến sự cố với cuộc gọi điện video.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Bật Công cụ gỡ lỗi (chỉ dành cho nhà phát triển)</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Số dòng tối đa để sao chép vào bảng nhớ tạm khi nhấn &quot;Sao chép nhật ký gỡ lỗi&quot;.</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> dòng</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tuổi tối đa (tính bằng giờ/phút) của các dòng nhật ký để sao chép vào bảng tạm khi nhấn &quot;Bản sao bản gỡ lỗi bản sao&quot;.</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tuổi tối đa:</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -573,6 +573,26 @@ which may lead to problems with video calls.</source>
         <source>Enable Debug Tools (developers only)</source>
         <translation>启用调试工具（仅限开发人员）</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">按“复制调试日志”时复制到剪贴板的最大行数。</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> 线</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">按“复制调试日志”时复制到剪贴板的日志行的最长期限（以小时/分钟为单位）。</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">最大年龄：</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -639,6 +639,26 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">啟用調試工具（僅限開發人員）</translation>
     </message>
+    <message>
+        <source>Maximum number of lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">按下“複製調試日誌”時，將最大數量複製到剪貼板中。</translation>
+    </message>
+    <message>
+        <source> lines</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished"> 線</translation>
+    </message>
+    <message>
+        <source>Maximum age (in hours/minutes) of log lines to copy into the clipboard when pressing &quot;Copy Debug Log&quot;.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">按下「複製偵錯日誌」時複製到剪貼簿的日誌行的最長期限（以小時/分鐘為單位）。</translation>
+    </message>
+    <message>
+        <source>Max age:</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">最大年齡：</translation>
+    </message>
 </context>
 <context>
     <name>AppManager</name>

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -10,9 +10,11 @@ add_library(
   src/algorithm.cpp
   include/util/display.h
   src/display.cpp
+  include/util/fileutil.h
+  src/fileutil.cpp
+  include/util/interface.h
   include/util/network.h
   src/network.cpp
-  include/util/interface.h
   include/util/ranges.h
   src/ranges.cpp
   include/util/strongtype.h

--- a/util/include/util/fileutil.h
+++ b/util/include/util/fileutil.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+
+#pragma once
+
+template <typename T>
+class QList;
+class QString;
+
+namespace FileUtil {
+QList<QString> tail(const QString& filename, int count);
+} // namespace FileUtil

--- a/util/src/fileutil.cpp
+++ b/util/src/fileutil.cpp
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+
+#include "util/fileutil.h"
+
+#include <QDebug>
+#include <QFile>
+#include <QString>
+#include <QStringList>
+#include <QTextStream>
+
+QStringList FileUtil::tail(const QString& filename, int count)
+{
+    if (count <= 0) {
+        return {};
+    }
+
+    QFile file{filename};
+    if (!file.exists()) {
+        qDebug() << "File" << filename << "does not exist";
+        return {};
+    }
+
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qDebug() << "Unable to open file" << filename;
+        return {};
+    }
+
+    // This could be made more efficient. We don't need to read the whole file,
+    // but we use this function rarely, so it's not a priority. Clarity of the
+    // code is more important here.
+    QStringList lines;
+    QTextStream in(&file);
+    while (!in.atEnd()) {
+        lines.append(in.readLine());
+    }
+
+    if (lines.isEmpty()) {
+        qDebug() << "File" << filename << "is empty";
+        return {};
+    }
+
+    if (lines.size() <= count) {
+        return lines;
+    }
+
+    return lines.mid(lines.size() - count);
+}


### PR DESCRIPTION
We usually don't need a very long history to debug issues. This protects us from having to look at unnecessarily old logs and protects users from sharing too much of their activity history.

The default of 1000 is chosen generously because it'll likely be limited by log line age first. The 1000 protects us from enormous logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/476)
<!-- Reviewable:end -->
