### PR TITLE
feat(settings): add markdown settings to UI

### DIFF
--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -229,6 +229,16 @@ GeneralForm::GeneralForm(Settings& settings_, Style& style_)
                                           / 1024 / 1024);
     bodyUI->autoacceptFiles->setChecked(settings.getAutoSaveEnabled());
 
+    bodyUI->markdownComboBox->insertItem(static_cast<int>(Settings::StyleType::NONE),
+                                         QObject::tr("Off", "Do not interpret Markdown language."));
+    bodyUI->markdownComboBox->insertItem(static_cast<int>(Settings::StyleType::WITH_CHARS),
+                                         QObject::tr("Show Markdown symbols",
+                                                     "Interpret Markdown and show symbols."));
+    bodyUI->markdownComboBox->insertItem(
+        static_cast<int>(Settings::StyleType::WITHOUT_CHARS),
+        QObject::tr("Don't show Markdown symbols", "Interpret Markdown and do not show symbols."));
+    bodyUI->markdownComboBox->setCurrentIndex(static_cast<int>(settings.getStylePreference()));
+
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false); // these don't seem to change the appearance of the widgets,
     bodyUI->autoAwaySpinBox->setEnabled(false); // though they are unusable
@@ -344,4 +354,21 @@ void GeneralForm::retranslateUi()
     bodyUI->transWeblate->setText(
         TextCompose::createLink(style, QStringLiteral("https://hosted.weblate.org/projects/qtox/qtox/"),
                                 bodyUI->transWeblate->text()));
+}
+
+void GeneralForm::on_markdownComboBox_currentIndexChanged(int index)
+{
+    switch (index) {
+    case 0:
+        settings.setStylePreference(Settings::StyleType::NONE);
+        break;
+    case 1:
+        settings.setStylePreference(Settings::StyleType::WITH_CHARS);
+        break;
+    case 2:
+        settings.setStylePreference(Settings::StyleType::WITHOUT_CHARS);
+        break;
+    default:
+        qCritical() << "Invalid index value for markdown combo box: " << index;
+    }
 }

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -47,6 +47,7 @@ private slots:
     void on_maxAutoAcceptSizeMB_editingFinished();
     void on_autoSaveFilesDir_clicked();
     void on_checkUpdates_stateChanged();
+    void on_markdownComboBox_currentIndexChanged(int index);
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -38,9 +38,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>576</width>
-        <height>510</height>
+        <y>-108</y>
+        <width>562</width>
+        <height>605</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0">
@@ -341,6 +341,16 @@ instead of closing entirely.</string>
               </property>
              </widget>
             </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="showMDSymbolsLabel">
+              <property name="text">
+               <string>Markdown language</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QComboBox" name="markdownComboBox"/>
+            </item>
            </layout>
           </item>
          </layout>
