### PR TITLE
fix(video): fix the way camera devices are taken, remove warning, when no device is selected

### DIFF
--- a/src/video/cameradevice.h
+++ b/src/video/cameradevice.h
@@ -37,6 +37,7 @@ public:
     static QString getDefaultDeviceName(Settings& settings);
 
     static bool isScreen(const QString& devName);
+    static const QString NONE;
 
 private:
     CameraDevice(QString devName_, AVFormatContext* context_);

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -202,7 +202,7 @@ void avLogCallback(void* obj, int level, const char* fmt, va_list args)
 
 CameraSource::CameraSource(Settings& settings_)
     : deviceThread{new QThread}
-    , deviceName{"none"}
+    , deviceName{CameraDevice::NONE}
     , device{nullptr}
     , mode{}
     , cctx{nullptr}
@@ -275,7 +275,7 @@ void CameraSource::setupDevice(const QString& deviceName_, const VideoMode& mode
 
     deviceName = deviceName_;
     mode = mode_;
-    isNone_ = (deviceName == "none");
+    isNone_ = (deviceName == CameraDevice::NONE);
 
     if ((subscriptions != 0) && !isNone_) {
         openDevice();
@@ -357,7 +357,7 @@ void CameraSource::openDevice()
     }
 
     const QWriteLocker locker{&streamMutex};
-    if (subscriptions == 0) {
+    if (subscriptions == 0 || deviceName == CameraDevice::NONE) {
         return;
     }
 


### PR DESCRIPTION
* Use new way of getting device list;
* Remove warning about inability ti select the device when no devices are selected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/488)
<!-- Reviewable:end -->
