### PR TITLE
cleanup: Some more translation string cleanups.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,8 @@ set(${PROJECT_NAME}_SOURCES
     src/widget/notificationscrollarea.h
     src/widget/passwordedit.cpp
     src/widget/passwordedit.h
+    src/widget/popup.cpp
+    src/widget/popup.h
     src/widget/qrwidget.cpp
     src/widget/qrwidget.h
     src/widget/splitterrestorer.cpp

--- a/src/chatlog/content/filetransferwidget.ui
+++ b/src/chatlog/content/filetransferwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">{{file transfer}}</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <property name="spacing">

--- a/src/widget/about/aboutfriendform.cpp
+++ b/src/widget/about/aboutfriendform.cpp
@@ -8,21 +8,12 @@
 #include "ui_aboutfriendform.h"
 
 #include "src/core/toxpk.h"
+#include "src/widget/popup.h"
 #include "src/widget/style.h"
 #include "src/widget/tool/imessageboxmanager.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
-
-namespace {
-QString getAutoAcceptDir(const QString& dir)
-{
-    //: popup title
-    const QString title = AboutFriendForm::tr("Choose an auto-accept directory");
-    return QFileDialog::getExistingDirectory(Q_NULLPTR, title, dir);
-}
-
-} // namespace
 
 AboutFriendForm::AboutFriendForm(std::unique_ptr<IAboutFriend> about_, Settings& settings_,
                                  Style& style_, IMessageBoxManager& messageBoxManager_, QWidget* parent)
@@ -82,7 +73,7 @@ void AboutFriendForm::onAutoAcceptDirClicked()
             return QString{};
         }
 
-        return getAutoAcceptDir(about->getAutoAcceptDir());
+        return Popup::getAutoAcceptDir(this, about->getAutoAcceptDir());
     }();
 
     about->setAutoAcceptDir(dir);
@@ -119,7 +110,7 @@ void AboutFriendForm::onAutoConferenceInvite()
 
 void AboutFriendForm::onSelectDirClicked()
 {
-    const QString dir = getAutoAcceptDir(about->getAutoAcceptDir());
+    const QString dir = Popup::getAutoAcceptDir(this, about->getAutoAcceptDir());
     about->setAutoAcceptDir(dir);
 }
 

--- a/src/widget/form/debug/debuglog.ui
+++ b/src/widget/form/debug/debuglog.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{debug log}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/widget/form/profileform.ui
+++ b/src/widget/form/profileform.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{profile}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/widget/form/searchsettingsform.ui
+++ b/src/widget/form/searchsettingsform.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">{{search settings}}</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">

--- a/src/widget/form/settings/aboutsettings.ui
+++ b/src/widget/form/settings/aboutsettings.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{about settings}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{advanced settings}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/widget/form/settings/avform.ui
+++ b/src/widget/form/settings/avform.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{av setings}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -11,6 +11,7 @@
 #include "src/persistence/settings.h"
 #include "src/widget/form/settings/textcompose.h"
 #include "src/widget/form/settingswidget.h"
+#include "src/widget/popup.h"
 #include "src/widget/style.h"
 #include "src/widget/tool/recursivesignalblocker.h"
 #include "src/widget/translator.h"
