### PR TITLE
cleanup: Remove untranslatable strings from translations.

### DIFF
--- a/src/widget/about/aboutfriendform.cpp
+++ b/src/widget/about/aboutfriendform.cpp
@@ -34,8 +34,6 @@ AboutFriendForm::AboutFriendForm(std::unique_ptr<IAboutFriend> about_, Settings&
     , messageBoxManager{messageBoxManager_}
 {
     ui->setupUi(this);
-    ui->label_4->hide();
-    ui->aliases->hide();
 
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &AboutFriendForm::onAcceptedClicked);
     connect(ui->autoacceptfile, &QCheckBox::clicked, this, &AboutFriendForm::onAutoAcceptDirClicked);

--- a/src/widget/about/aboutfriendform.ui
+++ b/src/widget/about/aboutfriendform.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">{{username}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
@@ -23,7 +23,7 @@
          <item>
           <widget class="QLabel" name="userName">
            <property name="text">
-            <string>username</string>
+            <string notr="true">{{username}}</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -48,7 +48,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>status message</string>
+            <string notr="true">{{status message}}</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -112,7 +112,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="label_5">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</string>
        </property>
        <property name="layoutDirection">
         <enum>Qt::LeftToRight</enum>
@@ -150,48 +150,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Used aliases:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="aliases">
-       <property name="text">
-        <string>HISTORY OF ALIASES</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0" colspan="2">
-      <widget class="QCheckBox" name="autoacceptfile">
-       <property name="accessibleDescription">
-        <string>Automatically accept files from contact if set</string>
-       </property>
-       <property name="text">
-        <string>Auto-accept files</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Default directory to save files:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QPushButton" name="selectSaveDir">
-       <property name="text">
-        <string>Auto-accept for this contact is disabled</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0" colspan="2">
+     <item row="1" column="0" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QLabel" name="label_2">
@@ -221,13 +180,37 @@
        </item>
       </layout>
      </item>
-     <item row="4" column="0" colspan="2">
+     <item row="2" column="0" colspan="2">
       <widget class="QCheckBox" name="autoConferenceInvite">
        <property name="accessibleDescription">
         <string>Automatically accept conference invitations from this contact if set.</string>
        </property>
        <property name="text">
         <string>Auto-accept conference invites</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QCheckBox" name="autoacceptfile">
+       <property name="accessibleDescription">
+        <string>Automatically accept files from contact if set</string>
+       </property>
+       <property name="text">
+        <string>Auto-accept files</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Default directory to save files:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QPushButton" name="selectSaveDir">
+       <property name="text">
+        <string>Auto-accept for this contact is disabled</string>
        </property>
       </widget>
      </item>

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -101,6 +101,7 @@ cc_fuzz_test(
     testonly = True,
     srcs = ["persistence/serialize_fuzz_test.cpp"],
     copts = COPTS,
+    corpus = ["//tools/toktok-fuzzer/corpus:serialize_fuzz_test"],
     tags = ["qt"],
     deps = ["//qtox/src:serialize"],
 )
@@ -135,6 +136,7 @@ cc_fuzz_test(
     testonly = True,
     srcs = ["model/exiftransform_fuzz_test.cpp"],
     copts = COPTS,
+    corpus = ["//tools/toktok-fuzzer/corpus:exiftransform_fuzz_test"],
     tags = ["qt"],
     deps = ["//qtox/src:exiftransform"],
 )

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -209,28 +209,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">الحوار</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation type="unfinished">اسم المستخدم</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation type="unfinished">الحالة</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation type="unfinished">الاسم:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">تاريخ الأسماء المستعارة</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation type="unfinished">قبول الملفات تلقائيا من جهة الاتصال المسجلة</translation>
     </message>
@@ -272,9 +250,9 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished">تم مسح السجل</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;هذا هو المفتاح العام لصديقك، استخدمه للتحقق من هويته عبر قناة أخرى. لا يمكنك إرسال هذا إلى أشخاص آخرين حتى يتمكنوا من إضافة جهة الاتصال هذه.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">هذا هو المفتاح العام لصديقك، استخدمه للتحقق من هويته عبر قناة أخرى. لا يمكنك إرسال هذا إلى أشخاص آخرين حتى يتمكنوا من إضافة جهة الاتصال هذه.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -203,26 +203,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Дыялог</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>імя карыстальніка</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>паведамленне аб стане</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Ужытыя псеўданімы:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ГІСТОРЫЯ ПСЕЎДАНІМАЎ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Аўтаматычна прымаць файлы ад кантактаў, калі зададзеная</translation>
     </message>
@@ -263,8 +243,8 @@ which may lead to problems with video calls.</source>
         <translation>Гісторыя выдаленая</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Гэта адкрыты ключ вашага сябра, выкарыстоўвайце яго, каб пацвердзіць яго асобу з дапамогай іншага канала. Вы не можаце адправіць гэта іншым людзям, каб яны маглі дадаць гэты кантакт.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Гэта адкрыты ключ вашага сябра, выкарыстоўвайце яго, каб пацвердзіць яго асобу з дапамогай іншага канала. Вы не можаце адправіць гэта іншым людзям, каб яны маглі дадаць гэты кантакт.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -222,31 +222,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴷⵉⵡⴻⵏⵏⵉ</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵏ ⵓⵙⴻⵇⴷⴰⵛ</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵣⴻⵏ ⵏ ⵜⴻⴳⵏⵉⵜ</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵏ ⵓⵙⵎⴻⴽⵜⵉ ⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⵏ:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">AMEZRUY N YISMAWEN</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵇⴱⴻⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ ⵉⴼⵓⵢⵍⴰ ⵙⴻⴳ ⵓⵎⴻⵙⵍⴰⵢ ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ</translation>
@@ -294,9 +269,9 @@ which may lead to problems with video calls.</source>
         <translation>ⵉⵜⵜⵡⴰⴽⴽⵙ ⵓⵎⵣⵔⵓⵢ</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;ⵀⵜⵎⵍ&gt;&lt;ⵀⴻⴰⴷ/&gt;&lt;body&gt;&lt;p&gt;Tagi ⴷ ⵜⴰⵙⴰⵔⵓⵜ ⵜⴰⵖⴻⵍⵏⴰⵡⵜ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍⵉⴽ, ⵙⵙⴻⵇⴷⴻⵛⵉⵜⵜ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⴼⵇⴻⴷ ⵜⴰⵎⴰⴳⵉⵜⵏⵙⴻⵏ ⵙ ⵜⵜⴰⵡⵉⵍ ⵏⵏⵉⴹⴻⵏ. ⵓⵔ ⵜⴻⵣⵎⵉⵔⴻⴹ ⴰⵔⴰ ⴰⴷ ⵜⴰⵣⵏⴻⴹ ⴰⵢⴰ ⵉ ⵢⵉⵎⴷⴰⵏⴻⵏ ⵢⴰⴹⵏⵉⵏ ⴰⴽⴽⴻⵏ ⴰⴷ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵔⵏⵓⵏ ⴰⵎⵢⴰⴳⴻⵔⴰ.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">ⵡⴰⴷ ⴰⵢⴷ ⵉⴳⴰⵏ ⵜⴰⵙⵓⵔⵉⴼⵜ ⵜⴰⴳⴷⵓⴷⴰⵏⵜ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵏⵏⵓⵏ, ⵙⵙⵎⵔⵙ ⵜ ⵃⵎⴰ ⴰⴷ ⵜⵙⵙⵎⵔⵙⵎ ⵜⴰⵎⴰⴳⵉⵜ ⵏⵏⵙⵏ ⵙ ⵜⴱⵔⵉⴷⵜ ⵏ ⵢⴰⵏ ⵓⴱⵔⵉⴷ ⵢⴰⴹⵏ. ⵓⵔ ⵜⵣⵎⵉⵔⴷ ⴰⴷ ⵜⵣⵔⵉⴷ ⴰⵢⴰ ⵉ ⵉⵡⴷⴰⵏ ⵢⴰⴹⵏⵉⵏ ⵃⵎⴰ ⴰⴷ ⵥⴹⴰⵕⵏ ⴰⴷ ⵔⵏⵓⵏ ⴰⵙⵖⵍ ⴰⴷ.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -197,26 +197,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Диалог</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>потребителско име</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>съобщение за състояние</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Използвани псевдоними:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ИСТОРИЯ НА ПСЕВДОНИМИ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Ако е отметнато, изпратените от този контакт файлове се приемат автоматично</translation>
     </message>
@@ -257,7 +237,7 @@ which may lead to problems with video calls.</source>
         <translation>Кореспонденцията е премахната</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translation>Това е публичният ключ на контакта. Използвайте го само за да потвърдите самоличността му чрез друг канал. Не можете да го изпращате на други хора с цел да го добавят като контакт.</translation>
     </message>
     <message>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -232,31 +232,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ডায়ালগ</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ব্যবহারকারীর নাম</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">অবস্থা বার্তা</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ব্যবহৃত উপনাম:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ALIASES ইতিহাস</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">সেট থাকলে স্বয়ংক্রিয়ভাবে পরিচিতি থেকে ফাইল গ্রহণ করুন</translation>
@@ -307,9 +282,9 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished">ইতিহাস মুছে ফেলা হয়েছে</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;এটি আপনার বন্ধুর সর্বজনীন কী, অন্য চ্যানেলের মাধ্যমে তাদের পরিচয় যাচাই করতে এটি ব্যবহার করুন৷ আপনি এটি অন্য লোকেদের কাছে পাঠাতে পারবেন না যাতে তারা এই পরিচিতি যোগ করতে পারে৷&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;৷</translation>
+        <translation type="unfinished">এটি আপনার বন্ধুর সর্বজনীন কী, অন্য চ্যানেলের মাধ্যমে তাদের পরিচয় যাচাই করতে এটি ব্যবহার করুন৷ আপনি এটি অন্য লোকেদের কাছে পাঠাতে পারবেন না যাতে তারা এই পরিচিতি যোগ করতে পারে৷৷</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -197,26 +197,6 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialogové okno</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>uživatelské jméno</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>zpráva o stavu</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Používané přezdívky:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTORIE PŘEZDÍVEK</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Pokud je povoleno, budou automaticky přijímány soubory od tohoto kontaktu</translation>
     </message>
@@ -257,8 +237,8 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
         <translation>Historie odstraněna</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toto je veřejný klíč vašeho přítele, použijte jej k ověření své identity prostřednictvím jiného kanálu. Tuto zprávu nemůžete poslat jiným lidem, aby mohli tento kontakt přidat.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Toto je veřejný klíč vašeho přítele, použijte jej k ověření své identity prostřednictvím jiného kanálu. Tuto zprávu nemůžete poslat jiným lidem, aby mohli tento kontakt přidat.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -204,28 +204,6 @@ hvilket kan føre til problemer med videoopkald.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Dialog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation type="unfinished">brugernavn</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation type="unfinished">statusmeddelelse</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation type="unfinished">Brugte aliaser:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">HISTORIE OM ALIASES</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Accepter automatisk filer fra kontakt, hvis indstillet</translation>
@@ -271,9 +249,9 @@ hvilket kan føre til problemer med videoopkald.</translation>
         <translation type="unfinished">Historik fjernet</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dette er din vens offentlige nøgle. Brug den til at bekræfte deres identitet via en anden kanal. Du kan ikke sende dette til andre personer, så de kan tilføje denne kontakt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Dette er din vens offentlige nøgle. Brug den til at bekræfte deres identitet via en anden kanal. Du kan ikke sende dette til andre personer, så de kan tilføje denne kontakt.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -196,26 +196,6 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>Benutzername</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>Statusmeldung</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Verwendete Nutzernamen:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>Verlauf der verwendeten Nutzernamen</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Nimmt Dateien dieses Kontaktes automatisch an, wenn aktiviert</translation>
     </message>
@@ -256,8 +236,8 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
         <translation>Chatverlauf gelöscht</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dies ist der öffentliche Schlüssel deines Freundes; verwende diesen, um seine Identität über einen anderen Kanal zu überprüfen. Diesen Schlüssel kann man nicht an andere Personen schicken, damit sie diesen Kontakt hinzufügen können.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Dies ist der öffentliche Schlüssel deines Freundes; verwende diesen, um seine Identität über einen anderen Kanal zu überprüfen. Diesen Schlüssel kann man nicht an andere Personen schicken, damit sie diesen Kontakt hinzufügen können.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -203,26 +203,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Παράθυρο διαλόγου</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>όνομα χρήστη</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>μήνυμα κατάστασης</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Χρησιμοποιούμενα ψευδώνυμα:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ΙΣΤΟΡΙΚΟ ΨΕΥΔΩΝΥΜΩΝ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Αυτόματη λήψη αρχείων από μια επαφή, εάν είναι επιλεγμένο</translation>
     </message>
@@ -263,9 +243,9 @@ which may lead to problems with video calls.</source>
         <translation>Το ιστορικό διεγράφη</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Αυτό είναι το δημόσιο κλειδί του φίλου σας, χρησιμοποιήστε το για να επαληθεύσετε την ταυτότητά του μέσω άλλου καναλιού. Δεν μπορείτε να το στείλετε σε άλλα άτομα, ώστε να μπορούν να προσθέσουν αυτήν την επαφή.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Αυτό είναι το δημόσιο κλειδί του φίλου σας, χρησιμοποιήστε το για να επαληθεύσετε την ταυτότητά του μέσω άλλου καναλιού. Δεν μπορείτε να το στείλετε σε άλλα άτομα, ώστε να μπορούν να προσθέσουν αυτήν την επαφή.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -217,26 +217,6 @@ kio povas konduki al problemoj kun videovokoj.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation type="unfinished">Dialogo</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation type="unfinished">uzantnomo</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation type="unfinished">statmesaĝo</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation type="unfinished">Kromnomoj uzataj:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation type="unfinished">HISTORIO DE KROMNOMOJ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Aŭtomate akceptu dosierojn de kontakto se agordita</translation>
@@ -285,9 +265,9 @@ kio povas konduki al problemoj kun videovokoj.</translation>
         <translation type="unfinished">Historio forigita</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ĉi tiu estas la publika ŝlosilo de via amiko, uzu ĝin por kontroli ilian identecon per alia kanalo. Vi ne povas sendi ĉi tion al aliaj homoj por ke ili povu aldoni ĉi tiun kontakton.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Ĉi tiu estas la publika ŝlosilo de via amiko, uzu ĝin por kontroli ilian identecon per alia kanalo. Vi ne povas sendi ĉi tion al aliaj homoj por ke ili povu aldoni ĉi tiun kontakton.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -196,26 +196,6 @@ lo que puede provocar problemas en las videollamadas.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Diálogo</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>nombre del usuario</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>mensaje de estado</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Alias usados:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTORIAL DE ALIAS</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Aceptar automáticamente archivos de los contactos si esta establecido</translation>
     </message>
@@ -256,8 +236,8 @@ lo que puede provocar problemas en las videollamadas.</translation>
         <translation>Historial eliminado</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Esta es la clave pública de su amigo, utilícela para verificar su identidad a través de otro canal. No puedes enviarla a otras personas para que puedan agregar este contacto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Esta es la clave pública de su amigo, utilícela para verificar su identidad a través de otro canal. No puedes enviarla a otras personas para que puedan agregar este contacto.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -197,26 +197,6 @@ mis võib põhjustada probleeme videokõnedega.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialoog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>kasutajanimi</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>olekuteade</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Kasutatud hüüdnimed:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HÜÜDNIMEDE AJALUGU</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Kui valitud, võetakse failid antud kontaktilt automaatselt vastu</translation>
     </message>
@@ -257,8 +237,8 @@ mis võib põhjustada probleeme videokõnedega.</translation>
         <translation>Ajalugu kustutatud</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;See on su sõbra avalik võti. Kasuta seda tema tuvastamiseks mõne teise kanali kaudu. Sa ei saa seda saata teistele inimestele, et nad saaksid lisata ta kontaktiks.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>See on su sõbra avalik võti. Kasuta seda tema tuvastamiseks mõne teise kanali kaudu. Sa ei saa seda saata teistele inimestele, et nad saaksid lisata ta kontaktiks.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -203,26 +203,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>دیالوگ</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>نام کاربری</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>پیام وضعیت</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>نام های مستعار استفاده شده:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>تاریخچه اسامی مستعار</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>در صورت تنظیم به شکل خودکار فایل ها را از مخاطب دریافت کن</translation>
     </message>
@@ -263,8 +243,8 @@ which may lead to problems with video calls.</source>
         <translation>تاریخچه پاک شد</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;این کلید عمومی دوست شماست، از آن برای تایید هویتشان از کانال دیگری، استفاده کنید. شما نبایستی این کلید را به دیگران ارسال کنید، زیرا که آنها را قادر به افزدون این مخاطب می‌کند.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>این کلید عمومی دوست شماست، از آن برای تایید هویتشان از کانال دیگری، استفاده کنید. شما نبایستی این کلید را به دیگران ارسال کنید، زیرا که آنها را قادر به افزدون این مخاطب می‌کند.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -197,26 +197,6 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialogi</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>käyttäjänimi</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>tilaviesti</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Käytetyt aliakset:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ALIASTEN HISTORIA</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Hyväksyy automaattisesti tiedostot kontaktilta, jos valittuna</translation>
     </message>
@@ -257,8 +237,8 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
         <translation>Historia poistettu</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tämä on ystäväsi julkinen avain, käytä sitä vahvistaaksesi hänen identiteettinsä toisen kanavan kautta. Et voi lähettää tätä toiselle ihmiselle, joten he voisivat lisätä tämän kontaktin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Tämä on ystäväsi julkinen avain, käytä sitä vahvistaaksesi hänen identiteettinsä toisen kanavan kautta. Et voi lähettää tätä toiselle ihmiselle, joten he voisivat lisätä tämän kontaktin.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -197,26 +197,6 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Discussion</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>nom d&apos;utilisateur</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>statut</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Alias utilisés :</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTORIQUE DES ALIAS</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Si actif, accepte automatiquement les fichiers du contact</translation>
     </message>
@@ -257,8 +237,8 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
         <translation>Historique effacé</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Celle-ci est la clé publique de votre ami, utilisez-la pour vérifier son identité via un autre canal. Vous ne pouvez pas envoyer celle-ci à d&apos;autres personnes pour qu&apos;elles puissent ajouter ce contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Celle-ci est la clé publique de votre ami, utilisez-la pour vérifier son identité via un autre canal. Vous ne pouvez pas envoyer celle-ci à d&apos;autres personnes pour qu&apos;elles puissent ajouter ce contact.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -203,26 +203,6 @@ o que pode provocar problemas coas videochamadas.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Diálogo</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>nome de usuario</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>mensaxe de estado</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Alcumes empregados:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTÓRICO DE ALCUMES</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Acepta ficheiros enviados polo contacto se está activado</translation>
     </message>
@@ -263,8 +243,8 @@ o que pode provocar problemas coas videochamadas.</translation>
         <translation>Histórico borrado</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Esta é a chave pública do seu contacto; úsea para verificar a súa identidade por outro medio. Non se pode enviala a outra xente para engadir este contacto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Esta é a chave pública do seu contacto; úsea para verificar a súa identidade por outro medio. Non se pode enviala a outra xente para engadir este contacto.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -217,31 +217,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">דיאלוג</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">שם משתמש</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">הודעת סטטוס</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">כינויים בשימוש:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">היסטוריה של כינויים</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">קבל אוטומטית קבצים מאיש קשר אם מוגדר</translation>
@@ -292,9 +267,9 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished">ההיסטוריה הוסרה</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;זהו המפתח הציבורי של חברך, השתמש בו כדי לאמת את זהותו דרך ערוץ אחר. אתה לא יכול לשלוח את זה לאנשים אחרים כדי שהם יוכלו להוסיף איש קשר זה.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">זהו המפתח הציבורי של חברך, השתמש בו כדי לאמת את זהותו דרך ערוץ אחר. אתה לא יכול לשלוח את זה לאנשים אחרים כדי שהם יוכלו להוסיף איש קשר זה.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -203,26 +203,6 @@ Ponekad vaša veza možda nije dovoljno dobra da podnese višu kvalitetu videa,
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dijalog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>korisničko ime</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>poruka stanja</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Korišteni pseudonimi:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>POVIJEST PSEUDONIMA</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Automatski prihvati datoteke od ove osobe, ako je postavljeno</translation>
     </message>
@@ -263,8 +243,8 @@ Ponekad vaša veza možda nije dovoljno dobra da podnese višu kvalitetu videa,
         <translation>Povijest je uklonjena</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ovo je javni ključ tvog prijatelja, pomoću njega možeš provjeriti njegov identitet na drugom kanalu. Ne možeš ga poslati drugima, da bi ga oni mogli dodati.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Ovo je javni ključ tvog prijatelja, pomoću njega možeš provjeriti njegov identitet na drugom kanalu. Ne možeš ga poslati drugima, da bi ga oni mogli dodati.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -203,26 +203,6 @@ ami problémákat okozhat a videohívásokkal kapcsolatban.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Párbeszédablak</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>felhasználónév</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>állapotüzenet</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Használt nevek:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>NÉV ELŐZMÉNYEK</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Automatikusan elfogad fájlokat a partnertől ha engedélyezve van</translation>
     </message>
@@ -263,8 +243,8 @@ ami problémákat okozhat a videohívásokkal kapcsolatban.</translation>
         <translation>Előzmények eltávolítva</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ez az ismerősének a nyilvános kulcsa, ezzel ellenőrizheti személyazonosságát egy másik csatornán keresztül. Ezt nem tudja elküldeni másoknak, így ők hozzáadhatják ezt a személyt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Ez az ismerősének a nyilvános kulcsa, ezzel ellenőrizheti személyazonosságát egy másik csatornán keresztül. Ezt nem tudja elküldeni másoknak, így ők hozzáadhatják ezt a személyt.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -219,30 +219,6 @@ sem getur leitt til vandræða með myndsímtöl.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Valmynd</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>notandanafn</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">stöðuskilaboð</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Notuð samnefni:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">SAGA NÁNANAÐARNA</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Samþykkja sjálfkrafa skrár frá tengilið ef stillt er</translation>
@@ -293,9 +269,9 @@ sem getur leitt til vandræða með myndsímtöl.</translation>
         <translation type="unfinished">Saga fjarlægð</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Þetta er almenningslykill vinar þíns, notaðu hann til að staðfesta auðkenni hans í gegnum aðra rás. Þú getur ekki sent þetta til annarra svo þeir geti bætt þessum tengilið við.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Þetta er almenningslykill vinar þíns, notaðu hann til að staðfesta auðkenni hans í gegnum aðra rás. Þú getur ekki sent þetta til annarra svo þeir geti bætt þessum tengilið við.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -197,26 +197,6 @@ il che può portare a problemi con le videochiamate.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Finestra di dialogo</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>Username</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>messaggio di stato</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Soprannomi usati:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>Cronologia dei soprannomi</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Accetta automaticamente files dal contatto se selezionato</translation>
     </message>
@@ -257,8 +237,8 @@ il che può portare a problemi con le videochiamate.</translation>
         <translation>Cronologia rimossa</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa è la chiave pubblica del tuo amico, usatela per verificare la sua identità attraverso un altro canale. Non è possibile inviarla ad altre persone in modo che possano aggiungere questo contatto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Questa è la chiave pubblica del tuo amico, usatela per verificare la sua identità attraverso un altro canale. Non è possibile inviarla ad altre persone in modo che possano aggiungere questo contatto.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -203,26 +203,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>ダイアログ</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>ユーザー名</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>ステータスメッセージ</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>使用したエイリアス:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>エイリアスの履歴</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>設定した場合、連絡先からのファイルを自動的に承認します</translation>
     </message>
@@ -263,9 +243,9 @@ which may lead to problems with video calls.</source>
         <translation>履歴を削除しました</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;これは友人の公開キーです。別のチャネルで友人の身元を確認するために使用します。これを他の人に送信して、他の人がこの連絡先を追加することはできません。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>これは友人の公開キーです。別のチャネルで友人の身元を確認するために使用します。これを他の人に送信して、他の人がこの連絡先を追加することはできません。</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -227,31 +227,6 @@ so&apos;o roi lo nu do jungau cu na banzu xamgu lo ka zgana lo nu zgana lo vidni
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">cpana</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">cmene cmene</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">kadni notci</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">pilno cmima:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">histori be lo ani</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">jaginai ciska</translation>
@@ -302,9 +277,9 @@ so&apos;o roi lo nu do jungau cu na banzu xamgu lo ka zgana lo nu zgana lo vidni
         <translation type="unfinished">lu citri pu vimcu</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ti me lo javni ckiku pe lo pendo be do gi&apos;e pilno lo nu jundi lo selcmi be vo&apos;a va&apos;o lo drata kanali do na kakne lo nu benji ti lo drata prenu mu&apos;i lo nu ko&apos;a kakne lo nu jmina lo vi cuntu.&lt;/ &lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">ti me lo javni ckiku pe lo pendo be do gi&apos;e pilno lo nu jundi lo selcmi be vo&apos;a va&apos;o lo drata kanali do na kakne lo nu benji ti lo drata prenu mu&apos;i lo nu ko&apos;a kakne lo nu jmina lo vi cuntu.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -230,31 +230,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಸಂವಾದ</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಬಳಕೆದಾರಹೆಸರು</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಸ್ಥಿತಿ ಸಂದೇಶ</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಬಳಸಿದ ಅಲಿಯಾಸ್:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಅಲಿಯಾಸ್‌ಗಳ ಇತಿಹಾಸ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಹೊಂದಿಸಿದಲ್ಲಿ ಸಂಪರ್ಕದಿಂದ ಫೈಲ್‌ಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸ್ವೀಕರಿಸಿ</translation>
@@ -305,9 +280,9 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished">ಇತಿಹಾಸವನ್ನು ತೆಗೆದುಹಾಕಲಾಗಿದೆ</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ಇದು ನಿಮ್ಮ ಸ್ನೇಹಿತರ ಸಾರ್ವಜನಿಕ ಕೀ, ಇನ್ನೊಂದು ಚಾನಲ್ ಮೂಲಕ ಅವರ ಗುರುತನ್ನು ಪರಿಶೀಲಿಸಲು ಇದನ್ನು ಬಳಸಿ. ನೀವು ಇದನ್ನು ಇತರ ಜನರಿಗೆ ಕಳುಹಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ ಆದ್ದರಿಂದ ಅವರು ಈ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸಬಹುದು.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">ಇದು ನಿಮ್ಮ ಸ್ನೇಹಿತರ ಸಾರ್ವಜನಿಕ ಕೀ, ಇನ್ನೊಂದು ಚಾನಲ್ ಮೂಲಕ ಅವರ ಗುರುತನ್ನು ಪರಿಶೀಲಿಸಲು ಇದನ್ನು ಬಳಸಿ. ನೀವು ಇದನ್ನು ಇತರ ಜನರಿಗೆ ಕಳುಹಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ ಆದ್ದರಿಂದ ಅವರು ಈ ಸಂಪರ್ಕವನ್ನು ಸೇರಿಸಬಹುದು.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -202,26 +202,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>대화</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation type="unfinished">사용자이름</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation type="unfinished">상태 메시지</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation type="unfinished">사용한 닉네임:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation type="unfinished">닉네임 기록</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">설정된 경우 연락처의 파일을 자동으로 수락합니다.</translation>
@@ -265,9 +245,9 @@ which may lead to problems with video calls.</source>
         <translation>기록 삭제</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;이것은 친구의 공개 키입니다. 다른 채널을 통해 친구의 신원을 확인하는 데 사용하세요. 이 연락처를 추가할 수 있도록 다른 사람에게 보낼 수는 없습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">이것은 친구의 공개 키입니다. 다른 채널을 통해 친구의 신원을 확인하는 데 사용하세요. 이 연락처를 추가할 수 있도록 다른 사람에게 보낼 수는 없습니다.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -237,39 +237,14 @@ wat kin leie tot probleme mit videogesprekke.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Dialoogvenster</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">gebruukersnaom</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">statusberiech</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dit is de openbare sleutel vaan dien vrund, gebruuk deze um hun identiteit te verifiëre via ‘n aander kanaal. Geer kin dit neet nao andere lui sjikke zodet ze dit kontak kinne toevoege.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Dit is de openbare sleutel vaan dien vrund, gebruuk deze um hun identiteit te verifiëre via ‘n aander kanaal. Geer kin dit neet nao andere lui sjikke zodet ze dit kontak kinne toevoege.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Openbare sleutel (geen ToxID):</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Gebruukde aliases:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">GESCHIEDTE VAN ALIASES</translation>
     </message>
     <message>
         <source>Automatically accept files from contact if set</source>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -197,26 +197,6 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialogas</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>Naudotojo vardas</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>Būsena</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Naudoti slapyvardžiai:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>SLAPYVARDŽIŲ ISTORIJA</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Jeigu nustatyta, automatiškai priimti failus iš šio kontakto</translation>
     </message>
@@ -257,8 +237,8 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
         <translation>Žurnalas išvalytas</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tai yra jūsų draugo viešasis raktas, naudokite jį, norėdami patvirtinti draugo tapatybę kitu kanalu. Jūs negalite siųsti šio rakto kitiems asmenims, kad jie pridėtų šį kontaktą.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Tai yra jūsų draugo viešasis raktas, naudokite jį, norėdami patvirtinti draugo tapatybę kitu kanalu. Jūs negalite siųsti šio rakto kitiems asmenims, kad jie pridėtų šį kontaktą.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -200,26 +200,6 @@ kas var radīt video zvanu problēmas.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialogs</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>lietotāja vārds</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>statusa ziņojums</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Izmantotie pseidonīmi:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>PSEIDONĪMU VĒSTURE</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Automātiski pieņemt failus no izvēlētā kontakta</translation>
     </message>
@@ -260,8 +240,8 @@ kas var radīt video zvanu problēmas.</translation>
         <translation>Vēsture ir dzēsta</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Šī ir Jūsu drauga publiskā atslēga, pielietojiet to, lai pārbaudītu savu identitāti, izmantojot citu kanālu. To nevar nosūtīt citiem cilvēkiem, lai viņi varētu pievienot šo kontaktu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Šī ir Jūsu drauga publiskā atslēga, pielietojiet to, lai pārbaudītu savu identitāti, izmantojot citu kanālu. To nevar nosūtīt citiem cilvēkiem, lai viņi varētu pievienot šo kontaktu.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -203,26 +203,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Дијалог</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>корисничко име</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>статусна порака</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Користени прекари:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ИСТОРИЈА НА ПРЕКАРИ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Ако е поставено, автоматски прифаќај датотеки од контакт</translation>
     </message>
@@ -263,9 +243,9 @@ which may lead to problems with video calls.</source>
         <translation>Историјата е отстранета</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ова е јавниот клуч на вашиот пријател, користете го за да го потврдите неговиот идентитет преку друг канал. Не можете да го испратите ова на други луѓе за да можат да го додадат овој контакт.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Ова е јавниот клуч на вашиот пријател, користете го за да го потврдите неговиот идентитет преку друг канал. Не можете да го испратите ова на други луѓе за да можат да го додадат овој контакт.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -197,26 +197,6 @@ noe som kan forårsake problemer i videosamtaler.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialogvindu</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>brukernavn</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>statusmelding</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Brukte alias:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ALIASHISTORIKK</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Automatisk godta filer fra kontakt hvis valgt</translation>
     </message>
@@ -257,8 +237,8 @@ noe som kan forårsake problemer i videosamtaler.</translation>
         <translation>Historikk fjernet</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dette er den offentlige nøkkelen til din venn, bruk den til å bekrefte identiteten deres via en annen kanal. Du kan ikke sende dette til andre folk slik at de kan legge til denne kontakten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Dette er den offentlige nøkkelen til din venn, bruk den til å bekrefte identiteten deres via en annen kanal. Du kan ikke sende dette til andre folk slik at de kan legge til denne kontakten.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -196,26 +196,6 @@ wat kan leiden tot problemen met videogesprekken.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialoogvenster</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>gebruikersnaam</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>statusbericht</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Gebruikte aliassen:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ALIASGESCHIEDENIS</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Indien ingesteld automatisch bestanden van dit contact aanvaarden</translation>
     </message>
@@ -256,8 +236,8 @@ wat kan leiden tot problemen met videogesprekken.</translation>
         <translation>Geschiedenis verwijderd</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dit is de publieke sleutel van jouw vriend, gebruik het om zijn/haar identiteit te bevestigen over een ander kanaal. Je kan dit niet naar andere mensen sturen om dit contact toe te voegen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Dit is de publieke sleutel van jouw vriend, gebruik het om zijn/haar identiteit te bevestigen over een ander kanaal. Je kan dit niet naar andere mensen sturen om dit contact toe te voegen.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -192,26 +192,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialoog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>gebruikersnaam</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>statusbericht</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Gebruikte aliassen:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ALIASGESCHIEDENIS</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Indien ingesteld automatisch bestanden van dit contact aanvaarden</translation>
     </message>
@@ -252,7 +232,7 @@ which may lead to problems with video calls.</source>
         <translation>Geschiedenis verwijderd</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -199,26 +199,6 @@ co może powodować problemy z rozmowami wideo.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Okno dialogowe</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>Nazwa użytkownika</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>komunikat o stanie</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Użyte aliasy:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTORIA ALIASÓW</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Jeśli zaznaczone, automatycznie odbieraj pliki</translation>
     </message>
@@ -259,8 +239,8 @@ co może powodować problemy z rozmowami wideo.</translation>
         <translation>Historia usunięta</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt; &lt;head/&gt; &lt;body&gt; &lt;p&gt; To jest klucz publiczny twojego znajomego, użyj go do zweryfikowania jego tożsamości innym sposobem komunikacji. Nie możesz wysłać tego innym osobom dla dodania kontaktu. &lt;/p&gt; &lt;/body&gt; &lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>To jest klucz publiczny twojego znajomego, użyj go do zweryfikowania jego tożsamości innym sposobem komunikacji. Nie możesz wysłać tego innym osobom dla dodania kontaktu.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -196,26 +196,6 @@ Take heed, fer higher qualities demand clearer skies and use more bandwidth. If 
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation type="unfinished">Dialog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation type="unfinished">Name</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation type="unfinished">Status report</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation type="unfinished">Past aliases:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation type="unfinished">RECORD O&apos; ALIASES</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation type="unfinished">Welcome all parcels</translation>
     </message>
@@ -256,7 +236,7 @@ Take heed, fer higher qualities demand clearer skies and use more bandwidth. If 
         <translation type="unfinished">All messages burnt</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translation type="unfinished">This be the public key o&apos; yer matey, use it ta verify their identity via another channel. Ye can&apos;t send this ta other people so they can add this contact.</translation>
     </message>
     <message>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -197,26 +197,6 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Diálogo</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>nome de utilizador</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>mensagem de estado</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Pseudónimos usados:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTÓRICO DE PSEUDÓNIMOS</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Se ativado, aceita automaticamente ficheiros do contacto</translation>
     </message>
@@ -257,8 +237,8 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
         <translation>Histórico eliminado</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Isto é a chave pública do seu amigo. Use-a para verificar a identidade dele através de outro meio. Não pode enviar isto para outras pessoas para que elas possam adicionar este contacto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Isto é a chave pública do seu amigo. Use-a para verificar a identidade dele através de outro meio. Não pode enviar isto para outras pessoas para que elas possam adicionar este contacto.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -197,26 +197,6 @@ o que pode levar a problemas com as videochamadas.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Diálogo</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>nome de usuário</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>mensagem de status</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Pseudônimos usados:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTÓRICO DE PSEUDÔNIMOS</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Se marcado, aceita automaticamente arquivos do contato</translation>
     </message>
@@ -257,8 +237,8 @@ o que pode levar a problemas com as videochamadas.</translation>
         <translation>Histórico apagado</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Essa é a chave pública do seu amigo, use-a para confirmar sua identidade por meio de outro canal. Você não pode enviar isso para outras pessoas para que elas possam adicionar esse contato.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Essa é a chave pública do seu amigo, use-a para confirmar sua identidade por meio de outro canal. Você não pode enviar isso para outras pessoas para que elas possam adicionar esse contato.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -196,26 +196,6 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>nume de utilizator</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>Mesaj de stare</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Aliasurile folosite:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ISTORIA ALIASELOR</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Acceptă automat fișiere din contact dacă este setat</translation>
     </message>
@@ -256,8 +236,8 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
         <translation>Istorie eliminată</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aceasta este cheia publică a prietenului tău, folosește-o pentru a-și verifica identitatea prin alt canal. Nu puteți trimite acest lucru altor persoane pentru a putea adăuga acest contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Aceasta este cheia publică a prietenului tău, folosește-o pentru a-și verifica identitatea prin alt canal. Nu puteți trimite acest lucru altor persoane pentru a putea adăuga acest contact.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -196,26 +196,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Диалог</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>имя пользователя</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>статус</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Используемый псевдоним:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ИСТОРИЯ ПСЕВДОНИМОВ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Автоматически принимать файлы от контактов если установленo</translation>
     </message>
@@ -256,8 +236,8 @@ which may lead to problems with video calls.</source>
         <translation>История переписки удалена</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это открытый (публичный) ключ вашего друга, используйте его, чтобы подтвердить свою личность через другой канал. Вы не можете отправить его другим людям для добавления этого контакта.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Это открытый (публичный) ключ вашего друга, используйте его, чтобы подтвердить свою личность через другой канал. Вы не можете отправить его другим людям для добавления этого контакта.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -235,31 +235,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ඩයලොග්</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">පරිශීලක නාමය</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">තත්ව පණිවිඩය</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">භාවිත අන්වර්ථ:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">අන්වර්ථ නාමයන්ගේ ඉතිහාසය</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">සකසා ඇත්නම් සම්බන්ධතාවෙන් ගොනු ස්වයංක්‍රීයව පිළිගන්න</translation>
@@ -310,9 +285,9 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished">ඉතිහාසය ඉවත් කර ඇත</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;මෙය ඔබේ මිතුරාගේ පොදු යතුරයි, වෙනත් නාලිකාවක් හරහා ඔවුන්ගේ අනන්‍යතාවය තහවුරු කිරීමට එය භාවිතා කරන්න. ඔබට මෙය වෙනත් පුද්ගලයින්ට යැවිය නොහැක, එවිට ඔවුන්ට මෙම සම්බන්ධතාව එක් කළ හැක.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">මෙය ඔබේ මිතුරාගේ පොදු යතුරයි, වෙනත් නාලිකාවක් හරහා ඔවුන්ගේ අනන්‍යතාවය තහවුරු කිරීමට එය භාවිතා කරන්න. ඔබට මෙය වෙනත් පුද්ගලයින්ට යැවිය නොහැක, එවිට ඔවුන්ට මෙම සම්බන්ධතාව එක් කළ හැක.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -197,26 +197,6 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialóg</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>používateľské meno</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>Správa o stave</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Používané prezývky:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTÓRIA PREZÝVOK</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Ak je zaškrtnuté, automaticky prijímať súbory od tohto kontaktu</translation>
     </message>
@@ -257,8 +237,8 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
         <translation>História bola odstránená</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toto je verejný kľúč vášho priateľa, použite ho na overenie jeho totožnosti prostredníctvom iného kanála. Tento kľúč nie je možné poslať iným ľuďom, aby si pridali tento kontakt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Toto je verejný kľúč vášho priateľa, použite ho na overenie jeho totožnosti prostredníctvom iného kanála. Tento kľúč nie je možné poslať iným ľuďom, aby si pridali tento kontakt.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -206,26 +206,6 @@ kar lahko povzroči težave z video klici.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Okno sporočila</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>uporabniško ime</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>sporočilo o stanju</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Uporabljeni vzdevki:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ZGODOVINA VZDEVKOV</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Samodejno sprejemanje datotek iz kontakta (če nastavljen)</translation>
     </message>
@@ -266,9 +246,9 @@ kar lahko povzroči težave z video klici.</translation>
         <translation>Zgodovina izbrisana</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To je javni ključ vašega prijatelja, uporabite ga za preverjanje njegove identitete prek drugega kanala. Tega ne morete poslati drugim osebam, da lahko dodajo ta stik.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">To je javni ključ vašega prijatelja, uporabite ga za preverjanje njegove identitete prek drugega kanala. Tega ne morete poslati drugim osebam, da lahko dodajo ta stik.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -230,31 +230,6 @@ gjë që mund të çojë në probleme me video thirrjet.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Dialogu</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">emri i përdoruesit</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">mesazh statusi</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Pseudonimet e përdorura:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">HISTORIA E PASTESAVE</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Prano automatikisht skedarët nga kontakti nëse është caktuar</translation>
@@ -305,9 +280,9 @@ gjë që mund të çojë në probleme me video thirrjet.</translation>
         <translation type="unfinished">Historia u hoq</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ky është çelësi publik i mikut tuaj, përdorni atë për të verifikuar identitetin e tij nëpërmjet një kanali tjetër. Nuk mund t&apos;ua dërgosh këtë njerëzve të tjerë që të mund ta shtojnë këtë kontakt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Ky është çelësi publik i mikut tuaj, përdorni atë për të verifikuar identitetin e tij nëpërmjet një kanali tjetër. Nuk mund t&apos;ua dërgosh këtë njerëzve të tjerë që të mund ta shtojnë këtë kontakt.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -203,26 +203,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Прозорче</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>корисничко име</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>порука стања</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Коришћени алијаси:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ИСТОРИЈАТ АЛИЈАСА</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Ако је постављено аутоматски прихвата датотеке од контаката</translation>
     </message>
@@ -263,8 +243,8 @@ which may lead to problems with video calls.</source>
         <translation>Историјат је уклоњен</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ово је јавни кључ вашег пријатеља, користите га да потврдите њихов идентитет преко другог канала. Не можете ово да пошаљете другим особама да би и они могли додати овај контакт.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Ово је јавни кључ вашег пријатеља, користите га да потврдите њихов идентитет преко другог канала. Не можете ово да пошаљете другим особама да би и они могли додати овај контакт.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -192,26 +192,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dijalog</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>orisničko ime</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>statusna poruka</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Korišćeni alijasi:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ISTORIJAT ALIJASA</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Ukoliko je postavljeno automatski prihvata fajlove od kontakata</translation>
     </message>
@@ -252,7 +232,7 @@ which may lead to problems with video calls.</source>
         <translation>Istorijat je uklonjen</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -197,26 +197,6 @@ vilket kan leda till problem med videosamtal.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Dialogruta</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>användarnamn</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>statusmeddelande</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Använda alias:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>HISTORIK AV ALIAS</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Acceptera filer automatiskt från kontakt om angivet</translation>
     </message>
@@ -257,8 +237,8 @@ vilket kan leda till problem med videosamtal.</translation>
         <translation>Historik borttagen</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detta är din väns offentliga nyckel, använd den för att verifiera dennes identitet via annan kanal. Du kan inte skicka detta till andra människor, så att de kan lägga till denna kontakt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Detta är din väns offentliga nyckel, använd den för att verifiera dennes identitet via annan kanal. Du kan inte skicka detta till andra människor, så att de kan lägga till denna kontakt.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -237,31 +237,6 @@ ambayo inaweza kusababisha matatizo na simu za video.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Mazungumzo</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">jina la mtumiaji</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ujumbe wa hali</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Lakabu zilizotumika:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">HISTORIA YA AJIRA</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Kubali faili kiotomatiki kutoka kwa anwani ikiwa imewekwa</translation>
@@ -312,9 +287,9 @@ ambayo inaweza kusababisha matatizo na simu za video.</translation>
         <translation type="unfinished">Historia imeondolewa</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Huu ni ufunguo wa umma wa rafiki yako, utumie kuthibitisha utambulisho wake kupitia kituo kingine. Huwezi kutuma hii kwa watu wengine ili waweze kuongeza anwani hii.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">Huu ni ufunguo wa umma wa rafiki yako, utumie kuthibitisha utambulisho wake kupitia kituo kingine. Huwezi kutuma hii kwa watu wengine ili waweze kuongeza anwani hii.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -209,26 +209,6 @@ qTox இல் தாங்கள் சிக்கலோ பாதுகாப
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation type="unfinished">உரையாடல்</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation type="unfinished">பயனர்பெயர்</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation type="unfinished">நிலைச்செய்தி</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation type="unfinished">பயன்பாட்டலுள்ள மாற்றுப்பெயர்கள்:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation type="unfinished">இதுவரை பயன்படுத்தப்பட்ட மாற்றுப்பெயர்கள்</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation type="unfinished">அவ்வாறு அமைக்கப்பட்டிருந்தால் தொடர்பிடமிருந்து கோப்புகளைத் தன்னிச்சையாக ஏற்க</translation>
     </message>
@@ -269,9 +249,9 @@ qTox இல் தாங்கள் சிக்கலோ பாதுகாப
         <translation type="unfinished">வரலாறு அகற்றப்பட்டது</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;இது உங்கள் நண்பரின் பொது விசை, இதைப் பயன்படுத்தி மற்றொரு சேனல் மூலம் அவரது அடையாளத்தைச் சரிபார்க்கவும். நீங்கள் இதை மற்றவர்களுக்கு அனுப்ப முடியாது, அதனால் அவர்கள் இந்தத் தொடர்பைச் சேர்க்கலாம்.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">இது உங்கள் நண்பரின் பொது விசை, இதைப் பயன்படுத்தி மற்றொரு சேனல் மூலம் அவரது அடையாளத்தைச் சரிபார்க்கவும். நீங்கள் இதை மற்றவர்களுக்கு அனுப்ப முடியாது, அதனால் அவர்கள் இந்தத் தொடர்பைச் சேர்க்கலாம்.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -198,26 +198,6 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>İletişim Kutusu</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>kullanıcı adı</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>durum iletisi</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Kullanılan rumuzlar:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>RUMUZ GEÇMİŞİ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Ayarlıysa kişiden gelen dosyaları sormadan kabul et</translation>
     </message>
@@ -258,8 +238,8 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
         <translation>Geçmiş kaldırıldı</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bu, arkadaşlarının açık anahtarıdır, herhangi bir kanalla kimliklerini doğrulamak için kullanın. Bunu diğer insanlara gönderemediğiniz için onlar bu kişiyi ekleyebilir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Bu, arkadaşlarının açık anahtarıdır, herhangi bir kanalla kimliklerini doğrulamak için kullanın. Bunu diğer insanlara gönderemediğiniz için onlar bu kişiyi ekleyebilir.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -203,26 +203,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>دېئالوگ</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>ئىشلەتكۈچى ئىسىمى</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>ئۇچۇر ھالىتى</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>ئىشلەتكەن ئىسىملار:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>بۇرۇن قوللانغان ئىسىملار</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>دوستلار ئەۋەتكەن ھۆججەتنى ئاپتۇماتىك قۇبۇل قىلىش</translation>
     </message>
@@ -263,9 +243,9 @@ which may lead to problems with video calls.</source>
         <translation>خاتىرىلەرنى تازىلاش</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt; &lt;head /&gt; &lt;body&gt; &lt;p&gt; بۇ دوستىڭىزنىڭ ئاممىۋى ئاچقۇچى ، ئۇنى ئىشلىتىپ باشقا قانال ئارقىلىق ئۇلارنىڭ كىملىكىنى دەلىللەڭ. بۇنى باشقا كىشىلەرگە ئەۋەتەلمەيسىز ، شۇڭا ئۇلار بۇ ئالاقىنى قوشالايدۇ. &lt;/p&gt; &lt;/body&gt; &lt;/html&gt;</translation>
+        <translation type="unfinished">بۇ دوستىڭىزنىڭ ئاممىۋى ئاچقۇچى ، ئۇنى ئىشلىتىپ باشقا قانال ئارقىلىق ئۇلارنىڭ كىملىكىنى دەلىللەڭ. بۇنى باشقا كىشىلەرگە ئەۋەتەلمەيسىز ، شۇڭا ئۇلار بۇ ئالاقىنى قوشالايدۇ.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -196,26 +196,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Діалог</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>ім&apos;я користувача</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>статус</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Псевдоніми, що використовуються:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>ІСТОРІЯ ПСЕВДОНІМІВ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Автоматично приймати файли від контакту, якщо встановлено</translation>
     </message>
@@ -256,8 +236,8 @@ which may lead to problems with video calls.</source>
         <translation>Історія видалена</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Це відкритий (публічний) ключ вашого друга, використовуйте його для підтвердження його особистості через інший канал. Ви не можете надсилати його іншим людям, щоб вони могли додати цей контакт.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Це відкритий (публічний) ключ вашого друга, використовуйте його для підтвердження його особистості через інший канал. Ви не можете надсилати його іншим людям, щоб вони могли додати цей контакт.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -211,31 +211,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ڈائیلاگ</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">صارف نام</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">حیثیت کا پیغام</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">استعمال شدہ عرفی نام:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">عرفی ناموں کی تاریخ</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">اگر سیٹ ہو تو رابطہ سے فائلوں کو خود بخود قبول کریں۔</translation>
@@ -286,9 +261,9 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished">تاریخ ہٹا دی گئی۔</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;یہ آپ کے دوست کی عوامی کلید ہے، اسے دوسرے چینل کے ذریعے ان کی شناخت کی تصدیق کے لیے استعمال کریں۔ آپ اسے دوسرے لوگوں کو نہیں بھیج سکتے تاکہ وہ اس رابطہ کو شامل کر سکیں۔&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished">یہ آپ کے دوست کی عوامی کلید ہے، اسے دوسرے چینل کے ذریعے ان کی شناخت کی تصدیق کے لیے استعمال کریں۔ آپ اسے دوسرے لوگوں کو نہیں بھیج سکتے تاکہ وہ اس رابطہ کو شامل کر سکیں۔</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -197,26 +197,6 @@ có thể dẫn đến sự cố với cuộc gọi điện video.</translation>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>Hộp thoại</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>tên tài khoản</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>dòng trạng thái</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>Bí danh đã sử dụng:</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>LỊCH SỬ BÍ DANH</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>Tự động chấp nhận các tệp từ người khác nếu được đặt</translation>
     </message>
@@ -257,8 +237,8 @@ có thể dẫn đến sự cố với cuộc gọi điện video.</translation>
         <translation>Lịch sử đã bị xóa</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Đây là khóa công khai của bạn bè bạn, hãy sử dụng nó để xác minh danh tính của họ qua một kênh khác. Bạn không thể gửi thông tin này cho người khác để họ có thể thêm liên hệ này.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>Đây là khóa công khai của bạn bè bạn, hãy sử dụng nó để xác minh danh tính của họ qua một kênh khác. Bạn không thể gửi thông tin này cho người khác để họ có thể thêm liên hệ này.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -196,26 +196,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation>对话框</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation>用户名</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation>状态消息</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation>已用的别名：</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation>曾用的别名</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translation>如果设置则自动接收来自联系人的文件</translation>
     </message>
@@ -256,8 +236,8 @@ which may lead to problems with video calls.</source>
         <translation>已删除历史记录</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;这是您朋友的公钥，使用它通过其它渠道来验证朋友的身份。您不能将该密钥发送给其他人以使他们可以添加该朋友为联系人。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
+        <translation>这是您朋友的公钥，使用它通过其它渠道来验证朋友的身份。您不能将该密钥发送给其他人以使他们可以添加该朋友为联系人。</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -206,26 +206,6 @@ which may lead to problems with video calls.</source>
 <context>
     <name>AboutFriendForm</name>
     <message>
-        <source>Dialog</source>
-        <translation type="unfinished">對話方塊</translation>
-    </message>
-    <message>
-        <source>username</source>
-        <translation type="unfinished">使用者名稱</translation>
-    </message>
-    <message>
-        <source>status message</source>
-        <translation type="unfinished">狀態訊息</translation>
-    </message>
-    <message>
-        <source>Used aliases:</source>
-        <translation type="unfinished">使用的別名：</translation>
-    </message>
-    <message>
-        <source>HISTORY OF ALIASES</source>
-        <translation type="unfinished">別名歷史</translation>
-    </message>
-    <message>
         <source>Automatically accept files from contact if set</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">如果設置，自動接受聯絡人的文件</translation>
@@ -270,9 +250,9 @@ which may lead to problems with video calls.</source>
         <translation type="unfinished">已移除歷史記錄</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
         <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;這是您朋友的公鑰，用它透過另一個管道驗證他們的身份。您無法將此資訊傳送給其他人，以便他們可以新增此聯絡人。</translation>
+        <translation type="unfinished">這是您朋友的公鑰，用它透過另一個管道驗證他們的身份。您無法將此資訊傳送給其他人，以便他們可以新增此聯絡人。</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>


### PR DESCRIPTION
These are confusing and useless to translate.

https://github.com/TokTok/qTox/issues/497

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/498)
<!-- Reviewable:end -->
