### PR TITLE
fix(Settings): Don't allow invalid proxy hosts in settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 # IDE support
 /compile_commands.json
 /.lsp_tidy_cache
+
+# Local Netlify folder
+.netlify

--- a/src/widget/form/settings/advancedform.h
+++ b/src/widget/form/settings/advancedform.h
@@ -44,6 +44,7 @@ private slots:
     void on_proxyType_currentIndexChanged(int index);
 
 private:
+    bool validateProxyAddr();
     void retranslateUi();
 
 private:

--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -24,8 +24,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>485</width>
-        <height>545</height>
+        <width>479</width>
+        <height>539</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -35,16 +35,16 @@
           <string notr="true">{IMPORTANT NOTE HERE}</string>
          </property>
          <property name="textFormat">
-          <enum>Qt::RichText</enum>
+          <enum>Qt::TextFormat::RichText</enum>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -111,7 +111,7 @@
           <string>Connection settings</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <layout class="QVBoxLayout" name="verticalLayoutProxy">
           <property name="topMargin">
@@ -154,40 +154,6 @@
           </item>
           <item>
            <layout class="QGridLayout" name="proxyLayout">
-            <item row="1" column="0">
-             <widget class="QLabel" name="proxyTypeLabel">
-              <property name="text">
-               <string>Proxy type:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QSpinBox" name="proxyPort">
-              <property name="minimum">
-               <number>0</number>
-              </property>
-              <property name="maximum">
-               <number>65535</number>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="proxyAddrLabel">
-              <property name="text">
-               <string extracomment="Text on proxy addr label">Address:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLineEdit" name="proxyAddr"/>
-            </item>
-            <item row="2" column="2">
-             <widget class="QLabel" name="proxyPortLabel">
-              <property name="text">
-               <string extracomment="Text on proxy port label">Port:</string>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="1" colspan="3">
              <widget class="QComboBox" name="proxyType">
               <property name="sizePolicy">
@@ -213,6 +179,47 @@
               </item>
              </widget>
             </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="proxyAddrLabel">