@@ -374,7 +384,6 @@ instead of closing entirely.</string>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>scrollArea</tabstop>
   <tabstop>transComboBox</tabstop>
   <tabstop>cbAutorun</tabstop>
   <tabstop>checkUpdates</tabstop>

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -1389,6 +1389,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">مساعدة في الترجمة</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">لغة التخفيض</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2696,6 +2701,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">إصدار قاعدة البيانات (%1) أحدث مما ندعمه حاليًا (%2). الرجاء ترقية qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">عرض رموز تخفيض</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">لا تظهر رموز تخفيض</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">عن</translation>
     </message>
 </context>
 <context>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -1343,6 +1343,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Дапамажыце перакласці</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Мова размеркавання</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2624,6 +2629,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Версія базы дадзеных (%1) навейшая, чым мы зараз падтрымліваем (%2). Абнавіце qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Паказаць сімвалы MarkDown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Не паказвайце сімвалы MarkDown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Выключаны</translation>
     </message>
 </context>
 <context>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -1534,6 +1534,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵄⵉⵡⴻⵏ ⴰⵙⵓⵇⴻⵍ</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵜⵓⵜⵍⴰⵢⵜ ⵏ ⵎⴰⵔⴽⵏ .</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3007,6 +3012,24 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
         <source>Control</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵃⴻⴽⵎ</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵙⵙⴽⵏ-ⴷ ⵉⵣⵡⴰⵍ ⵏ ⵎⴰⵔⴽⴷⵓⵏ</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵓⵔ ⴷⴰ ⵙⵙⴽⴰⵏⵖ ⵉⵣⵡⴰⵍ ⵏ ⵎⴰⵔⴽⴷⵓⵏ</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵢⴻⴼⴼⴻⵖ</translation>
     </message>
 </context>
 <context>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -1301,6 +1301,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Помогнете с превода</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Език за маркиране</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2536,6 +2541,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>Изданието не банката от данни (%1) е по-нова от поддържаната в момента (%2). Обновете qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Покажете символите за маркиране</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Не показвайте символи Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Изключване</translation>
     </message>
 </context>
 <context>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -1562,6 +1562,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">অনুবাদে সাহায্য করুন</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">মার্কডাউন ভাষা</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3062,6 +3067,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ডাটাবেস সংস্করণ (%1) আমরা বর্তমানে সমর্থন করি (%2) এর চেয়ে নতুন। অনুগ্রহ করে qTox আপগ্রেড করুন।</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">মার্কডাউন প্রতীকগুলি দেখান</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">মার্কডাউন প্রতীকগুলি প্রদর্শন করবেন না</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">বন্ধ</translation>
     </message>
 </context>
 <context>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -1304,6 +1304,11 @@ nedojde k jeho úplnému ukončení.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pomozte přeložit</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown jazyk</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2557,6 +2562,24 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Verze databáze (%1) je novější, než aktuálně podporujeme (%2). Upgradujte prosím qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zobrazit symboly Markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nezobrazujte symboly Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vypnuto</translation>
     </message>
 </context>
 <context>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -1445,6 +1445,11 @@ i stedet for at lukke helt.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Hjælp med at oversætte</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown -sprog</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2879,6 +2884,24 @@ Dette ID inkluderer NoSpam-koden (i blåt) og kontrolsummen (i gråt).</translat
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Databaseversionen (%1) er nyere, end vi i øjeblikket understøtter (%2). Opgrader venligst qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vis Markdown -symboler</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vis ikke Markdown -symboler</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Slukket</translation>
     </message>
 </context>
 <context>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -1296,6 +1296,11 @@ anstatt ganz zu schließen.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Helfen Sie beim Übersetzen</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown -Sprache</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2531,6 +2536,24 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>Datenbank Version (%1) ist neuer als wir unterstützen (%2). Bitte aktualisiere qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zeigen Sie Markdown -Symbole</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zeigen Sie keine Markdown -Symbole an</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Aus</translation>
     </message>
 </context>
 <context>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -1348,6 +1348,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Βοηθήστε στη μετάφραση</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Γλωσσική γλώσσα</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2641,6 +2646,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Η έκδοση της βάσης δεδομένων (%1) είναι νεότερη από αυτήν που υποστηρίζουμε αυτήν τη στιγμή (%2). Αναβαθμίστε το qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Εμφάνιση συμβόλων Markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μην εμφανίζετε σύμβολα Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μακριά από</translation>
     </message>
 </context>
 <context>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -1464,6 +1464,11 @@ anstataŭ tute fermi.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Helpu traduki</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown Lingvo</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2891,6 +2896,24 @@ Kunhavigu ĝin kun viaj amikoj por komenci babili.
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Datumbaza versio (%1) estas pli nova ol ni nuntempe subtenas (%2). Bonvolu ĝisdatigi qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Montri markajn simbolojn</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ne montru markajn simbolojn</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">For</translation>
     </message>
 </context>
 <context>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -1294,6 +1294,11 @@ en lugar de cerrarse por completo.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ayuda a traducir</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Lenguaje de markdown</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2527,6 +2532,24 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>La versión de la base de datos (%1) es más reciente que la que actualmente soportamos (%2). Por favor, actualice qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostrar símbolos de Markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">No muestres símbolos de Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Apagado</translation>
     </message>
 </context>
 <context>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -1302,6 +1302,11 @@ jätab ta tööle teavituste alal.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aidake tõlkida</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Märgistamiskeel</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2554,6 +2559,24 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Andmebaasi versioon (%1) on uuem, kui me praegu toetame (%2). Palun uuendage qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Näita märgistamise sümboleid</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ära näita märgistus sümboleid</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ära</translation>
     </message>
 </context>
 <context>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -1337,6 +1337,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">کمک به ترجمه</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">زبان نشانه گذاری</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2611,6 +2616,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">نسخه پایگاه داده (%1) جدیدتر از آنچه در حال حاضر پشتیبانی می کنیم (%2) است. لطفا qTox را ارتقا دهید.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">نمادهای علامت گذاری را نشان دهید</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">نمادهای علامت گذاری را نشان ندهید</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">از روی</translation>
     </message>
 </context>
 <context>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -1301,6 +1301,11 @@ eikä sulkeudu kokonaan.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Auta kääntämään</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Merkintäkieli</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2552,6 +2557,24 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Tietokannan versio (%1) on uudempi kuin tällä hetkellä tuemme (%2). Päivitä qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Näytä Markdown -symbolit</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Älä näytä Markdown -symboleja</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pois</translation>
     </message>
 </context>
 <context>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -1300,6 +1300,11 @@ au lieu de fermer entièrement.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aidez à traduire</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Langue de marque</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2535,6 +2540,24 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>La version de la base de données (%1) est plus récente que celle que nous supportons actuellement (%2). Veuillez mettre à jour qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Afficher les symboles de marque</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ne montrez pas les symboles de marque</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Désactivé</translation>
     </message>
 </context>
 <context>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -1338,6 +1338,11 @@ en lugar de pechar por completo.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Axuda a traducir</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Linguaxe de marcas</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2613,6 +2618,24 @@ Este ID inclúe o código NoSpam (en azul) e a suma de verificación (en gris).<
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">A versión da base de datos (%1) é máis recente que a que admitimos actualmente (%2). Actualiza qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostrar símbolos de Markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Non mostre os símbolos de Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Off</translation>
     </message>
 </context>
 <context>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -1546,6 +1546,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">עזרה בתרגום</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">שפת סימון</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3045,6 +3050,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">גרסת מסד הנתונים (%1) חדשה יותר ממה שאנו תומכים כרגע (%2). נא לשדרג את qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">הצג סמלי סימון</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">אל תראה סמלי סימון</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">כבוי</translation>
     </message>
 </context>
 <context>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -1338,6 +1338,11 @@ umjesto da se potpuno zatvori.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pomozite prevesti</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Jezik oznake</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2613,6 +2618,24 @@ Ovaj ID uključuje NoSpam kod (plavo) i kontrolni zbroj (sivo).</translation>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Verzija baze podataka (%1) je novija nego što trenutno podržavamo (%2). Nadogradite qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Prikaži simbole Markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ne pokazuju znak Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Izvan</translation>
     </message>
 </context>
 <context>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -1334,6 +1334,11 @@ ahelyett, hogy teljesen bezárná.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Segíts fordítani</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown nyelv</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2607,6 +2612,24 @@ Ez az azonosító tartalmazza a NoSpam kódot (kék színnel) és az ellenőrző
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Az adatbázis verziója (%1) újabb, mint a jelenleg támogatott (%2). Kérjük, frissítse a qToxot.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mutasd meg a Markdown szimbólumokat</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ne mutasd meg a markdown szimbólumokat</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Le</translation>
     </message>
 </context>
 <context>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -1547,6 +1547,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Hjálpaðu til við að þýða</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown tungumál</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3036,6 +3041,24 @@ Deildu því með vinum þínum til að byrja að spjalla.
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Gagnagrunnsútgáfa (%1) er nýrri en við styðjum eins og er (%2). Vinsamlegast uppfærðu qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sýna Markdown tákn</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ekki sýna Markdown tákn</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Off</translation>
     </message>
 </context>
 <context>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -1300,6 +1300,11 @@ invece di chiudersi completamente.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aiuta a tradurre</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Lingua di markdown</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2535,6 +2540,24 @@ Questo ID include una sezione NoSpam (in colore blu) e il controllo checksum (in
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>La versione del database (%1) è più recente di quella attualmente supportata (%2). Si prega di aggiornare qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostra simboli di markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Non mostrare simboli di markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Spento</translation>
     </message>
 </context>
 <context>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -1354,6 +1354,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>翻訳を手伝ってください</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">マークダウン言語</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2645,6 +2650,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>データベースのバージョン (%1) は、現在サポートされているバージョン (%2) よりも新しいです。 qTox を更新してください。</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">マークダウンシンボルを表示します</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">マークダウンシンボルを表示しないでください</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">オフ</translation>
     </message>
 </context>
 <context>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -1540,6 +1540,11 @@ mu&apos;i nai lo nu mulno ganlo</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ko sidju lo ka fanva</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">la markdown</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3022,6 +3027,24 @@ le samselcmi cu mapti le blanu zoi gy. NoSpam .gy. joi le checksum zoi gy. gray<
         <source>Control</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">jitro</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ko jarco tu&apos;a lo marce sinxa</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ko na jarco lo markdown sinxa</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">desakti</translation>
     </message>
 </context>
 <context>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -1555,6 +1555,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಅನುವಾದಿಸಲು ಸಹಾಯ ಮಾಡಿ</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಮುಸುಕಿನ ಭಾಷೆ</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3051,6 +3056,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ನಾವು ಪ್ರಸ್ತುತ ಬೆಂಬಲಿಸುವ (%2) ಗಿಂತ ಡೇಟಾಬೇಸ್ ಆವೃತ್ತಿ (%1) ಹೊಸದು. ದಯವಿಟ್ಟು qTox ಅನ್ನು ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಮಾರ್ಕ್‌ಡೌನ್ ಚಿಹ್ನೆಗಳನ್ನು ತೋರಿಸಿ</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಮಾರ್ಕ್‌ಡೌನ್ ಚಿಹ್ನೆಗಳನ್ನು ತೋರಿಸಬೇಡಿ</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ತಟ್ಟಿಸು</translation>
     </message>
 </context>
 <context>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -1438,6 +1438,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">번역을 도와주세요</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">마크 다운 언어</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2892,6 +2897,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">데이터베이스 버전(%1)은 현재 지원하는 버전(%2)보다 최신 버전입니다. qTox를 업그레이드해주세요.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">마크 다운 기호를 보여줍니다</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">마크 다운 기호를 표시하지 마십시오</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">끄다</translation>
     </message>
 </context>
 <context>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -1570,6 +1570,11 @@ in plaats vaan gans te slete.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Help vertaole</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markonder taol</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3073,6 +3078,24 @@ Deze ID umvat de NoSpam-code (in blauw) en de checksum (in gries).</translation>
         <source>Incoming call...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inkomende oproep...</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown-symbole toene</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Toon Markdown symbole neet</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Oet</translation>
     </message>
 </context>
 <context>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -1304,6 +1304,11 @@ vietoje to, kad būtų visiškai uždarytas.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Padėkite išversti</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown kalba</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2558,6 +2563,24 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Duomenų bazės versija (%1) yra naujesnė nei šiuo metu palaikome (%2). Atnaujinkite qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Rodyti žymėjimo simbolius</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nerodykite žymėjimo simbolių</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Išjungtas</translation>
     </message>
 </context>
 <context>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -1318,6 +1318,11 @@ vietā pilnīgi aizveroties.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Palīdziet tulkot</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Marķējuma valoda</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2604,6 +2609,24 @@ Kopīgojiet to ar draugiem, lai sāktu tērzēšanu.
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Datu bāzes versija (%1) ir jaunāka, nekā mēs pašlaik atbalstām (%2). Lūdzu, jauniniet qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Parādīt marķējuma simbolus</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Neuzrāda marķējuma simbolus</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ārpus</translation>
     </message>
 </context>
 <context>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -1357,6 +1357,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Помогнете да се преведе</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Јазик за обележување</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2653,6 +2658,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Верзијата на базата на податоци (%1) е понова отколку што моментално поддржуваме (%2). Ве молиме надградете го qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Покажете симболи за обележување</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Не покажувајте симболи на Маркдаун</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Исклучено</translation>
     </message>
 </context>
 <context>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -1302,6 +1302,11 @@ istedenfor å lukke seg helt.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Hjelp til å oversette</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown -språk</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2539,6 +2544,24 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Databaseversjonen (%1) er nyere enn vi støtter for øyeblikket (%2). Vennligst oppgrader qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vis markdown -symboler</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ikke vis markdown -symboler</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Av</translation>
     </message>
 </context>
 <context>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -1293,6 +1293,11 @@ in plaats van volledig te sluiten.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Help vertalen</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown -taal</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2526,6 +2531,24 @@ Deze ID bevat de NoSpam-code (in het blauw) en de checksum (in het grijs).</tran
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>Databaseversie (%1) is nieuwer dan we momenteel ondersteunen (%2). Upgrade qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Toon markdown -symbolen</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Toon geen markdown -symbolen</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Uit</translation>
     </message>
 </context>
 <context>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -1284,6 +1284,10 @@ instead of closing entirely.</source>
         <source>Help translate</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2509,6 +2513,21 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -1317,6 +1317,11 @@ zamiast zostać całkowicie zamknięty.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pomóż przetłumaczyć</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Język Markdown</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2570,6 +2575,24 @@ To ID zawiera kod NoSpam (w kolorze niebieskim) oraz sumę kontrolną (w kolorze
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Wersja bazy danych (%1) jest nowsza niż obecnie obsługiwana (%2). Proszę zaktualizować qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pokaż symbole Markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nie pokazuj symboli Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Wyłączony</translation>
     </message>
 </context>
 <context>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -1289,6 +1289,10 @@ instead of closing entirely.</source>
         <source>Help translate</source>
         <translation type="unfinished">Lend a hand translatin&apos;</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2520,6 +2524,21 @@ This ID has th&apos; NoSpam code (in blue), &apos;n&apos; th&apos; checksum (in 
     <message>
         <source>Control</source>
         <translation type="unfinished">Th&apos; Helm</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -1301,6 +1301,11 @@ em vez de fechar.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ajude a traduzir</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Linguagem de remarca</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2552,6 +2557,24 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">A versão do banco de dados (%1) é mais recente do que a suportada atualmente (%2). Atualize o qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostre símbolos de markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Não mostre símbolos de markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Desligado</translation>
     </message>
 </context>
 <context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -1303,6 +1303,11 @@ ao invés de fechar.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ajude a traduzir</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Linguagem de remarca</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2539,6 +2544,24 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>A versão do banco de dados (%1) é mais recente do que a que suportamos atualmente (%2). Favor atualizar o qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mostre símbolos de markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Não mostre símbolos de markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Desligado</translation>
     </message>
 </context>
 <context>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -1299,6 +1299,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ajută la traducere</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Limbaj de marcare</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2534,6 +2539,24 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>Versiunea bazei de date (%1) este mai nouă decât suportăm în prezent (%2). Vă rugăm să faceți upgrade la qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Afișați simbolurile de marcare</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nu afișați simbolurile marcajului</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">OFF</translation>
     </message>
 </context>
 <context>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -1299,6 +1299,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Помочь перевести</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation>Язык разметки</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2533,6 +2538,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>Версия базы данных (%1) новее, чем поддерживаемая нами в настоящее время (%2). Пожалуйста, обновите qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation>Показать символы маркировки</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation>Не показывать символы маркировки</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation>Выключено</translation>
     </message>
 </context>
 <context>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -1565,6 +1565,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">පරිවර්තනයට උදව් කරන්න</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">මාර්ක්ඩවුන් භාෂාව</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3065,6 +3070,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">දත්ත සමුදා අනුවාදය (%1) අපි දැනට සහය දක්වන (%2) ට වඩා අලුත් ය. කරුණාකර qTox උත්ශ්‍රේණි කරන්න.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">මාර්ක්ඩවුන් සංකේත පෙන්වන්න</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">මාර්ක්ඩවුන් සංකේත පෙන්වන්න එපා</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">අක්රිය කරන්න</translation>
     </message>
 </context>
 <context>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -1306,6 +1306,11 @@ namiesto toho, že by sa zavrel úplne.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pomôžte s prekladom</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Jazyk</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2545,6 +2550,24 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Verzia databázy (%1) je novšia ako v súčasnosti podporujeme (%2). Aktualizujte qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zobraziť symboly zrážania</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nezobrazujte symboly Markdown</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vypnutý</translation>
     </message>
 </context>
 <context>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -1365,6 +1365,11 @@ namesto da bi se popolnoma zaprl.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pomagajte prevesti</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown jezik</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2735,6 +2740,24 @@ Ta ID vključuje kodo NoSpam (v modri barvi) in kontrolno vsoto (v sivi barvi).<
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Različica zbirke podatkov (%1) je novejša od trenutno podprte (%2). Prosimo, nadgradite qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Pokažite simbole označevanja</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ne prikazujte simbolov označevanja</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">OFF</translation>
     </message>
 </context>
 <context>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -1560,6 +1560,11 @@ në vend që të mbyllet plotësisht.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ndihmoni përkthimin</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Gjuhë e shenjtë</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3060,6 +3065,24 @@ Ky ID përfshin kodin NoSpam (në blu) dhe kontrollin (në gri).</translation>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Versioni i bazës së të dhënave (%1) është më i ri nga sa mbështesim aktualisht (%2). Ju lutemi përditësoni qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Trego simbolet e shënjestrës</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mos i tregoni simbolet e shënjestrës</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">I largët</translation>
     </message>
 </context>
 <context>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -1341,6 +1341,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Помозите у преводу</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Језички језик</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2617,6 +2622,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Верзија базе података (%1) је новија од оне коју тренутно подржавамо (%2). Молимо надоградите кТок.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Прикажи симболе Маркдовн</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Не приказујте симболе Маркдовн</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Искључен</translation>
     </message>
 </context>
 <context>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -1288,6 +1288,10 @@ instead of closing entirely.</source>
         <source>Help translate</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2514,6 +2518,21 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -1305,6 +1305,11 @@ istället för att stänga helt.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Hjälp till att översätta</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nedslagsspråk</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2557,6 +2562,24 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Databasversionen (%1) är nyare än vi för närvarande stöder (%2). Vänligen uppgradera qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Visa markdown -symboler</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Visa inte markdown -symboler</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Av</translation>
     </message>
 </context>
 <context>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -1567,6 +1567,11 @@ badala ya kufunga kabisa.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Saidia kutafsiri</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Lugha ya Markdown</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3067,6 +3072,24 @@ Kitambulisho hiki kinajumuisha msimbo wa NoSpam (wa bluu), na hundi (ya kijivu).
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Toleo la hifadhidata (%1) ni jipya kuliko tunalotumia sasa (%2). Tafadhali pata toleo jipya la qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Onyesha alama za alama</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Usionyeshe alama za alama</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Mbali</translation>
     </message>
 </context>
 <context>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -1377,6 +1377,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">மொழிபெயர்க்க உதவுங்கள்</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">மார்க் டவுன் மொழி</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2823,6 +2828,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">தரவுத்தள பதிப்பு (%1) நாங்கள் தற்போது ஆதரிக்கும் (%2) விட புதியது. தயவுசெய்து qTox ஐ மேம்படுத்தவும்.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">மார்க் டவுன் சின்னங்களைக் காட்டு</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">மார்க் டவுன் சின்னங்களைக் காட்ட வேண்டாம்</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ஆஃப்</translation>
     </message>
 </context>
 <context>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -1301,6 +1301,11 @@ tamamen kapanmak yerine tepsiye kapanacak.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Çeviriye yardım edin</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">İşaret dili</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2535,6 +2540,24 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>Veri tabanı sürümü (%1) şu anda desteklediğimizden (%2) daha yeni. Lütfen qTox&apos;u yükseltin.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown Sembollerini Göster</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Markdown sembollerini göstermeyin</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kapalı</translation>
     </message>
 </context>
 <context>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -1355,6 +1355,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">تەرجىمە قىلىشقا ياردەم قىلىڭ</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">بەلگە يولى</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2649,6 +2654,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ساندان نەشرى (%1) بىز قوللىغاندىن يېڭى (%2). QTox نى يېڭىلاڭ.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">تامغا بەلگە بەلگىسىنى كۆرسىتىڭ</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">چېكىنىش بەلگىسىنى كۆرسەتمەڭ</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Off</translation>
     </message>
 </context>
 <context>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -1296,6 +1296,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Допомогти перекласти</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Мова розмітки</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2539,6 +2544,24 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>Версія бази даних (%1) новіша, ніж та, яку ми зараз підтримуємо (%2). Будь ласка, оновіть qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Показати символи розмітки</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Не показуйте символи розмітки</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Не вистачати</translation>
     </message>
 </context>
 <context>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -1541,6 +1541,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ترجمہ کرنے میں مدد کریں۔</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">مارک ڈاون زبان</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -3041,6 +3046,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ڈیٹا بیس ورژن (%1) اس سے نیا ہے جو ہم فی الحال سپورٹ کرتے ہیں (%2)۔ براہ کرم qTox کو اپ گریڈ کریں۔</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">مارک ڈاون علامتیں دکھائیں</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">مارک ڈاون علامتیں نہ دکھائیں</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">آف</translation>
     </message>
 </context>
 <context>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -1300,6 +1300,11 @@ thay vì đóng hoàn toàn.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Trợ giúp dịch</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ngôn ngữ đánh dấu</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2537,6 +2542,24 @@ ID này bao gồm mã NoSpam (màu xanh lam) và checksum (màu xám).</translat
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Phiên bản cơ sở dữ liệu (%1) mới hơn phiên bản chúng tôi hiện hỗ trợ (%2). Vui lòng nâng cấp qTox.</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Hiển thị biểu tượng Markdown</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Không hiển thị các biểu tượng đánh dấu</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tắt</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1290,6 +1290,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">帮忙翻译</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">降价语言</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2522,6 +2527,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translation>数据库版本 (%1) 比我们当前支持的 (%2) 更新。请升级 qTox 。</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">显示Markdown符号</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">不要显示降价符号</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">离开</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -1463,6 +1463,11 @@ instead of closing entirely.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">幫忙翻譯</translation>
     </message>
+    <message>
+        <source>Markdown language</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">降價語言</translation>
+    </message>
 </context>
 <context>
     <name>GenericChatForm</name>
@@ -2935,6 +2940,24 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">資料庫版本 (%1) 比我們目前支援的 (%2) 新。請升級 qTox。</translation>
+    </message>
+    <message>
+        <source>Show Markdown symbols</source>
+        <comment>Interpret Markdown and show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">顯示Markdown符號</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show Markdown symbols</source>
+        <comment>Interpret Markdown and do not show symbols.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">不要顯示降價符號</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <comment>Do not interpret Markdown language.</comment>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">離開</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
We have the logic to
    * Hide Markdown
    * Interpret markdown and show markdown symbols;
    * Interpret markdown but do not show markdown symbols.

This PR exposes this setting in UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/491)
<!-- Reviewable:end -->
