### PR TITLE
fix(chatform): fix the status button alignment

### DIFF
--- a/themes/dark/statusButton/statusButton.qss
+++ b/themes/dark/statusButton/statusButton.qss
@@ -4,6 +4,7 @@ QPushButton
     background-color: @themeMediumDark;
     border: none;
     border-radius: 6px;
+    text-align: center;
     width: 20px;
     height: 40px;
 }

--- a/themes/default/statusButton/statusButton.qss
+++ b/themes/default/statusButton/statusButton.qss
@@ -4,6 +4,7 @@ QPushButton
     background-color: @themeMediumDark;
     border: none;
     border-radius: 6px;
+    text-align: center;
     width: 20px;
     height: 40px;
 }


### PR DESCRIPTION
In Qt6 the icon is left aligned by default, so it seems trimmed from the left. Here we explicitly set alignment to centre.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/515)
<!-- Reviewable:end -->
