### PR TITLE
fix(chatform): sanitize the toxstring to remove characters after the \0

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -51,6 +51,9 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QSt
     QString senderText = sender;
 
     auto textType = Text::NORMAL;
+    // TRIfA suffixes
+    text = TextFormatter::processTrifaSuffixes(text, settings.getHideTrifaSuffix());
+
     // smileys
     if (settings.getUseEmoticons())
         text = smileyPack.smileyfied(text);

--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -80,6 +80,9 @@ const QVector<QRegularExpression> URI_WORD_PATTERNS = {
     QRegularExpression(QStringLiteral(R"((?<=^|\s)\S*(ed2k://\|file\|\S+))")),
 };
 
+const QRegularExpression TRIFA_WRAPPER(QStringLiteral("[[]TRIfA_SUFFIX[]](.+)[[]/TRIfA_SUFFIX[]]$"),
+                                       QRegularExpression::DotMatchesEverythingOption);
+const QString TRIFA_PLACEHOLDER = QStringLiteral("<font color=#228B22>[...]</font>");
 
 struct MatchingUri
 {
@@ -239,6 +242,26 @@ QString TextFormatter::applyMarkdown(const QString& message, bool showFormatting
             result.replace(startPos, length, wrappedText);
             offset += wrappedText.length() - length;
         }
+    }
+    return result;
+}
+
+/**
+ * @brief Remove or show suffixes added by TRIfA
+ * @param message Formatting string
+ * @param hideTrifaSuffix True if suffixes  should be replaced by [...]
+ * @return Copy of message where <TRIfA_SUFFIX> tags are removed and and suffix
+ * is replaced by [...], or remained as is.
+ */
+QString TextFormatter::processTrifaSuffixes(const QString& message, bool hideTrifaSuffix)
+{
+    QString result = message;
+    if (hideTrifaSuffix) {
+        return result.replace(TRIFA_WRAPPER, TRIFA_PLACEHOLDER);
+    }
+    QRegularExpressionMatch match = TRIFA_WRAPPER.match(result);
+    if (match.hasMatch()) {
+        result = result.replace(TRIFA_WRAPPER, match.captured(match.lastCapturedIndex()));
     }
     return result;
 }

