### PR TITLE
fix(chatform): Remove assertion that breaks friend information call.

### DIFF
--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -912,8 +912,7 @@ void History::markAsDelivered(RowId messageId)
 bool History::historyAccessBlocked()
 {
     if (!settings.getEnableLogging()) {
-        assert(false);
-        qCritical() << "Blocked history access while history is disabled";
+        qDebug() << "Blocked history access while history is disabled";
         return true;
     }
 


### PR DESCRIPTION
In this PR we are removing the assertion that the logging is on, when user tries to get the friend information. This assertion causes qTox failure when the logging is switched off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/478)
<!-- Reviewable:end -->