+              <property name="text">
+               <string extracomment="Text on proxy addr label">Address:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="proxyAddr"/>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="proxyPortLabel">
+              <property name="text">
+               <string extracomment="Text on proxy port label">Port:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QSpinBox" name="proxyPort">
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="proxyTypeLabel">
+              <property name="text">
+               <string>Proxy type:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="proxyIpLabel">
+              <property name="text">
+               <string notr="true">{{proxyIP}}</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item>
@@ -231,7 +238,7 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -533,6 +533,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">احفظ الملف</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">عنوان الوكيل غير صالح</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">الرجاء إدخال عنوان IP صالح أو اسم مضيف لإعداد الوكيل.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -507,6 +507,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Захаваць файл</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Несапраўдны проксі -адрас</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Калі ласка, увядзіце сапраўдны IP -адрас або імя хаста для налады проксі.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -575,6 +575,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵃⵔⴻⵣ ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⵜⴰⵏⵙⴰ ⵏ ⴱⵔⵓⴽⵙⵉⵍ ⵓⵔ ⵉⵏⵏⴼⵍⵏ</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⴰⵔ ⵜⵜⵔⴰⵔⴰⵏ ⵢⴰⵏ ⵓⵏⵙⴰ ⵏ IP ⵏⵖ ⵢⴰⵏ ⵉⵙⵎ ⵏ ⵓⵎⵙⵏⵓⴱⴳ ⵍⵍⵉ ⵔⴰⴷ ⴽⵏ ⵢⴰⵡⵙ.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -489,6 +489,16 @@ which may lead to problems with video calls.</source>
         <source>Save file</source>
         <translation>Запазване на файл</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Невалиден прокси адрес</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Моля, въведете валиден IP адрес или име на хост за настройката на прокси.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -590,6 +590,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ফাইল সংরক্ষণ করুন</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">অবৈধ প্রক্সি ঠিকানা</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">প্রক্সি সেটিংয়ের জন্য দয়া করে একটি বৈধ আইপি ঠিকানা বা হোস্টনেম লিখুন।</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -489,6 +489,16 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
         <source>Save file</source>
         <translation>Uložit soubor</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Neplatná adresa proxy</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zadejte platnou IP adresu nebo název hostitele pro nastavení proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -532,6 +532,16 @@ hvilket kan føre til problemer med videoopkald.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Gem fil</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ugyldig proxyadresse</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Indtast en gyldig IP -adresse eller værtsnavn for proxyindstillingen.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -487,6 +487,16 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
         <source>Save file</source>
         <translation>Datei speichern</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ungültige Proxy -Adresse</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Bitte geben Sie eine gültige IP -Adresse oder einen gültigen Hostnamen für die Proxy -Einstellung ein.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -512,6 +512,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Αποθήκευση αρχείου</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Μη έγκυρη διεύθυνση πληρεξούσιου</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Εισαγάγετε μια έγκυρη διεύθυνση IP ή ένα όνομα κεντρικού υπολογιστή για τη ρύθμιση πληρεξούσιου.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -556,6 +556,16 @@ kio povas konduki al problemoj kun videovokoj.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Konservu dosieron</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nevalida prokura adreso</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Bonvolu enigi validan IP -adreson aŭ gastiganton por la prokura agordo.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -487,6 +487,16 @@ lo que puede provocar problemas en las videollamadas.</translation>
         <source>Save file</source>
         <translation>Guardar archivo</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dirección proxy no válida</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ingrese una dirección IP o nombre IP válido para la configuración de proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -488,6 +488,16 @@ mis võib põhjustada probleeme videokõnedega.</translation>
         <source>Save file</source>
         <translation>Salvesta fail</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kehtetu puhverserveri aadress</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sisestage puhverserveri sätte jaoks kehtiv IP -aadress või hostinimi.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -505,6 +505,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ذخیره فایل</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">آدرس پروکسی نامعتبر</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">لطفاً یک آدرس IP معتبر یا نام میزبان را برای تنظیم پروکسی وارد کنید.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -488,6 +488,16 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
         <source>Save file</source>
         <translation>Tallenna tiedosto</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Virheellinen välityspalvelinosoite</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Anna välityspalvelimen asetusten kelvollinen IP -osoite tai isäntänimi.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -488,6 +488,16 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
         <source>Save file</source>
         <translation>Enregistrer le fichier</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Adresse proxy non valide</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Veuillez saisir une adresse IP valide ou un nom d&apos;hôte pour le paramètre de proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -506,6 +506,16 @@ o que pode provocar problemas coas videochamadas.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Gardar ficheiro</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Enderezo de proxy non válido</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Insira un enderezo IP válido ou nome de host para a configuración do proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -575,6 +575,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">שמור קובץ</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">כתובת פרוקסי לא חוקית</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">אנא הזן כתובת IP או שם מארח תקף להגדרת ה- Proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -507,6 +507,16 @@ Ponekad vaša veza možda nije dovoljno dobra da podnese višu kvalitetu videa,
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Spremi datoteku</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nevažeća proxy adresa</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Unesite valjanu IP adresu ili ime hosta za postavku proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -505,6 +505,16 @@ ami problémákat okozhat a videohívásokkal kapcsolatban.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Fájl mentése</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Érvénytelen proxy cím</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kérjük, írjon be érvényes IP -címet vagy gazdagépnevet a proxy beállításhoz.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -576,6 +576,16 @@ sem getur leitt til vandræða með myndsímtöl.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Vista skrá</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ógilt umboð heimilisfang</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vinsamlegast sláðu inn gilt IP -tölu eða hýsingarheiti fyrir proxy stillinguna.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -488,6 +488,16 @@ il che può portare a problemi con le videochiamate.</translation>
         <source>Save file</source>
         <translation>Salvare il file</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Indirizzo proxy non valido</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Immettere un indirizzo IP o un nome host valido per l&apos;impostazione proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -514,6 +514,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>ファイルの保存</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">無効なプロキシアドレス</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">プロキシ設定には、有効なIPアドレスまたはホスト名を入力してください。</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -585,6 +585,16 @@ so&apos;o roi lo nu do jungau cu na banzu xamgu lo ka zgana lo nu zgana lo vidni
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">vimcu lo sfaile</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">na&apos;e vrici proksi judri</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">.e&apos;o ko setca lo validu IP judri ji lo minji cmene be lo proxy seltcidu</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -587,6 +587,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಫೈಲ್ ಉಳಿಸಿ</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಅಮಾನ್ಯ ಪ್ರಾಕ್ಸಿ ವಿಳಾಸ</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಪ್ರಾಕ್ಸಿ ಸೆಟ್ಟಿಂಗ್‌ಗಾಗಿ ದಯವಿಟ್ಟು ಮಾನ್ಯ ಐಪಿ ವಿಳಾಸ ಅಥವಾ ಹೋಸ್ಟ್ ಹೆಸರನ್ನು ನಮೂದಿಸಿ.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -528,6 +528,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">파일 저장</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">잘못된 프록시 주소</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">프록시 설정에 대한 유효한 IP 주소 또는 호스트 이름을 입력하십시오.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -596,6 +596,16 @@ wat kin leie tot probleme mit videogesprekke.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Geavanceerd</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ongeldige volmachtadres</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vuur ‘n geldig IP-adres of hostnaom in veur de proxy-instelling in.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -489,6 +489,16 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
         <source>Save file</source>
         <translation>Įrašyti failą</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Neteisingas tarpinio serverio adresas</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Įveskite galiojantį įgaliotinio nustatymo IP adresą arba pagrindinio kompiuterio vardą.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -492,6 +492,16 @@ kas var radīt video zvanu problēmas.</translation>
         <source>Save file</source>
         <translation>Saglabāt failu</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nederīga starpniekservera adrese</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Lūdzu, ievadiet derīgu IP adresi vai resursdatora nosaukumu starpniekservera iestatījumam.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -513,6 +513,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Зачувај датотека</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Невалидна прокси адреса</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Внесете важечка IP адреса или име на домаќинот за поставката за прокси.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -488,6 +488,16 @@ noe som kan forårsake problemer i videosamtaler.</translation>
         <source>Save file</source>
         <translation>Lagre fil</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ugyldig fullmaktsadresse</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vennligst skriv inn en gyldig IP -adresse eller vertsnavn for proxy -innstillingen.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -487,6 +487,16 @@ wat kan leiden tot problemen met videogesprekken.</translation>
         <source>Save file</source>
         <translation>Bestand opslaan</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ongeldig proxy -adres</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Voer een geldig IP -adres of hostnaam in voor de proxy -instelling.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -483,6 +483,14 @@ which may lead to problems with video calls.</source>
         <source>Save file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -494,6 +494,16 @@ co może powodować problemy z rozmowami wideo.</translation>
         <source>Save file</source>
         <translation>Zapisz plik</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nieprawidłowy adres proxy</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Wprowadź prawidłowy adres IP lub nazwę hosta dla ustawienia proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -487,6 +487,14 @@ Take heed, fer higher qualities demand clearer skies and use more bandwidth. If 
         <source>Save file</source>
         <translation>Store parcel</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translation type="unfinished">Yer proxy be cursed</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translation type="unfinished">Enter a proper IP address or port name fer th&apos; proxy, ye scurvy dog.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>