@@ -311,12 +312,11 @@ void GeneralForm::on_autoacceptFiles_stateChanged()
 void GeneralForm::on_autoSaveFilesDir_clicked()
 {
     const QString previousDir = settings.getGlobalAutoAcceptDir();
-    QString directory =
-        QFileDialog::getExistingDirectory(Q_NULLPTR,
-                                          tr("Choose an auto accept directory", "popup title"),
-                                          QDir::homePath());
-    if (directory.isEmpty()) // cancel was pressed
+    QString directory = Popup::getAutoAcceptDir(this, QDir::homePath());
+    if (directory.isEmpty()) {
+        // cancel was pressed
         directory = previousDir;
+    }
 
     settings.setGlobalAutoAcceptDir(directory);
     bodyUI->autoSaveFilesDir->setText(directory);

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{general settings}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">

--- a/src/widget/form/settings/privacysettings.ui
+++ b/src/widget/form/settings/privacysettings.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{privacy settings}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">{{ui settings}}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -19,6 +19,7 @@
 #include "src/persistence/settings.h"
 #include "src/widget/about/aboutfriendform.h"
 #include "src/widget/form/chatform.h"
+#include "src/widget/popup.h"
 #include "src/widget/style.h"
 #include "src/widget/tool/croppinglabel.h"
 #include "src/widget/widget.h"
@@ -265,10 +266,7 @@ void FriendWidget::changeAutoAccept(bool enable)
 {
     if (enable) {
         const auto oldDir = chatroom->getAutoAcceptDir();
-        const auto newDir =
-            QFileDialog::getExistingDirectory(Q_NULLPTR,
-                                              tr("Choose an auto accept directory", "popup title"),
-                                              oldDir);
+        const auto newDir = Popup::getAutoAcceptDir(this, oldDir);
         chatroom->setAutoAcceptDir(newDir);
     } else {
         chatroom->disableAutoAccept();

--- a/src/widget/popup.cpp
+++ b/src/widget/popup.cpp
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2019 by The qTox Project Contributors
+ * Copyright © 2024-2025 The TokTok team.
+ */
+
+#include "popup.h"
+
+#include <QFileDialog>
+
+QString Popup::getAutoAcceptDir(QWidget* parent, const QString& dir)
+{
+    const QString title = QFileDialog::tr("Choose an auto-accept directory", "popup title");
+    return QFileDialog::getExistingDirectory(parent, title, dir);
+}

--- a/src/widget/popup.h
+++ b/src/widget/popup.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2019 by The qTox Project Contributors
+ * Copyright © 2024-2025 The TokTok team.
+ */
+
+#pragma once
+
+class QString;
+class QWidget;
+
+namespace Popup {
+QString getAutoAcceptDir(QWidget* parent, const QString& dir);
+} // namespace Popup

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -298,12 +298,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">يمكنك حفظ التعليقات حول جهة الاتصال هذه هنا.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">اختر دليل القبول التلقائي</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1018,10 +1012,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>النوع</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>انتظار للارسال...</translation>
@@ -1175,11 +1165,6 @@ so you can save the file on Windows.</source>
         <translation>اظهار التفاصيل</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>اختر مجلد الحفظ التلقائي</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>رسالة جديدة</translation>
     </message>
@@ -1225,11 +1210,6 @@ so you can save the file on Windows.</source>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>اختيار مسار الحفظ التلقائي</translation>
-    </message>
     <message>
         <source>General</source>
         <translation>عام</translation>
@@ -2422,6 +2402,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">اختر دليل القبول التلقائي</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2752,10 +2740,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">النوع</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -287,12 +287,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Вы можаце захоўваць каментарыі аб гэтым кантакце тут.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Выберыце каталог з аўтаматычным прыняццем</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -977,11 +971,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Форма</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Чаканне адпраўкі...</translation>
@@ -1142,11 +1131,6 @@ so you can save the file on Windows.</source>
         <translation>Паказаць дэталі</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Выбраць каталог для аўтаматычна прынятых файлаў</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Новае паведамленне</translation>
     </message>
@@ -1188,11 +1172,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Агульныя</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Выбраць каталог для аўтаматычна прынятых файлаў</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2362,6 +2341,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Выберыце каталог з аўтаматычным прыняццем</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2680,10 +2667,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Форма</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Пачаць шукаць:</translation>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -318,12 +318,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵣⴻⵎⵔⴻⴹ ⴰⴷ ⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵉⵎⴻⵙⵍⴰⵢⴻⵏ ⵖⴻⴼ ⵓⵙⵎⴻⵍⴰ ⴷⴰⴳⵉ.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴼⵔⴻⵏ ⴰⴹⵔⵉⵙ ⵏ ⵓⵇⴱⴰⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1102,11 +1096,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴳⴻⵜⵯⴷ</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1298,12 +1287,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">ⵙⴽⴻⵏ ⵜⵉⴼⴻⵙⵙⴰⵙⵉⵏ</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴼⵔⴻⵏ ⴰⴹⵔⵉⵙ ⵏ ⵓⵇⴱⴰⵍ ⵙ ⵜⵉⵎⵎⴰⴷⵉⵙ</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓ</translation>
@@ -1350,12 +1333,6 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵎⴰⵜⴰ</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴼⵔⴻⵏ ⴰⴹⵔⵉⵙ ⵏ ⵓⵇⴱⴰⵍ ⵙ ⵜⵉⵎⵎⴰⴷⵉⵙ</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2717,6 +2694,14 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">ⴼⵔⴻⵏ ⴰⴹⵔⵉⵙ ⵏ ⵓⵇⴱⴰⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3065,11 +3050,6 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴳⴻⵜⵯⴷ</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -276,11 +276,6 @@ which may lead to problems with video calls.</source>
         <source>You can save comments about this contact here.</source>
         <translation>Можете да напишете бележка за контакта.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Изберете папката, в която се приемат файлове</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -946,10 +941,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Формуляр</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Изчакване преди изпращане…</translation>
@@ -1074,11 +1065,6 @@ so you can save the file on Windows.</source>
         <translation>Покана за групов разговор</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Изберете папката, в която се приемат файлове</translation>
-    </message>
-    <message>
         <source>Open chat in new window</source>
         <translation>Преместване в отделен прозорец</translation>
     </message>
@@ -1150,11 +1136,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Общи</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Изберете папка за автоматично приемане</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2292,6 +2273,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Изберете папката, в която се приемат файлове</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2592,10 +2581,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Формуляр</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Започни търсене:</translation>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -331,12 +331,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">আপনি এখানে এই পরিচিতি সম্পর্কে মন্তব্য সংরক্ষণ করতে পারেন.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">একটি স্বয়ংক্রিয় গ্রহণ ডিরেক্টরি নির্বাচন করুন</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1129,11 +1123,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ফর্ম</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1325,12 +1314,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">বিস্তারিত দেখান</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">একটি স্বয়ংক্রিয় গ্রহণ ডিরেক্টরি নির্বাচন করুন</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">নতুন বার্তা</translation>
@@ -1378,12 +1361,6 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">সাধারণ</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">একটি স্বয়ংক্রিয় গ্রহণ ডিরেক্টরি নির্বাচন করুন</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2758,6 +2735,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">একটি স্বয়ংক্রিয় গ্রহণ ডিরেক্টরি নির্বাচন করুন</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3125,11 +3110,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ফর্ম</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -276,11 +276,6 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
         <source>You can save comments about this contact here.</source>
         <translation>Sem můžete přidat poznámky k tomuto kontaktu.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Zvolte složku pro ukládání přijatých souborů</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -948,10 +943,6 @@ takže můžete soubor uložit i v systému Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Rámec</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čekáme na odeslání...</translation>
@@ -1089,11 +1080,6 @@ takže můžete soubor uložit i v systému Windows.</translation>
         <translation>Automaticky přijímat soubory od tohoto kontaktu</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Vyberte sloužku pro automatický příjem</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nová zpráva</translation>
     </message>
@@ -1149,11 +1135,6 @@ takže můžete soubor uložit i v systému Windows.</translation>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Vyberte sloužku pro automatický příjem</translation>
-    </message>
     <message>
         <source>General</source>
         <translation>Obecné</translation>
@@ -2297,6 +2278,14 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Zvolte složku pro ukládání přijatých souborů</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2613,10 +2602,6 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Rámec</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Zahájit vyhledávání:</translation>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -298,12 +298,6 @@ hvilket kan føre til problemer med videoopkald.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Du kan gemme kommentarer om denne kontakt her.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Vælg en auto-accept mappe</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1036,11 +1030,6 @@ så du kan gemme filen på Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Venter på at sende...</translation>
@@ -1207,12 +1196,6 @@ så du kan gemme filen på Windows.</translation>
         <translation type="unfinished">Vis detaljer</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Vælg en autoaccepter-mappe</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Ny besked</translation>
     </message>
@@ -1267,12 +1250,6 @@ så du kan gemme filen på Windows.</translation>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Generel</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Vælg en autoaccepter-mappe</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2589,6 +2566,14 @@ Dette ID inkluderer NoSpam-koden (i blåt) og kontrolsummen (i gråt).</translat
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Vælg en auto-accept mappe</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2943,10 +2928,6 @@ Dette ID inkluderer NoSpam-koden (i blåt) og kontrolsummen (i gråt).</translat
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -275,11 +275,6 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Sie können Kommentare über diesen Kontakt hier speichern.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Wähle einen Ordner aus, in dem die automatisch akzeptierten Dateien gespeichert werden sollen</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -940,11 +935,6 @@ um sie in Windows speichern zu können.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Eingabemaske</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Dateitransfer läuft...</translation>
@@ -1102,11 +1092,6 @@ um sie in Windows speichern zu können.</translation>
         <translation>Zeige Details</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Speicherort für empfangene Dateien wählen</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Neue Nachricht</translation>
     </message>
@@ -1146,11 +1131,6 @@ um sie in Windows speichern zu können.</translation>
     <message>
         <source>General</source>
         <translation>Allgemein</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Speicherort für empfangenen Dateien wählen</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2287,6 +2267,14 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Wähle einen Ordner aus, in dem die automatisch akzeptierten Dateien gespeichert werden sollen</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2587,10 +2575,6 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formular</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Suche starten:</translation>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -290,12 +290,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Μπορείτε να αποθηκεύσετε σχόλια σχετικά με αυτήν την επαφή εδώ.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Επιλέξτε έναν κατάλογο αυτόματης αποδοχής</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -981,10 +975,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Φόρμα</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Αναμονή για αποστολή...</translation>
@@ -1133,11 +1123,6 @@ so you can save the file on Windows.</source>
         <translation>Αυτόματη αποδοχή αρχείων από αυτόν/η το φίλο/η</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Επιλέξτε έναν φάκελο κατάλογου για αυτόματη αποδοχή</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Νέο μήνυμα</translation>
     </message>
@@ -1187,11 +1172,6 @@ so you can save the file on Windows.</source>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Επιλέξτε έναν φάκελο αυτόματης αποδοχής</translation>
-    </message>
     <message>
         <source>General</source>
         <translation>Γενικά</translation>
@@ -2370,6 +2350,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Επιλέξτε έναν κατάλογο αυτόματης αποδοχής</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2699,10 +2687,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Φόρμα</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -313,12 +313,6 @@ kio povas konduki al problemoj kun videovokoj.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Vi povas konservi komentojn pri ĉi tiu kontakto ĉi tie.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Elektu aŭtomate akceptan dosierujon</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1060,11 +1054,6 @@ do vi povas konservi la dosieron en Vindozo.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Formo</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Atendante por sendi...</translation>
@@ -1238,12 +1227,6 @@ do vi povas konservi la dosieron en Vindozo.</translation>
         <translation>Montri detalojn</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Elektu aŭtomate akceptan dosierujon</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nova mesaĝo</translation>
     </message>
@@ -1282,12 +1265,6 @@ do vi povas konservi la dosieron en Vindozo.</translation>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Elektu aŭtomate akceptan dosierujon</translation>
-    </message>
     <message>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -2609,6 +2586,14 @@ Kunhavigu ĝin kun viaj amikoj por komenci babili.
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Elektu aŭtomate akceptan dosierujon</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2959,11 +2944,6 @@ Kunhavigu ĝin kun viaj amikoj por komenci babili.
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Formo</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -275,11 +275,6 @@ lo que puede provocar problemas en las videollamadas.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Puedes guardar comentarios acerca de este contacto aquí.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Elige un directorio para descargas automáticas</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -940,10 +935,6 @@ para que puedas guardar el archivo en windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Plantilla</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Envío en espera...</translation>
@@ -1113,11 +1104,6 @@ para que puedas guardar el archivo en windows.</translation>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Elige un directorio para descargas automáticas</translation>
-    </message>
-    <message>
         <source>Open chat in new window</source>
         <translation>Abrir chat en una nueva ventana</translation>
     </message>
@@ -1144,11 +1130,6 @@ para que puedas guardar el archivo en windows.</translation>
     <message>
         <source>General</source>
         <translation>General</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Elige un directorio para transferencias automáticas</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2283,6 +2264,14 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Elige un directorio para descargas automáticas</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2583,10 +2572,6 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulario</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Iniciar búsqueda:</translation>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -276,11 +276,6 @@ mis võib põhjustada probleeme videokõnedega.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Selle kasutaja kommentaarid kirjuta siia.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Vali kaust, kuhu automaatselt vastu võetud failid salvestame</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -946,10 +941,6 @@ ja sa saad seda faili nüüd Windowsis salvestada.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Aken</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Ootan, et saata...</translation>
@@ -1099,11 +1090,6 @@ ja sa saad seda faili nüüd Windowsis salvestada.</translation>
         <translation>Näita üksikasju</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Vali kaust, kuhu automaatselt vastuvõetavad failid paigutatakse</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Uus sõnum</translation>
     </message>
@@ -1147,11 +1133,6 @@ ja sa saad seda faili nüüd Windowsis salvestada.</translation>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Vali kaust, kuhu automaatselt vastuvõetavad failid laetakse</translation>
-    </message>
     <message>
         <source>General</source>
         <translation>Üldine</translation>
@@ -2295,6 +2276,14 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Vali kaust, kuhu automaatselt vastu võetud failid salvestame</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2610,10 +2599,6 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Vorm</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Alusta otsingut:</translation>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -287,12 +287,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">می توانید نظرات مربوط به این مخاطب را در اینجا ذخیره کنید.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">دایرکتوری پذیرش خودکار را انتخاب کنید</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -971,11 +965,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>فرم</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>در انتظار ارسال...</translation>
@@ -1136,11 +1125,6 @@ so you can save the file on Windows.</source>
         <translation>نمایش جزئیات</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>یک پوشه برای فایلهایی که به صورت خودکار دریافت میشوند انتخاب کنید</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>پیام جدید</translation>
     </message>
@@ -1182,11 +1166,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>عمومی</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>یک پوشه برای دریافت فایلها به شکل خودکار انتخاب کنید</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2349,6 +2328,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">دایرکتوری پذیرش خودکار را انتخاب کنید</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2667,10 +2654,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>فرم</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>شروع جست‌و‌جو:</translation>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -276,11 +276,6 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Voit tallentaa kommentit tästä kontaktista tänne.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Valitse automaattihyväksynnän sijainti</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -945,10 +940,6 @@ joten voit tallentaa tiedoston Windowsissa.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Kenttä</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Odotetaan lähettämistä...</translation>
@@ -1094,11 +1085,6 @@ joten voit tallentaa tiedoston Windowsissa.</translation>
         <translation>Hyväksy tiedostot automaattisesti tältä kontaktilta</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Valitse hakemisto automaattisesti hyväksyttäville tiedostoille</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Uusi viesti</translation>
     </message>
@@ -1149,11 +1135,6 @@ joten voit tallentaa tiedoston Windowsissa.</translation>
     <message>
         <source>General</source>
         <translation>Yleiset</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Valitse hakemisto automaattisesti hyväksyttäville tiedostoille</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2293,6 +2274,14 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Valitse automaattihyväksynnän sijainti</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2608,10 +2597,6 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Lomake</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Aloita etsintä:</translation>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -276,11 +276,6 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Vous pouvez enregistrer ici des commentaires sur ce contact.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Sélectionner un répertoire d&apos;acceptation automatique</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -945,10 +940,6 @@ afin que vous puissiez enregistrer le fichier sur windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Formulaire</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>En attente d&apos;envoi...</translation>
@@ -1106,11 +1097,6 @@ afin que vous puissiez enregistrer le fichier sur windows.</translation>
         <translation>Hors ligne</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Sélectionner un répertoire d&apos;acceptation automatique</translation>
-    </message>
-    <message>
         <source>Open chat in new window</source>
         <translation>Ouvrir la discussion dans une nouvelle fenêtre</translation>
     </message>
@@ -1149,11 +1135,6 @@ afin que vous puissiez enregistrer le fichier sur windows.</translation>
     <message>
         <source>General</source>
         <translation>Général</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Sélectionner un répertoire d&apos;acceptation automatique</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2291,6 +2272,14 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Sélectionner un répertoire d&apos;acceptation automatique</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2591,10 +2580,6 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulaire</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Lancer la recherche :</translation>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -287,12 +287,6 @@ o que pode provocar problemas coas videochamadas.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Podes gardar comentarios sobre este contacto aquí.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Escolla un directorio de aceptación automática</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -972,11 +966,6 @@ para que poida gardar o ficheiro en Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Formulario</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Quérese enviar...</translation>
@@ -1137,11 +1126,6 @@ para que poida gardar o ficheiro en Windows.</translation>
         <translation>Amosar detalles</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Elixa un cartafol para os aceptados automáticamente</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nova mensaxe</translation>
     </message>
@@ -1183,11 +1167,6 @@ para que poida gardar o ficheiro en Windows.</translation>
     <message>
         <source>General</source>
         <translation>Xeral</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Elixa un cartafol para aceptados automáticamente</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2351,6 +2330,14 @@ Este ID inclúe o código NoSpam (en azul) e a suma de verificación (en gris).<
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Escolla un directorio de aceptación automática</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2669,10 +2656,6 @@ Este ID inclúe o código NoSpam (en azul) e a suma de verificación (en gris).<
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulario</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Comezar a buscar:</translation>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -316,12 +316,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">אתה יכול לשמור הערות על איש קשר זה כאן.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">בחר ספריית קבלה אוטומטית</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1113,11 +1107,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">טוֹפֶס</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1299,12 +1288,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">הצג פרטים</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">בחר ספריית אישור אוטומטי</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">הודעה חדשה</translation>
@@ -1362,12 +1345,6 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">כְּלָלִי</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">בחר ספריית אישור אוטומטי</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2742,6 +2719,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">בחר ספריית קבלה אוטומטית</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3108,11 +3093,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">טוֹפֶס</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -287,12 +287,6 @@ Ponekad vaša veza možda nije dovoljno dobra da podnese višu kvalitetu videa,
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ovdje možete spremiti komentare o ovom kontaktu.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Odaberite imenik s automatskim prihvaćanjem</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -974,10 +968,6 @@ tako da možete spremiti datoteku na Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Obrazac</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čekanje na slanje …</translation>
@@ -1105,11 +1095,6 @@ tako da možete spremiti datoteku na Windows.</translation>
         <translation>Automatski prihvati datoteke ovog prijatelja</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Odaberi direktorij za automatsko prihvaćanje</translation>
-    </message>
-    <message>
         <source>Open chat in new window</source>
         <translation>Otvori čavrljanje u novom prozoru</translation>
     </message>
@@ -1183,11 +1168,6 @@ tako da možete spremiti datoteku na Windows.</translation>
     <message>
         <source>General</source>
         <translation>Opće</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Odaberi direktorij za automatsko prihvaćanje</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2351,6 +2331,14 @@ Ovaj ID uključuje NoSpam kod (plavo) i kontrolni zbroj (sivo).</translation>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Odaberite imenik s automatskim prihvaćanjem</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2669,10 +2657,6 @@ Ovaj ID uključuje NoSpam kod (plavo) i kontrolni zbroj (sivo).</translation>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Obrazac</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Započni pretragu:</translation>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -287,12 +287,6 @@ ami problémákat okozhat a videohívásokkal kapcsolatban.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ide mentheti a névjegyhez fűzött megjegyzéseit.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Válasszon egy automatikus elfogadási könyvtárat</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -970,10 +964,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Űrlap</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Várakozás elküldésre...</translation>
@@ -1101,11 +1091,6 @@ so you can save the file on Windows.</source>
         <translation>Fájlok automatikus elfogadása e partnertől</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Válasszon egy mappát az automatikus fájlfogadáshoz</translation>
-    </message>
-    <message>
         <source>Open chat in new window</source>
         <translation>Chat megnyitása új ablakban</translation>
     </message>
@@ -1179,11 +1164,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Általános</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Válasszon egy mappát az automatikus elfogadáshoz</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2345,6 +2325,14 @@ Ez az azonosító tartalmazza a NoSpam kódot (kék színnel) és az ellenőrző
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Válasszon egy automatikus elfogadási könyvtárat</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2663,10 +2651,6 @@ Ez az azonosító tartalmazza a NoSpam kódot (kék színnel) és az ellenőrző
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Űrlap</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Keresés indítása:</translation>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -318,12 +318,6 @@ sem getur leitt til vandræða með myndsímtöl.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Þú getur vistað athugasemdir um þennan tengilið hér.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Veldu sjálfvirka samþykkisskrá</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1115,11 +1109,6 @@ svo þú getur vistað skrána á Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1311,12 +1300,6 @@ svo þú getur vistað skrána á Windows.</translation>
         <translation type="unfinished">Sýna upplýsingar</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Veldu sjálfvirka samþykkisskrá</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ný skilaboð</translation>
@@ -1364,12 +1347,6 @@ svo þú getur vistað skrána á Windows.</translation>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Almennt</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Veldu sjálfvirka samþykkisskrá</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2733,6 +2710,14 @@ Deildu því með vinum þínum til að byrja að spjalla.
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Veldu sjálfvirka samþykkisskrá</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3100,11 +3085,6 @@ Deildu því með vinum þínum til að byrja að spjalla.
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Form</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -276,11 +276,6 @@ il che può portare a problemi con le videochiamate.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Puoi salvare un commento per questo contatto qui.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Scegli dove salvare i file accettati automaticamente</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -945,10 +940,6 @@ in modo da poter salvare il file su Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Modulo</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>In attesa di inviare...</translation>
@@ -1090,11 +1081,6 @@ in modo da poter salvare il file su Windows.</translation>
         <translation>Mostra dettagli</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Scegli dove salvare i file accettati automaticamente</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nuovo messaggio</translation>
     </message>
@@ -1149,11 +1135,6 @@ in modo da poter salvare il file su Windows.</translation>
     <message>
         <source>General</source>
         <translation>Generale</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Scegli dove salvare i file accettati automaticamente</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2291,6 +2272,14 @@ Questo ID include una sezione NoSpam (in colore blu) e il controllo checksum (in
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Scegli dove salvare i file accettati automaticamente</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2591,10 +2580,6 @@ Questo ID include una sezione NoSpam (in colore blu) e il controllo checksum (in
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulario</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Iniziare ricerca:</translation>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -291,12 +291,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>この連絡先に関するコメントをここに保存できます。</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation>自動承認ディレクトリを選択してください</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -986,10 +980,6 @@ Windows にファイルを保存できるようになります。</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>フォーム</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>送信を待機しています…</translation>
@@ -1150,11 +1140,6 @@ Windows にファイルを保存できるようになります。</translation>
         <translation>詳細を表示</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>自動承認したファイルの保存場所を選択</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>新しいメッセージ</translation>
     </message>
@@ -1192,11 +1177,6 @@ Windows にファイルを保存できるようになります。</translation>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>自動承認したファイルの保存場所を選択</translation>
-    </message>
     <message>
         <source>General</source>
         <translation>一般</translation>
@@ -2374,6 +2354,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">自動承認ディレクトリを選択してください</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2703,10 +2691,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>フォーム</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -326,12 +326,6 @@ so&apos;o roi lo nu do jungau cu na banzu xamgu lo ka zgana lo nu zgana lo vidni
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">do ka&apos;e nurxru lo pinka be lo vi cuntu</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ko cuxna lo ka tolcmi lo karce</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1109,11 +1103,6 @@ e&apos;u do ka&apos;e sfaile lo nu sfaile bu&apos;u la .Windows.zoi ke&apos;a nu
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">fi&apos;o samci&apos;e</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1305,12 +1294,6 @@ e&apos;u do ka&apos;e sfaile lo nu sfaile bu&apos;u la .Windows.zoi ke&apos;a nu
         <translation type="unfinished">ko jarco lo ctila</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ko cuxna lo&apos;i selsau lo&apos;i karce</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">notci notci</translation>
@@ -1356,12 +1339,6 @@ e&apos;u do ka&apos;e sfaile lo nu sfaile bu&apos;u la .Windows.zoi ke&apos;a nu
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">cnima</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ko cuxna lo&apos;i selsau lo&apos;i karce</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2722,6 +2699,14 @@ le samselcmi cu mapti le blanu zoi gy. NoSpam .gy. joi le checksum zoi gy. gray<
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">ko cuxna lo ka tolcmi lo karce</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3081,11 +3066,6 @@ le samselcmi cu mapti le blanu zoi gy. NoSpam .gy. joi le checksum zoi gy. gray<
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">fi&apos;o samci&apos;e</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -329,12 +329,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಈ ಸಂಪರ್ಕದ ಕುರಿತು ನೀವು ಕಾಮೆಂಟ್‌ಗಳನ್ನು ಇಲ್ಲಿ ಉಳಿಸಬಹುದು.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಸ್ವಯಂ ಸ್ವೀಕರಿಸುವ ಡೈರೆಕ್ಟರಿಯನ್ನು ಆರಿಸಿ</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1125,11 +1119,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಫಾರ್ಮ್</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1321,12 +1310,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">ವಿವರಗಳನ್ನು ತೋರಿಸಿ</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಸ್ವಯಂ ಸ್ವೀಕರಿಸುವ ಡೈರೆಕ್ಟರಿಯನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation type="unfinished">ಹೊಸ ಸಂದೇಶ</translation>
     </message>
@@ -1371,12 +1354,6 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಸಾಮಾನ್ಯ</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಸ್ವಯಂ ಸ್ವೀಕರಿಸುವ ಡೈರೆಕ್ಟರಿಯನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2748,6 +2725,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">ಸ್ವಯಂ ಸ್ವೀಕರಿಸುವ ಡೈರೆಕ್ಟರಿಯನ್ನು ಆರಿಸಿ</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3114,11 +3099,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಫಾರ್ಮ್</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -294,12 +294,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">이 연락처에 대한 의견을 여기에 저장할 수 있습니다.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">자동 수락 디렉터리 선택</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1032,11 +1026,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>폼</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>전송 대기...</translation>
@@ -1215,11 +1204,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">세부정보 표시</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation type="unfinished">자동받기 폴더 선택</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">새 메시지</translation>
@@ -1265,11 +1249,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>일반</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation type="unfinished">자동받기 폴더 선택</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2606,6 +2585,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">자동 수락 디렉터리 선택</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2960,10 +2947,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">폼</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -317,12 +317,6 @@ wat kin leie tot probleme mit videogesprekke.</translation>
         <translation type="unfinished">Geer kin hei opmerkinge euver dit kontak opsjlaon.</translation>
     </message>
     <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Kies un automatische acceptatiemap</translation>
-    </message>
-    <message>
         <source>Confirmation</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Bevestiging</translation>
@@ -1137,11 +1131,6 @@ zodet geer ut bestand op Windows kin opsjlaon.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Formulier</translation>
-    </message>
-    <message>
         <source>Location not writable</source>
         <comment>Title of permissions popup</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1344,12 +1333,6 @@ zodet geer ut bestand op Windows kin opsjlaon.</translation>
         <translation type="unfinished">Details toene</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Kies un automatische acceptatiemap</translation>
-    </message>
-    <message>
         <source>Online</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Online</translation>
@@ -1386,12 +1369,6 @@ zodet geer ut bestand op Windows kin opsjlaon.</translation>
         <source>%1 (no fonts)</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 (geen lettertype)</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Kies un automatische acceptatiemap</translation>
     </message>
     <message>
         <source>General</source>
@@ -2769,6 +2746,14 @@ Deze ID umvat de NoSpam-code (in blauw) en de checksum (in gries).</translation>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Kies un automatische acceptatiemap</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>%1 is not a valid Tox address.</source>
@@ -3136,11 +3121,6 @@ Deze ID umvat de NoSpam-code (in blauw) en de checksum (in gries).</translation>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Formulier</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -276,11 +276,6 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Čia galite išsaugoti komentarus apie šį kontaktą.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Pasirinkite katalogą automatiniam priėmimui</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -948,10 +943,6 @@ tad dabar galite įrašyti failą Windows sistemoje.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Forma</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Laukiama gavėjo...</translation>
@@ -1101,11 +1092,6 @@ tad dabar galite įrašyti failą Windows sistemoje.</translation>
         <translation>Rodyti profilį</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Pasirinkite katalogą priimamiems failams</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nauja žinutė</translation>
     </message>
@@ -1152,11 +1138,6 @@ tad dabar galite įrašyti failą Windows sistemoje.</translation>
     <message>
         <source>General</source>
         <translation>Bendrosios</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Pasirinkite priimamų failų katalogą</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2299,6 +2280,14 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Pasirinkite katalogą automatiniam priėmimui</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2614,10 +2603,6 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Forma</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Pradėti paiešką:</translation>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -279,11 +279,6 @@ kas var radīt video zvanu problēmas.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Jūs varat saglabāt kontaktpersonas komentārus.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Atlasīt automātiskās pieņemšanas mapi</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -957,11 +952,6 @@ lai varētu saglabāt failus Windows operētājsistēmā.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Forma</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Gaida nosūtīšanu ...</translation>
@@ -1120,11 +1110,6 @@ lai varētu saglabāt failus Windows operētājsistēmā.</translation>
         <translation>Rādīt detalizētu informāciju</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Izvēlieties automātiskās pieņemšanas mapi</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Jauna ziņa</translation>
     </message>
@@ -1165,11 +1150,6 @@ lai varētu saglabāt failus Windows operētājsistēmā.</translation>
     <message>
         <source>General</source>
         <translation>Vispārīgi</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Izvēlieties automātiskās pieņemšanas mapi</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2339,6 +2319,14 @@ Kopīgojiet to ar draugiem, lai sāktu tērzēšanu.
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Atlasīt automātiskās pieņemšanas mapi</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2660,10 +2648,6 @@ Kopīgojiet to ar draugiem, lai sāktu tērzēšanu.
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Forma</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Sākt meklēšanu:</translation>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -290,12 +290,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Можете да зачувате коментари за овој контакт овде.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Изберете директориум за автоматско прифаќање</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -987,11 +981,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Форма</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Чека да се прати...</translation>
@@ -1152,11 +1141,6 @@ so you can save the file on Windows.</source>
         <translation>Покажи ги деталите</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Избери папка за автоматско прифаќање</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Нова порака</translation>
     </message>
@@ -1198,11 +1182,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation></translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Изберете папка за автоматско прифаќање</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2381,6 +2360,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Изберете директориум за автоматско прифаќање</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2711,10 +2698,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Форма</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -276,11 +276,6 @@ noe som kan forårsake problemer i videosamtaler.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Du kan lagre kommentarer om denne kontakten her.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Velg en mappe for automatiske nedlastninger</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -947,10 +942,6 @@ slik at du kan lagre filen på Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Skjema</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Venter på å sende...</translation>
@@ -1088,11 +1079,6 @@ slik at du kan lagre filen på Windows.</translation>
         <translation>Auto-aksepter filer fra denne kontakten</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Velg en mappe for auto-aksepterte filer</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Ny melding</translation>
     </message>
@@ -1151,11 +1137,6 @@ slik at du kan lagre filen på Windows.</translation>
     <message>
         <source>General</source>
         <translation>Generelt</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Velg en mappe for auto-aksepterte filer</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2293,6 +2274,14 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Velg en mappe for automatiske nedlastninger</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2595,10 +2584,6 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Skjema</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Søk:</translation>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -275,11 +275,6 @@ wat kan leiden tot problemen met videogesprekken.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Hier kun je opmerkingen over dit contact opslaan.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Kies een bestandsmap voor automatisch accepteren</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -939,10 +934,6 @@ zodat u het bestand op Windows kunt opslaan.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Formulier</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Wachten om te versturen…</translation>
@@ -1080,11 +1071,6 @@ zodat u het bestand op Windows kunt opslaan.</translation>
         <translation>Bestanden van deze vriend automatisch aanvaarden</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Kies een map om automatisch aanvaarde bestanden op te slaan</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nieuw bericht</translation>
     </message>
@@ -1143,11 +1129,6 @@ zodat u het bestand op Windows kunt opslaan.</translation>
     <message>
         <source>General</source>
         <translation>Algemeen</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Kies een map om automatisch aanvaarde bestanden op te slaan</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2282,6 +2263,14 @@ Deze ID bevat de NoSpam-code (in het blauw) en de checksum (in het grijs).</tran
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Kies een bestandsmap voor automatisch accepteren</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2582,10 +2571,6 @@ Deze ID bevat de NoSpam-code (in het blauw) en de checksum (in het grijs).</tran
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulier</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Zoekopdracht starten:</translation>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -271,11 +271,6 @@ which may lead to problems with video calls.</source>
         <source>You can save comments about this contact here.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -931,11 +926,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Formulier</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Wachten voor te versturen…</translation>
@@ -1093,11 +1083,6 @@ so you can save the file on Windows.</source>
         <translation>Details tonen</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Kies een map voor automatisch aanvaarde bestanden in op te slaan</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nieuw bericht</translation>
     </message>
@@ -1137,11 +1122,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Algemeen</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Kies een map voor automatisch aanvaarde bestanden in op te slaan</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2265,6 +2245,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2565,10 +2553,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Formulier</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation type="unfinished"></translation>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -278,11 +278,6 @@ co może powodować problemy z rozmowami wideo.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Tutaj możesz dodać komentarz do kontaktu.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Wybierz folder dla automatycznie przyjętych plików</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -957,10 +952,6 @@ więc możesz zapisać ten plik na systemie Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Od</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>better translation?</translatorcomment>
@@ -1128,11 +1119,6 @@ więc możesz zapisać ten plik na systemie Windows.</translation>
         <translation>Usuń z &apos;%1&apos; kręgu</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Wybierz domyślną ścieżkę dla plików</translation>
-    </message>
-    <message>
         <source>To new conference</source>
         <translation type="unfinished">Do nowej grupy</translation>
     </message>
@@ -1163,12 +1149,6 @@ więc możesz zapisać ten plik na systemie Windows.</translation>
     <message>
         <source>General</source>
         <translation>Główne</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>better translation?</translatorcomment>
-        <translation>Wybierz domyślną ścieżkę dla plików</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2322,6 +2302,14 @@ To ID zawiera kod NoSpam (w kolorze niebieskim) oraz sumę kontrolną (w kolorze
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Wybierz folder dla automatycznie przyjętych plików</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2626,10 +2614,6 @@ To ID zawiera kod NoSpam (w kolorze niebieskim) oraz sumę kontrolną (w kolorze
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Od</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Rozpocznij wyszukiwanie:</translation>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -275,11 +275,6 @@ Take heed, fer higher qualities demand clearer skies and use more bandwidth. If 
         <source>You can save comments about this contact here.</source>
         <translation>Scrawl down any observations yer havin&apos; about this matey.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation type="unfinished">Pick a chest fer auto-acceptin&apos; parcels</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -936,11 +931,6 @@ so ye can stash th&apos; file on Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation type="unfinished">Shape</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Awaitin&apos; approval...</translation>
@@ -1102,11 +1092,6 @@ so ye can stash th&apos; file on Windows.</translation>
         <translation>Examine</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Pick a parcel-chest</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>New writin&apos;</translation>
     </message>
@@ -1142,11 +1127,6 @@ so ye can stash th&apos; file on Windows.</translation>
     <message>
         <source>General</source>
         <translation type="unfinished">Th&apos; Whole Ship</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Pick a chest fer auto-accepting parcels</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2275,6 +2255,14 @@ This ID has th&apos; NoSpam code (in blue), &apos;n&apos; th&apos; checksum (in 
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Pick a chest fer auto-acceptin&apos; parcels</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2575,10 +2563,6 @@ This ID has th&apos; NoSpam code (in blue), &apos;n&apos; th&apos; checksum (in 
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Shape</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation type="unfinished">Start searchin&apos;:</translation>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -276,11 +276,6 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Pode guardar comentários sobre esse contacto aqui.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Escolha um diretório para aceitar ficheiros automaticamente</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -945,10 +940,6 @@ de forma que possa guardar o ficheiro no Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Formulário</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>A esperar para enviar...</translation>
@@ -1086,11 +1077,6 @@ de forma que possa guardar o ficheiro no Windows.</translation>
         <translation>Aceitar ficheiros deste contacto automaticamente</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Escolher uma pasta para onde aceitar ficheiros automaticamente</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nova mensagem</translation>
     </message>
@@ -1149,11 +1135,6 @@ de forma que possa guardar o ficheiro no Windows.</translation>
     <message>
         <source>General</source>
         <translation>Geral</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Escolher uma pasta para onde aceitar ficheiros automaticamente</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2293,6 +2274,14 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Escolha um diretório para aceitar ficheiros automaticamente</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2608,10 +2597,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulário</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Iniciar procura:</translation>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -276,11 +276,6 @@ o que pode levar a problemas com as videochamadas.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Você pode salvar comentários sobre esse contato aqui.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Escolha um diretório para aceitar arquivos automaticamente</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -946,11 +941,6 @@ de forma que você possa salvar o arquivo no Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Formulário</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Esperando para enviar...</translation>
@@ -1108,11 +1098,6 @@ de forma que você possa salvar o arquivo no Windows.</translation>
         <translation>Mostrar detalhes</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Escolher um diretório para aceitar arquivos automaticamente</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nova mensagem</translation>
     </message>
@@ -1152,11 +1137,6 @@ de forma que você possa salvar o arquivo no Windows.</translation>
     <message>
         <source>General</source>
         <translation>Geral</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Escolher um diretório para aceitar arquivos automaticamente</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2295,6 +2275,14 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Escolha um diretório para aceitar arquivos automaticamente</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2595,10 +2583,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulário</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Iniciar busca:</translation>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -275,11 +275,6 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Puteți salva comentarii despre acest contact aici.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Alegeți un director de acceptare automată</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -943,11 +938,6 @@ astfel încât să puteți salva fișierul pe Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Formă</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Așteptați trimiterea...</translation>
@@ -1105,11 +1095,6 @@ astfel încât să puteți salva fișierul pe Windows.</translation>
         <translation>Arata detaliile</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Alegeți un director de acceptare automată</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Mesaj nou</translation>
     </message>
@@ -1149,11 +1134,6 @@ astfel încât să puteți salva fișierul pe Windows.</translation>
     <message>
         <source>General</source>
         <translation>General</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Alegeți un director de acceptare automată</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2290,6 +2270,14 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Alegeți un director de acceptare automată</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2590,10 +2578,6 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formă</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Începe căutare:</translation>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -275,11 +275,6 @@ which may lead to problems with video calls.</source>
         <source>You can save comments about this contact here.</source>
         <translation>Вы можете сохранять заметки об этом контакте здесь.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Выберите папку для автоматического приёма файлов</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -944,10 +939,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>От</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Ожидание отправки...</translation>
@@ -1106,11 +1097,6 @@ so you can save the file on Windows.</source>
         <translation>О контакте</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Выбрать папку для автоматического приёма</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Новое сообщение</translation>
     </message>
@@ -1146,11 +1132,6 @@ so you can save the file on Windows.</source>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Выбрать папку для автоматического приёма</translation>
-    </message>
     <message>
         <source>General</source>
         <translation>Общие</translation>
@@ -2289,6 +2270,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Выберите папку для автоматического приёма файлов</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2589,10 +2578,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Форма</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Начать поиск:</translation>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -334,12 +334,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ඔබට මෙම සම්බන්ධතාවය පිළිබඳ අදහස් මෙහි සුරැකිය හැක.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ස්වයංක්‍රීයව පිළිගන්න නාමාවලියක් තෝරන්න</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1132,11 +1126,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">පෝරමය</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1328,12 +1317,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">විස්තර පෙන්වන්න</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ස්වයංක්‍රීය පිළිගැනීමේ නාමාවලියක් තෝරන්න</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">නව පණිවිඩයක්</translation>
@@ -1381,12 +1364,6 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ජෙනරාල්</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ස්වයංක්‍රීය පිළිගැනීමේ නාමාවලියක් තෝරන්න</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2761,6 +2738,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">ස්වයංක්‍රීයව පිළිගන්න නාමාවලියක් තෝරන්න</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3128,11 +3113,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">පෝරමය</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -276,11 +276,6 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
         <source>You can save comments about this contact here.</source>
         <translation>Tu si môžete uložiť informácie o tomto kontakte.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Vybrať priečinok pre automatické prijímanie</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -949,11 +944,6 @@ so you can save the file on Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Formulář</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čaká sa na odoslanie...</translation>
@@ -1111,11 +1101,6 @@ so you can save the file on Windows.</translation>
         <translation>Zobraziť podrobnosti</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Zvoľte priečinok pre automatické prijímanie</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nová správa</translation>
     </message>
@@ -1155,11 +1140,6 @@ so you can save the file on Windows.</translation>
     <message>
         <source>General</source>
         <translation>Všeobecné</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Zvoľte priečinok pre automatické prijímanie</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2299,6 +2279,14 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Vybrať priečinok pre automatické prijímanie</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2601,10 +2589,6 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulár</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Spustiť hľadanie:</translation>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -295,12 +295,6 @@ kar lahko povzroči težave z video klici.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Tukaj lahko shranite komentarje o tem stiku.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Izberite imenik za samodejno sprejemanje</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -996,10 +990,6 @@ tako da lahko datoteko shranite v sistem Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Nastavitve</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čakanje na pošiljanje...</translation>
@@ -1127,11 +1117,6 @@ tako da lahko datoteko shranite v sistem Windows.</translation>
         <translation>Samodejno sprejmi datoteke od te osebe</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Izberi mapo za avtomatsko sprejemanje datotek</translation>
-    </message>
-    <message>
         <source>Open chat in new window</source>
         <translation>Odpri klepet v novem oknu</translation>
     </message>
@@ -1205,11 +1190,6 @@ tako da lahko datoteko shranite v sistem Windows.</translation>
     <message>
         <source>General</source>
         <translation>Splošno</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Izberi mapo za avtomatsko sprejemanje datotek</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2462,6 +2442,14 @@ Ta ID vključuje kodo NoSpam (v modri barvi) in kontrolno vsoto (v sivi barvi).<
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Izberite imenik za samodejno sprejemanje</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2802,10 +2790,6 @@ Ta ID vključuje kodo NoSpam (v modri barvi) in kontrolno vsoto (v sivi barvi).<
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Nastavitve</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -329,12 +329,6 @@ gjë që mund të çojë në probleme me video thirrjet.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ju mund të ruani komentet rreth këtij kontakti këtu.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Zgjidhni një direktori të pranimit automatik</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1127,11 +1121,6 @@ kështu që mund ta ruani skedarin në Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Forma</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1323,12 +1312,6 @@ kështu që mund ta ruani skedarin në Windows.</translation>
         <translation type="unfinished">Trego detajet</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Zgjidhni një direktori të pranimit automatik</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Mesazh i ri</translation>
@@ -1376,12 +1359,6 @@ kështu që mund ta ruani skedarin në Windows.</translation>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Gjeneral</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Zgjidhni një direktori të pranimit automatik</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2756,6 +2733,14 @@ Ky ID përfshin kodin NoSpam (në blu) dhe kontrollin (në gri).</translation>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Zgjidhni një direktori të pranimit automatik</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3123,11 +3108,6 @@ Ky ID përfshin kodin NoSpam (në blu) dhe kontrollin (në gri).</translation>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Forma</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -287,12 +287,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Овде можете сачувати коментаре о овом контакту.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Изаберите директоријум за аутоматско прихватање</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -975,11 +969,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Образац</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Чекам на слање...</translation>
@@ -1140,11 +1129,6 @@ so you can save the file on Windows.</source>
         <translation>Прикажи детаље</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Изаберте фасциклу за аутоматски пријем</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Нова порука</translation>
     </message>
@@ -1186,11 +1170,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Опште</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Изаберите фасциклу за самостални пријем</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2355,6 +2334,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Изаберите директоријум за аутоматско прихватање</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2673,10 +2660,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Образац</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Почетак претраге:</translation>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -271,11 +271,6 @@ which may lead to problems with video calls.</source>
         <source>You can save comments about this contact here.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -934,11 +929,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Obrazac</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Čekam na slanje...</translation>
@@ -1097,11 +1087,6 @@ so you can save the file on Windows.</source>
         <translation>Prikaži detalje</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Izaberte fasciklu za automatski prijem</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Nova poruka</translation>
     </message>
@@ -1141,11 +1126,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Opšte</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Izaberite fasciklu za automatski prijem</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2270,6 +2250,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2570,10 +2558,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Obrazac</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation type="unfinished"></translation>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -276,11 +276,6 @@ vilket kan leda till problem med videosamtal.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Du kan spara kommentarer om denna kontakt här.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Välj en mapp för automatisk accepterade</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -946,10 +941,6 @@ så att du kan spara filen i Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Formulär</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Väntar på att skicka...</translation>
@@ -1074,12 +1065,6 @@ så att du kan spara filen i Windows.</translation>
         <translation>Bjud in till grupp</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Hmm, hard one. Got any better?</translatorcomment>
-        <translation>Välj en acceptera-automatiskt-katalog</translation>
-    </message>
-    <message>
         <source>Open chat in new window</source>
         <translation>Öppna chatt i nytt fönster</translation>
     </message>
@@ -1151,11 +1136,6 @@ så att du kan spara filen i Windows.</translation>
     <message>
         <source>General</source>
         <translation>Allmänt</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Välj en acceptera-automatiskt-katalog</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2298,6 +2278,14 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Välj en mapp för automatisk accepterade</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2613,10 +2601,6 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Formulär</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Börja sök:</translation>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -336,12 +336,6 @@ ambayo inaweza kusababisha matatizo na simu za video.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Unaweza kuhifadhi maoni kuhusu mtu huyu hapa.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Chagua saraka ya kukubali kiotomatiki</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1134,11 +1128,6 @@ kwa hivyo unaweza kuhifadhi faili kwenye Windows.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Fomu</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1330,12 +1319,6 @@ kwa hivyo unaweza kuhifadhi faili kwenye Windows.</translation>
         <translation type="unfinished">Onyesha maelezo</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Chagua saraka ya kukubali kiotomatiki</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ujumbe mpya</translation>
@@ -1383,12 +1366,6 @@ kwa hivyo unaweza kuhifadhi faili kwenye Windows.</translation>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Mkuu</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Chagua saraka ya kukubali kiotomatiki</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2763,6 +2740,14 @@ Kitambulisho hiki kinajumuisha msimbo wa NoSpam (wa bluu), na hundi (ya kijivu).
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Chagua saraka ya kukubali kiotomatiki</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3130,11 +3115,6 @@ Kitambulisho hiki kinajumuisha msimbo wa NoSpam (wa bluu), na hundi (ya kijivu).
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Fomu</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -298,12 +298,6 @@ qTox இல் தாங்கள் சிக்கலோ பாதுகாப
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">இந்தத் தொடர்பைப் பற்றிய கருத்துகளை இங்கே சேமிக்கலாம்.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">தானாக ஏற்கும் கோப்பகத்தைத் தேர்ந்தெடுக்கவும்</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1007,11 +1001,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>படிவம்</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>அனுப்பக் காத்திருப்பிலுள்ளது...</translation>
@@ -1172,11 +1161,6 @@ so you can save the file on Windows.</source>
         <translation>விவரங்களைக் காட்டு</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation type="unfinished">தன்னிச்சையேற்புக்கான கோப்பகத்தைத் தேர்வு செய்க</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>புதிய செய்தி</translation>
     </message>
@@ -1218,11 +1202,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation type="unfinished">பொதுப்படை</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation type="unfinished">தன்னிச்சையேற்புக்கான கோப்பகத்தைத் தேர்வு செய்க</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2539,6 +2518,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">தானாக ஏற்கும் கோப்பகத்தைத் தேர்ந்தெடுக்கவும்</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2890,10 +2877,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">படிவம்</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -277,11 +277,6 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Bu kişi hakkındaki yorumları buraya kaydedebilirsiniz.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Otomatik olarak kabul etme dizini seç</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -945,10 +940,6 @@ geçersiz karakterler _ olarak değiştirildi.</translation>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>Form</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Göndermek için bekliyor...</translation>
@@ -1095,11 +1086,6 @@ geçersiz karakterler _ olarak değiştirildi.</translation>
         <translation>Bu arkadaştan gelen dosyaları sormadan kabul et</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Sormadan kabul etme dizini seç</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Yeni ileti</translation>
     </message>
@@ -1147,11 +1133,6 @@ geçersiz karakterler _ olarak değiştirildi.</translation>
 </context>
 <context>
     <name>GeneralForm</name>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Sormadan kabul etme dizini seç</translation>
-    </message>
     <message>
         <source>General</source>
         <translation>Genel</translation>
@@ -2291,6 +2272,14 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Otomatik olarak kabul etme dizini seç</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2591,10 +2580,6 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Form</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Aramayı başlat:</translation>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -291,12 +291,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">بۇ ئالاقىگە مۇناسىۋەتلىك باھالارنى بۇ يەردىن ساقلىۋالالايسىز.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ئاپتوماتىك قوبۇل قىلىدىغان مۇندەرىجىنى تاللاڭ</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -985,11 +979,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>جەدۋەل</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>يوللاشنى ساقلاۋاتىدۇ...</translation>
@@ -1150,11 +1139,6 @@ so you can save the file on Windows.</source>
         <translation>تەپسىلاتى</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>قۇبۇل قىلىش مۇندەرىجىسى تاللاڭ</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>يېڭى ئۇچۇر</translation>
     </message>
@@ -1196,11 +1180,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>ئورتاق</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>قۇبۇل قىلىش مۇندەرىجىسى تاللاڭ</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2378,6 +2357,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">ئاپتوماتىك قوبۇل قىلىدىغان مۇندەرىجىنى تاللاڭ</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2707,10 +2694,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">جەدۋەل</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -275,11 +275,6 @@ which may lead to problems with video calls.</source>
         <source>You can save comments about this contact here.</source>
         <translation>Ви можете зберігати коментарі про цей контакт тут.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Виберіть каталог для автоматичного приймання</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -942,10 +937,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Очікування передачі...</translation>
@@ -1115,11 +1106,6 @@ so you can save the file on Windows.</source>
         <translation>Не в мережі</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Оберіть теку, для автоматичного отримання файлів</translation>
-    </message>
-    <message>
         <source>To new conference</source>
         <translation>До нової конференції</translation>
     </message>
@@ -1146,11 +1132,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Основні</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Оберіть теку, для автоматичного отримання файлів</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2292,6 +2273,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Виберіть каталог для автоматичного приймання</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2595,10 +2584,6 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Форма</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Почати пошук:</translation>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -310,12 +310,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">آپ اس رابطے کے بارے میں تبصرے یہاں محفوظ کر سکتے ہیں۔</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ایک خودکار قبول ڈائریکٹری منتخب کریں۔</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1108,11 +1102,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">فارم</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translatorcomment>Automated translation.</translatorcomment>
@@ -1304,12 +1293,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">تفصیلات دکھائیں۔</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ایک خودکار قبول ڈائریکٹری منتخب کریں۔</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">نیا پیغام</translation>
@@ -1357,12 +1340,6 @@ so you can save the file on Windows.</source>
         <source>General</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">جنرل</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ایک خودکار قبول ڈائریکٹری منتخب کریں۔</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2737,6 +2714,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">ایک خودکار قبول ڈائریکٹری منتخب کریں۔</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3104,11 +3089,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">فارم</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -276,11 +276,6 @@ có thể dẫn đến sự cố với cuộc gọi điện video.</translation>
         <source>You can save comments about this contact here.</source>
         <translation>Bạn có thể lưu ý kiến về liên hệ này tại đây.</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>Chọn một thư mục tự động chấp nhận</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -943,11 +938,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>Biểu mẫu</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>Đang gửi...</translation>
@@ -1105,11 +1095,6 @@ so you can save the file on Windows.</source>
         <translation>Hiện chi tiết</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Chọn một thư mục tự động chấp nhận</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>Tin nhắn mới</translation>
     </message>
@@ -1149,11 +1134,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>Chung</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>Chọn một thư mục tự động chấp nhận</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2291,6 +2271,14 @@ ID này bao gồm mã NoSpam (màu xanh lam) và checksum (màu xám).</translat
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">Chọn một thư mục tự động chấp nhận</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2593,10 +2581,6 @@ ID này bao gồm mã NoSpam (màu xanh lam) và checksum (màu xám).</translat
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>Biểu mẫu</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>Bắt đầu tìm kiếm:</translation>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -275,11 +275,6 @@ which may lead to problems with video calls.</source>
         <source>You can save comments about this contact here.</source>
         <translation>您可以在此处保存有关此联系人的注释。</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translation>选择一个自动接受目录</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -936,10 +931,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translation>表单</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>正在等待发送...</translation>
@@ -1088,11 +1079,6 @@ so you can save the file on Windows.</source>
         <translation>离线</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>选择默认接收目录</translation>
-    </message>
-    <message>
         <source>Remove chat from this window</source>
         <translation>从此窗口中移除聊天</translation>
     </message>
@@ -1140,11 +1126,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>通用</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation>选择默认接收目录</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2278,6 +2259,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">选择一个自动接受目录</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -2578,10 +2567,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation>表单</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translation>开始搜索：</translation>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -299,12 +299,6 @@ which may lead to problems with video calls.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">您可以在此處保存有關此聯絡人的評論。</translation>
     </message>
-    <message>
-        <source>Choose an auto-accept directory</source>
-        <extracomment>popup title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">選擇自動接受目錄</translation>
-    </message>
 </context>
 <context>
     <name>AboutSettings</name>
@@ -1062,11 +1056,6 @@ so you can save the file on Windows.</source>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <source>Form</source>
-        <translatorcomment>Ausgelassen</translatorcomment>
-        <translation>表單</translation>
-    </message>
-    <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
         <translation>等待傳送…</translation>
@@ -1242,11 +1231,6 @@ so you can save the file on Windows.</source>
         <translation type="unfinished">顯示詳情</translation>
     </message>
     <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation type="unfinished">選擇自動接受目錄</translation>
-    </message>
-    <message>
         <source>New message</source>
         <translation>新訊息</translation>
     </message>
@@ -1289,11 +1273,6 @@ so you can save the file on Windows.</source>
     <message>
         <source>General</source>
         <translation>一般</translation>
-    </message>
-    <message>
-        <source>Choose an auto accept directory</source>
-        <comment>popup title</comment>
-        <translation type="unfinished">選擇自動接受目錄</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
@@ -2643,6 +2622,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
 </context>
 <context>
+    <name>QFileDialog</name>
+    <message>
+        <source>Choose an auto-accept directory</source>
+        <comment>popup title</comment>
+        <translation type="unfinished">選擇自動接受目錄</translation>
+    </message>
+</context>
+<context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
@@ -3002,10 +2989,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 </context>
 <context>
     <name>SearchSettingsForm</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">表單</translation>
-    </message>
     <message>
         <source>Start search:</source>
         <translatorcomment>Automated translation.</translatorcomment>


### PR DESCRIPTION
Marked some more unused window titles as notr. Also unified the "Choose an auto-accept directory" string into one file so we don't generate 3 strings for them.

https://github.com/TokTok/qTox/issues/497#issuecomment-2641117317

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/505)
<!-- Reviewable:end -->