--- a/src/chatlog/textformatter.h
+++ b/src/chatlog/textformatter.h
@@ -11,4 +11,6 @@ namespace TextFormatter {
 QString highlightURI(const QString& message);
 
 QString applyMarkdown(const QString& message, bool showFormattingSymbols);
+
+QString processTrifaSuffixes(const QString& message, bool hideTrifaSuffix);
 } // namespace TextFormatter

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -382,7 +382,7 @@ void Core::onFriendMessage(Tox* tox, uint32_t friendId, Tox_Message_Type type,
 {
     std::ignore = tox;
     const bool isAction = (type == TOX_MESSAGE_TYPE_ACTION);
-    const QString msg = ToxString(cMessage, cMessageSize).getQString();
+    const QString msg = ToxString(cMessage, cMessageSize, true).getQString();
     emit static_cast<Core*>(core)->friendMessageReceived(friendId, msg, isAction);
 }
 
@@ -492,7 +492,7 @@ void Core::onConferenceMessage(Tox* tox, uint32_t conferenceId, uint32_t peerId,
     std::ignore = tox;
     Core* core = static_cast<Core*>(vCore);
     const bool isAction = type == TOX_MESSAGE_TYPE_ACTION;
-    const QString message = ToxString(cMessage, length).getQString();
+    const QString message = ToxString(cMessage, length, true).getQString();
     emit core->conferenceMessageReceived(conferenceId, peerId, message, isAction);
 }
 

--- a/src/core/toxstring.h
+++ b/src/core/toxstring.h
@@ -16,10 +16,12 @@ public:
     explicit ToxString(const QString& text);
     explicit ToxString(QByteArray text);
     ToxString(const uint8_t* text, size_t length);
+    ToxString(const uint8_t* text, size_t length, bool fix_trifa);
 
     const uint8_t* data() const;
     size_t size() const;
     QString getQString() const;
+    QString getQString(QByteArray stringVal) const;
     const QByteArray& getBytes() const;
 
 private:

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -11,6 +11,9 @@
 
 namespace {
 
+const QRegularExpression TRIFA_WRAPPER(QStringLiteral("[[]TRIfA_SUFFIX[]](.+)[[]/TRIfA_SUFFIX[]]$"),
+                                       QRegularExpression::DotMatchesEverythingOption);
+
 QString generateContent(const QHash<const Conference*, size_t>& conferenceNotifications,
                         QString lastMessage, const ToxPk& sender)
 {
@@ -51,7 +54,9 @@ NotificationData NotificationGenerator::friendMessageNotification(const Friend* 
     }
 
     ret.title = f->getDisplayedName();
-    ret.message = message;
+    // Make sure we have removed the TRIfA suffix if any.
+
+    ret.message = QString(message).remove(TRIFA_WRAPPER);
     ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
 
     return ret;

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -236,6 +236,7 @@ void Settings::loadGlobal()
         imagePreview = s.value("imagePreview", true).toBool();
         chatMaxWindowSize = s.value("chatMaxWindowSize", 100).toInt();
         chatWindowChunkSize = s.value("chatWindowChunkSize", 50).toInt();
+        hideTrifaSuffix = s.value("hideTrifaSuffix", true).toBool();
     });
 
     inGroup(s, "Chat", [this, &s] {
@@ -690,6 +691,7 @@ void Settings::saveGlobal()
         s.setValue("statusChangeNotificationEnabled", statusChangeNotificationEnabled);
         s.setValue("showConferenceJoinLeaveMessages", showConferenceJoinLeaveMessages);
         s.setValue("spellCheckingEnabled", spellCheckingEnabled);
+        s.setValue("hideTrifaSuffix", hideTrifaSuffix);
     });
 
     inGroup(s, "Chat", [this, &s] { //
@@ -1440,6 +1442,19 @@ void Settings::setChatMessageFont(const QFont& font)
 {
     if (setVal(chatMessageFont, font)) {
         emit chatMessageFontChanged(font);
+    }
+}
+
+bool Settings::getHideTrifaSuffix() const
+{
+    const QMutexLocker<QRecursiveMutex> locker(&bigLock);
+    return hideTrifaSuffix;
+}
+
+void Settings::setHideTrifaSuffix(bool hide)
+{
+    if (setVal(hideTrifaSuffix, hide)) {
+        emit hideTrifaSuffixChanged(hide);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -222,6 +222,7 @@ signals:
     void dateFormatChanged(const QString& format);
     void statusChangeNotificationEnabledChanged(bool enabled);
     void spellCheckingEnabledChanged(bool enabled);
+    void hideTrifaSuffixChanged(bool show);
 
     // Privacy
     void typingNotificationChanged(bool enabled);
@@ -458,6 +459,9 @@ public:
     bool getSpellCheckingEnabled() const;
     void setSpellCheckingEnabled(bool newValue);
 
+    bool getHideTrifaSuffix() const;
+    void setHideTrifaSuffix(bool hide);
+
     // Privacy
     bool getTypingNotification() const;
     void setTypingNotification(bool enabled);
@@ -671,6 +675,7 @@ private:
     bool statusChangeNotificationEnabled;
     bool showConferenceJoinLeaveMessages;
     bool spellCheckingEnabled;
+    bool hideTrifaSuffix;
 
     // Privacy
     bool typingNotification;

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -80,6 +80,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
     bodyUI->chatLogMaxTxt->setValue(settings.getChatMaxWindowSize());
     bodyUI->chatLogChunkTxt->setValue(settings.getChatWindowChunkSize());
     bodyUI->cbImagePreview->setChecked(settings.getImagePreview());
+    bodyUI->cbHideTrifaSuffix->setChecked(settings.getHideTrifaSuffix());
 
     bodyUI->cbConferencePosition->setChecked(settings.getConferencePosition());
     bodyUI->cbCompactLayout->setChecked(settings.getCompactLayout());
@@ -397,6 +398,11 @@ void UserInterfaceForm::on_notifyHide_stateChanged(int value)
 void UserInterfaceForm::on_cbImagePreview_stateChanged()
 {
     settings.setImagePreview(bodyUI->cbImagePreview->isChecked());
+}
+
+void UserInterfaceForm::on_cbHideTrifaSuffix_stateChanged()
+{
+    settings.setHideTrifaSuffix(bodyUI->cbHideTrifaSuffix->isChecked());
 }
 
 void UserInterfaceForm::on_chatLogChunkTxt_valueChanged(int value)

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -56,6 +56,7 @@ private slots:
     void on_txtChatFontSize_valueChanged(int px);
     void on_useNameColors_stateChanged(int value);
     void on_cbImagePreview_stateChanged();
+    void on_cbHideTrifaSuffix_stateChanged();
     void on_chatLogMaxTxt_valueChanged(int value);
     void on_chatLogChunkTxt_valueChanged(int value);
 

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -39,8 +39,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>664</width>
-        <height>993</height>
+        <width>650</width>
+        <height>1104</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0,0">
@@ -167,6 +167,13 @@ Hide formatting characters:
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Chat log:</string>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="1">
            <widget class="QCheckBox" name="cbImagePreview">
             <property name="toolTip">
@@ -177,7 +184,7 @@ Hide formatting characters:
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_4">
             <item>
              <widget class="QLabel" name="chatLogMaxLbl">
@@ -224,10 +231,10 @@ number here may cause the scroll bar to disappear.</string>
             </item>
            </layout>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label">
+          <item row="4" column="1">
+           <widget class="QCheckBox" name="cbHideTrifaSuffix">
             <property name="text">
-             <string>Chat log:</string>
+             <string>Hide suffix after NULL symbol</string>
             </property>
            </widget>
           </item>

--- a/test/chatlog/textformatter_test.cpp
+++ b/test/chatlog/textformatter_test.cpp
@@ -259,6 +259,54 @@ const QVector<QPair<QString, QString>> URL_CASES{
         "[&quot;" MAKE_LINK("https://en.wikipedia.org/wiki/Seal_(East_Asia)") "&quot;]?"),
 };
 
+const QVector<StringPair> TRIFA_CASE{
+    // Test case when user decided to hide TRIfA suffixes.
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Hello<font color=#228B22>[...]</font>"),
+    PAIR_FORMAT("Hello[TRIfA_SUFFIX]xxxxxxxxxxxxx[/HTML]xxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/"
+                "TRIfA_SUFFIX]",
+                "Hello<font color=#228B22>[...]</font>"),
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxx\nxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Hello<font color=#228B22>[...]</font>"),
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxx\rxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Hello<font color=#228B22>[...]</font>"),
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxx\n\rxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Hello<font color=#228B22>[...]</font>")};
+
+const QVector<StringPair> TRIFA_CASE_OPT_OUT{
+    // Test case when user decided to show TRIfA suffixes as is.
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
+    PAIR_FORMAT("Hello[TRIfA_SUFFIX]xxxxxxxxxxxxx[/HTML]xxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/"
+                "TRIfA_SUFFIX]",
+                "Helloxxxxxxxxxxxxx[/HTML]xxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxx\nxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Helloxxxxxxx\nxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxx\rxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Helloxxxxxxx\rxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxx\n\rxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
+        "Helloxxxxxxx\n\rxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z")};
+
+const QVector<StringPair> TRIFA_CASES_NEGATIVE{
+    // Test cases when TRIfA suffix is not formed correctly
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]x",
+        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]x"),
+    PAIR_FORMAT(
+        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[TRIfA_SUFFIX]",
+        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[TRIfA_SUFFIX]")};
+
+const QVector<StringPair> ALL_TRIFA_CASES = concat(TRIFA_CASE, TRIFA_CASES_NEGATIVE);
+const QVector<StringPair> ALL_TRIFA_OPT_OUT_CASES = concat(TRIFA_CASE_OPT_OUT, TRIFA_CASES_NEGATIVE);
+
 #undef PAIR_FORMAT
 
 using MarkdownFunction = QString (*)(const QString&, bool);
@@ -289,6 +337,19 @@ void workCasesTest(MarkdownFunction applyMarkdown, const QVector<MarkdownToTags>
             QString result = applyMarkdown(input, showSymbols);
             QVERIFY(output == result);
         }
+    }
+}
+
+/*
+ * @brief Testing cases for TRIfA suffix.
+ * @param testData Test data - string pairs "Source message - Message after formatting"
+ * @param True if suffixes  should be replaced by [...]
+ */
+void trifaCasesTest(const QVector<StringPair>& testData, bool hideTrifaSuffix)
+{
+    for (const StringPair& data : testData) {
+        QString result = TextFormatter::processTrifaSuffixes(data.first, hideTrifaSuffix);
+        QCOMPARE(data.second, result);
     }
 }
 
@@ -408,6 +469,8 @@ private slots:
     void singleAndDoubleMarkdownExceptionsShowSymbols();
     void singleAndDoubleMarkdownExceptionsHideSymbols();
     void mixedFormattingSpecialCases();
+    void trifaTags();
+    void trifaTagsOptOut();
     void urlTest();
 
 private:
@@ -503,6 +566,16 @@ void TestTextFormatter::mixedFormattingSpecialCases()
 void TestTextFormatter::urlTest()
 {
     urlHighlightTest(urlHighlightFunction, URL_CASES);
+}
+
+void TestTextFormatter::trifaTags()
+{
+    trifaCasesTest(ALL_TRIFA_CASES, true);
+}
+
+void TestTextFormatter::trifaTagsOptOut()
+{
+    trifaCasesTest(ALL_TRIFA_OPT_OUT_CASES, false);
 }
 
 QTEST_GUILESS_MAIN(TestTextFormatter)

--- a/test/core/toxstring_test.cpp
+++ b/test/core/toxstring_test.cpp
@@ -30,6 +30,7 @@ private slots:
     void combiningCharacterTest();
     void multiLineTest();
     void tabTest();
+    void trifaFormatTest();
 
 private:
     /* Test Strings */
@@ -350,6 +351,33 @@ void TestToxString::combiningCharacterTest()
 
     for (const auto& testCase : testCases) {
         QCOMPARE(ToxString(testCase.input).getQString(), testCase.expected);
+    }
+}
+
+/**
+ * @brief Check that we trim TRIfA suffix only if it has a right shape and user set this option.
+ */
+void TestToxString::trifaFormatTest()
+{
+    const struct TestCase
+    {
+        const uint8_t* text;
+        const size_t length;
+        const bool fix_trifa;
+        const QString expected;
+    } testCases[] = {
+        {reinterpret_cast<const uint8_t*>("Hello\0\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 43,
+         true, QStringLiteral("Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]")},
+        {reinterpret_cast<const uint8_t*>("Hello\0\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 43,
+         false, QStringLiteral("Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444")},
+        {reinterpret_cast<const uint8_t*>("Hello\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 42, true,
+         QStringLiteral("Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444")},
+        {reinterpret_cast<const uint8_t*>("Hello\0\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 42, true,
+         QStringLiteral("Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444")},
+    };
+    for (const auto& testCase : testCases) {
+        QCOMPARE(ToxString(testCase.text, testCase.length, testCase.fix_trifa).getQString(),
+                 testCase.expected);
     }
 }
 

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -3192,6 +3192,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">سجل
 الدردشة:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">إخفاء اللاحقة بعد رمز فارغ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -3105,6 +3105,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">Журнал
 чата:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Схаваць суфікс пасля нулявога сімвала</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -3549,6 +3549,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">ⴰⵖⵎⵉⵙ ⵏ
 ⵓⵎⴻⵙⵍⴰⵢ:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ⴼⴼⵔⵏ ⴷⴼⴼⵉⵔ ⵏ ⵓⵣⴰⵎⵓⵍ ⵏ NULL</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -3019,6 +3019,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Разговори:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Скриване на суфикс след нулев символ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -3607,6 +3607,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">চ্যাট লগ:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">নাল প্রতীক পরে প্রত্যয় লুকান</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -3035,6 +3035,11 @@ protokolu chatu</translation>
         <translation type="unfinished">Protokol
 chatu:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Skrýt příponu po nulovém symbolu</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -3418,6 +3418,11 @@ størrelse</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Chatlog:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Skjul suffiks efter nullsymbol</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -3001,6 +3001,11 @@ Bildlaufleiste verschwindet.</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Chatprotokoll:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Suffix nach Nullsymbol verbergen</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -3142,6 +3142,11 @@ number here may cause the scroll bar to disappear.</source>
 ο συνομιλ
 ίας:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Απόκρυψη επιθέματος μετά το μηδενικό σύμβολο</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -3428,6 +3428,11 @@ de babilejo</translation>
         <translation type="unfinished">Babilprot
 okolo:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Kaŝi Sufikson Post Nula Simbolo</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -3002,6 +3002,11 @@ registro de chat</translation>
 de conver
 saciones:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ocultar sufijo tras símbolo nulo</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -3032,6 +3032,11 @@ suurus</translation>
         <translation type="unfinished">Vestluse
 logi:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Peida järelliide pärast null sümbolit</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -3090,6 +3090,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">گزارش چت:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">پسوند را پس از نماد تهی پنهان کنید</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -3028,6 +3028,11 @@ saattaa aiheuttaa vierityspalkin katoamisen.</translation>
         <translation type="unfinished">Chat-
 loki:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Piilota jälkiliite NULL -symbolin jälkeen</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -3014,6 +3014,11 @@ discussion</translation>
 de discus
 sion&#xa0;:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Masquer le suffixe après le symbole nul</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -3094,6 +3094,11 @@ do rexistro de chat</translation>
         <translation type="unfinished">Rexistro
 de chat:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ocultar o sufixo despois do símbolo nulo</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -3590,6 +3590,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">יומן
 צ&apos;אט:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">הסתר סיומת אחרי סמל NULL</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -3094,6 +3094,11 @@ dnevnika razgovora</translation>
         <translation type="unfinished">Dnevnik r
 azgovora:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Sakrij sufiks nakon nultog simbola</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -3088,6 +3088,11 @@ naplódarab mérete</translation>
         <translation type="unfinished">Csevegési
 napló:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Elrejtse az utótagot null szimbólum után</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -3583,6 +3583,11 @@ spjalldagskrár</translation>
         <translation type="unfinished">Spjallskr
 á:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Fela viðskeyti eftir núll tákn</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -3012,6 +3012,11 @@ della chat</translation>
 della
 chat:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Nascondere il suffisso dopo il simbolo null</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -3148,6 +3148,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">チャットログ:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ヌル記号の後に接尾辞を非表示にします</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -3561,6 +3561,11 @@ lo nu vi cmima cu rinka lo nu lo rokci bajra cu canci</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">fi&apos;o casnu log:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">zoi gy</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -3599,6 +3599,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">ಚಾಟ್
 ಲಾಗ್:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಶೂನ್ಯ ಚಿಹ್ನೆಯ ನಂತರ ಪ್ರತ್ಯಯವನ್ನು ಮರೆಮಾಡಿ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -3436,6 +3436,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">채팅 로그:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">널 기호 후 접미사를 숨 깁니다</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -3621,6 +3621,11 @@ chatlogboek</translation>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Chatlog:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Verberg achterkants nao NULL-symbool</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -3036,6 +3036,11 @@ gabalo dydis</translation>
         <translation type="unfinished">Pokalbių
 žurnalas:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Paslėpti priesagą po nulinio simbolio</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -3108,6 +3108,11 @@ gabala lielums</translation>
 s
 žurnāls:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Paslēpt piedēkli pēc nulles simbola</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -3152,6 +3152,11 @@ number here may cause the scroll bar to disappear.</source>
 на разгов
 ори:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Скријте го суфиксот по нулта симбол</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -3014,6 +3014,11 @@ størrelse</translation>
         <translation type="unfinished">Chat-
 logg:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Skjul suffiks etter nullsymbol</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -3000,6 +3000,11 @@ chatlogboek</translation>
         <translation type="unfinished">Chatlogbo
 ek:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Het achtervoegsel verbergen na nulsymbool</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -2953,6 +2953,10 @@ number here may cause the scroll bar to disappear.</source>
         <source>Chat log:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -3041,6 +3041,11 @@ dziennika czatu</translation>
         <translation type="unfinished">Dziennik
 czatu:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ukryj sufiks po zerowym symbolu</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -2977,6 +2977,10 @@ here may cause th&apos; scroll bar ta vanish.</translation>
         <source>Chat log:</source>
         <translation type="unfinished">Th&apos; Message Log:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -3033,6 +3033,11 @@ papo</translation>
 de bate-
 papo:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ocultar sufixo após símbolo nulo</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -3015,6 +3015,11 @@ papo</translation>
 de bate-
 papo:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ocultar sufixo após símbolo nulo</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -3007,6 +3007,11 @@ de chat</translation>
         <translation type="unfinished">Jurnal de
 chat:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ascunde sufixul după simbolul nul</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -3004,6 +3004,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Журнал чата:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Скрыть суффикс после нулевого символа</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -3613,6 +3613,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">කතාබස්
 ලොගය:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ශුන්ය සංකේතයෙන් පසු උපසර්ගය සඟවන්න</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -3018,6 +3018,11 @@ denníka rozhovoru</translation>
         <translation type="unfinished">Denník ro
 zhovoru:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Skryť príponu po nulovom symbole</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -3275,6 +3275,11 @@ dnevnika klepeta</translation>
         <translation type="unfinished">Dnevnik
 klepeta:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Skrij pripono po ničelnem simbolu</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -3611,6 +3611,11 @@ bisedës</translation>
         <translation type="unfinished">Ditari i
 bisedës:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Fshih prapashtesë pas simbolit të pavlefshëm</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -3096,6 +3096,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">Дневник
 ћаскања:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Сакриј суфикс након нула симбола</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -2958,6 +2958,10 @@ number here may cause the scroll bar to disappear.</source>
         <source>Chat log:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -3038,6 +3038,11 @@ för lågt nummer här kan göra att rullningslisten försvinner.</translation>
         <translation type="unfinished">Chattlogg
 :</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Dölj suffix efter nollsymbol</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -3616,6 +3616,11 @@ gumzo</translation>
         <translation type="unfinished">logi ya
 gumzo:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ficha kiambishi baada ya alama null</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -3371,6 +3371,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>அரட்டை பதிவு:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">பூஜ்ய சின்னத்திற்குப் பிறகு பின்னொட்டு மறைக்கவும்</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -3009,6 +3009,11 @@ yığın boyutu</translation>
         <translation type="unfinished">Sohbet
 günlüğü:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">NULL SEMBOLUSUNDAN SONRA SAKIM GEMİN</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -3145,6 +3145,11 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">پاراڭ
 خاتىرىسى:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Null بەلگىسىدىن كېيىن قوشۇمچىنى يوشۇرۇڭ</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -3009,6 +3009,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>Журнал чату:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Сховати суфікс за нульовим символом</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -3587,6 +3587,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">چیٹ لاگ:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">کالعدم علامت کے بعد لاحقہ چھپائیں</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -3009,6 +3009,11 @@ nhật ký trò chuyện</translation>
 trò
 chuyện:</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Ẩn hậu tố sau ký hiệu null</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2989,6 +2989,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">聊天记录：</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">在null符号之后隐藏后缀</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -3483,6 +3483,11 @@ number here may cause the scroll bar to disappear.</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">聊天記錄：</translation>
     </message>
+    <message>
+        <source>Hide suffix after NULL symbol</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">在null符號之後隱藏後綴</translation>
+    </message>
 </context>
 <context>
     <name>Widget</name>


### PR DESCRIPTION
In Qt6 when we convert QByteArray to string, \0 is considered as a valid character  and do not end the string. Some messengers as TRIfA may provide additional information after the 0-th symbol, resulting in unexpected output of non readable symbols.
By default TRIfA v3 message will have the next structure:
message
2 bytes \0 (guard)
32  bytes of random values
4 bytes timestamp
See [source](https://github.com/zoff99/ToxAndroidRefImpl/blob/a00aed444f49ac5af277235e549047381b6b515c/jni-c-toxcore/jni-c-toxcore.c#L4005)
In This PR we are adding option to hide this line, or show it (the content of the line is saved in chat history).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/513)
<!-- Reviewable:end -->