@@ -1884,7 +1892,7 @@ Press Shift+F1 fer more information.</translation>
     </message>
     <message>
         <source>Incoming call</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Ahoy, someone&apos;s callin&apos;!</translation>
     </message>
 </context>
 <context>
@@ -2975,7 +2983,7 @@ here may cause th&apos; scroll bar ta vanish.</translation>
     </message>
     <message>
         <source>Chat log chunk size</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Size o&apos; yer chat scroll</translation>
     </message>
     <message>
         <source>Chat log:</source>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -488,6 +488,16 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
         <source>Save file</source>
         <translation>Guardar ficheiro</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Endereço de proxy inválido</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Por favor, insira um endereço IP válido ou nome de host para a configuração de proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -488,6 +488,16 @@ o que pode levar a problemas com as videochamadas.</translation>
         <source>Save file</source>
         <translation>Salvar arquivo</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Endereço de proxy inválido</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Por favor, insira um endereço IP válido ou nome de host para a configuração de proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -488,6 +488,16 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
         <source>Save file</source>
         <translation>Salvați fișierul</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Adresa proxy nevalide</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vă rugăm să introduceți o adresă IP sau un nume de gazdă valabil pentru setarea proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -489,6 +489,16 @@ which may lead to problems with video calls.</source>
         <source>Save file</source>
         <translation>Файл сохранения</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Неверный прокси -адрес</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Пожалуйста, введите действительный IP -адрес или имя хоста для настройки прокси.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -593,6 +593,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ගොනුව සුරකින්න</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">අවලංගු ප්රොක්සි ලිපිනය</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">කරුණාකර ප්රොක්සි සැකසුම සඳහා වලංගු IP ලිපිනයක් හෝ ධාරක නාමයක් ඇතුළත් කරන්න.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -489,6 +489,16 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
         <source>Save file</source>
         <translation>Uložiť súbor</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Neplatná proxy adresa</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Zadajte platnú adresu IP alebo názov hostiteľa pre nastavenie proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -519,6 +519,16 @@ kar lahko povzroči težave z video klici.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Shrani datoteko</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Neveljaven proxy naslov</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vnesite veljaven IP naslov ali ime gostitelja za nastavitev Proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -588,6 +588,16 @@ gjë që mund të çojë në probleme me video thirrjet.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ruaj skedarin</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Adresa e pavlefshme e përfaqësuesit</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ju lutemi shkruani një adresë IP të vlefshme ose emrin e hostit për cilësimin e përfaqësuesit.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -507,6 +507,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Сачувај датотеку</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Неважећа адреса за проки</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Молимо унесите важећу ИП адресу или име хоста за подешавање прокија.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -484,6 +484,14 @@ which may lead to problems with video calls.</source>
         <source>Save file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -488,6 +488,16 @@ vilket kan leda till problem med videosamtal.</translation>
         <source>Save file</source>
         <translation>Spara fil</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ogiltig proxyadress</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ange en giltig IP -adress eller värdnamn för proxyinställningen.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -595,6 +595,16 @@ ambayo inaweza kusababisha matatizo na simu za video.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Hifadhi faili</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Anwani ya wakala batili</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Tafadhali ingiza anwani halali ya IP au jina la mwenyeji kwa mpangilio wa wakala.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -529,6 +529,16 @@ qTox இல் தாங்கள் சிக்கலோ பாதுகாப
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">கோப்பை சேமிக்கவும்</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">தவறான ப்ராக்ஸி முகவரி</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ப்ராக்ஸி அமைப்பிற்கு செல்லுபடியாகும் ஐபி முகவரி அல்லது ஹோஸ்ட்பெயரை உள்ளிடவும்.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -490,6 +490,16 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
         <source>Save file</source>
         <translation>Dosyayı kaydet</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Geçersiz Proxy Adresi</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Proxy ayarı için lütfen geçerli bir IP adresi veya ana bilgisayar adı girin.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -513,6 +513,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ھۆججەتنى ساقلاش</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ئىناۋەتسىز ۋاكالەتچى ئادرېسى</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ئىناۋەتلىك ICLY تەڭشىكى ئۈچۈن ئىناۋەتلىك IP ئادرېسى ياكى باش ئىسمى كىرگۈزۈڭ.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -488,6 +488,16 @@ which may lead to problems with video calls.</source>
         <source>Save file</source>
         <translation>Файл збереження</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Недійсна проксі -адреса</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Введіть дійсну IP -адресу або ім&apos;я хоста для налаштування проксі.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -569,6 +569,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">فائل محفوظ کریں۔</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">غلط پراکسی ایڈریس</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">براہ کرم پراکسی ترتیب کے لئے ایک درست IP ایڈریس یا میزبان نام درج کریں۔</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -487,6 +487,16 @@ có thể dẫn đến sự cố với cuộc gọi điện video.</translation>
         <source>Save file</source>
         <translation>Lưu tệp</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Địa chỉ proxy không hợp lệ</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Vui lòng nhập địa chỉ IP hợp lệ hoặc tên máy chủ cho cài đặt proxy.</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -486,6 +486,16 @@ which may lead to problems with video calls.</source>
         <source>Save file</source>
         <translation>保存文件</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">无效的代理地址</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">请为代理设置输入有效的IP地址或主机名。</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -540,6 +540,16 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">儲存檔案</translation>
     </message>
