### PR TITLE
fix(video): fix rare deadlock during call cancelation

### DIFF
--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -123,6 +123,9 @@ private:
 private:
     // atomic because potentially accessed by different threads
     std::atomic<IAudioControl*> audio;
+    // atomic flag showing that we do not need to accept frames as the cancel
+    // call request was sent.
+    std::atomic<bool> isCancelling;
     std::unique_ptr<ToxAV, ToxAVDeleter> toxav;
     std::unique_ptr<QThread> coreAvThread;
     QTimer* iterateTimer = nullptr;


### PR DESCRIPTION
In rare cases we can get the deadlock during call cancellation.
1. User hits hang up and the `QWriteLocker locker{&callsLock};` will lock the frame processing
2. Now in very edge case, the frame comes between the (1) and the call `toxav_call_control(toxav.get(), friendNum, TOXAV_CALL_CONTROL_CANCEL, &err);` which will never complete as it will hit the mutex inside toxcore (`ToxAv->mutex`). This mutex will wait for frame to be processed , which will never happen because of (1)

In this PR we stop processing frames as far as used cancelled the call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/489)
<!-- Reviewable:end -->