+    <message>
+        <source>Invalid proxy address</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">無效的代理地址</translation>
+    </message>
+    <message>
+        <source>Please enter a valid IP address or hostname for the proxy setting.</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">請為代理設置輸入有效的IP地址或主機名。</translation>
+    </message>
 </context>
 <context>
     <name>AdvancedSettings</name>

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -10,5 +10,6 @@ cc_library(
     deps = [
         "//c-toxcore",
         "@qt//:qt_core",
+        "@qt//:qt_network",
     ],
 )

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -8,16 +8,19 @@ add_library(
   util_library STATIC
   include/util/algorithm.h
   src/algorithm.cpp
+  include/util/display.h
+  src/display.cpp
+  include/util/network.h
+  src/network.cpp
   include/util/interface.h
   include/util/ranges.h
   src/ranges.cpp
   include/util/strongtype.h
-  include/util/display.h
-  src/display.cpp
   include/util/toxcoreerrorparser.h
   src/toxcoreerrorparser.cpp)
 
 # We need this directory, and users of our library will need it too
 target_include_directories(util_library PUBLIC include/)
 target_link_libraries(util_library PRIVATE Qt6::Core)
+target_link_libraries(util_library PRIVATE Qt6::Network)
 target_link_libraries(util_library PRIVATE qtox::warnings)

--- a/util/include/util/network.h
+++ b/util/include/util/network.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+
+#pragma once
+
+#include <QList>
+
+class QHostAddress;
+class QHostInfo;
+
+namespace NetworkUtil {
+QList<QHostAddress> ipAddresses(const QHostInfo& hostInfo, bool enableIPv6);
+} // namespace NetworkUtil

--- a/util/src/network.cpp
+++ b/util/src/network.cpp
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2025 The TokTok team.
+ */
+
+#include "util/network.h"
+
+#include <QHostAddress>
+#include <QHostInfo>
+
+QList<QHostAddress> NetworkUtil::ipAddresses(const QHostInfo& hostInfo, bool enableIPv6)
+{
+    QList<QHostAddress> addresses;
+    for (const QHostAddress& address : hostInfo.addresses()) {
+        if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+            addresses.append(address);
+        } else if (enableIPv6 && address.protocol() == QAbstractSocket::IPv6Protocol) {
+            addresses.append(address);
+        }
+    }
+    return addresses;
+}


### PR DESCRIPTION
If the user enters a DNS name that works today but not tomorrow, then tomorrow they might still get locked out of their profile in the same way as before.

https://github.com/TokTok/qTox/issues/493

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/495)
<!-- Reviewable:end -->
