### PR TITLE
cleanup: Rename "Add new circle" to "Create new circle".

### DIFF
--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -382,7 +382,7 @@ void FriendListWidget::removeFriendWidget(FriendWidget* w)
 
 void FriendListWidget::addCircleWidget(int id)
 {
-    createCircleWidget(id);
+    std::ignore = createCircleWidget(id);
 }
 
 void FriendListWidget::addCircleWidget(FriendWidget* friendWidget)

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -42,7 +42,7 @@ public:
                      ConferenceList& conferenceList, Profile& profile, bool conferencesOnTop = true);
     ~FriendListWidget() override;
     void setMode(SortingMode mode);
-    SortingMode getMode() const;
+    [[nodiscard]] SortingMode getMode() const;
 
     void addConferenceWidget(ConferenceWidget* widget);
     void addFriendWidget(FriendWidget* w);
@@ -78,12 +78,12 @@ private slots:
     void dayTimeout();
 
 private:
-    CircleWidget* createCircleWidget(int id = -1);
-    CategoryWidget* getTimeCategoryWidget(const Friend* frd) const;
+    [[nodiscard]] CircleWidget* createCircleWidget(int id = -1);
+    [[nodiscard]] CategoryWidget* getTimeCategoryWidget(const Friend* frd) const;
     void sortByMode();
     void cleanMainLayout();
-    QWidget* getNextWidgetForName(IFriendListItem* currentPos, bool forward) const;
-    QVector<std::shared_ptr<IFriendListItem>> getItemsFromCircle(CircleWidget* circle) const;
+    [[nodiscard]] QWidget* getNextWidgetForName(IFriendListItem* currentPos, bool forward) const;
+    [[nodiscard]] QVector<std::shared_ptr<IFriendListItem>> getItemsFromCircle(CircleWidget* circle) const;
 
     SortingMode mode;
     QVBoxLayout* listLayout = nullptr;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2584,10 +2584,10 @@ void Widget::friendListContextMenu(const QPoint& pos)
 {
     QMenu menu(this);
     QAction* createConferenceAction = menu.addAction(tr("Create new conference..."));
-    QAction* addCircleAction = menu.addAction(tr("Add new circle..."));
+    QAction* createCircleAction = menu.addAction(tr("Create new circle..."));
     QAction* chosenAction = menu.exec(ui->friendList->mapToGlobal(pos));
 
-    if (chosenAction == addCircleAction) {
+    if (chosenAction == createCircleAction) {
         chatListWidget->addCircleWidget();
     } else if (chosenAction == createConferenceAction) {
         core->createConference();

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -3215,7 +3215,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>اسمك</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>اضافة قائمة جديدة...</translation>
     </message>
     <message>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -3168,7 +3168,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">Ставарыць новую групу…</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Дадаць новы круг…</translation>
     </message>
     <message>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -3633,7 +3633,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⴰⵙⴰⵔⴰⴳ ⴰⵎⴰⵢⵏⵓⵜ...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵔⵏⵓ ⵜⴰⵖⴻⵛⵜ ⵜⴰⵎⴰⵢⵏⵓⵜ...</translation>
     </message>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -3065,7 +3065,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>Създаване на групов разговор…</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Създаване на списък…</translation>
     </message>
     <message>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -3692,7 +3692,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">নতুন সম্মেলন তৈরি করুন...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">নতুন চেনাশোনা যোগ করুন...</translation>
     </message>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -3068,7 +3068,7 @@ chatu:</translation>
         <translation>Stav</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Přidat nový kruh...</translation>
     </message>
     <message>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -3488,7 +3488,7 @@ størrelse</translation>
         <translation>Dit navn</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Opret ny cirkel...</translation>
     </message>
     <message>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -3064,7 +3064,7 @@ Bildlaufleiste verschwindet.</translation>
         <translation>Neue Konferenz erstellen...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Neuen Kreis hinzufügen...</translation>
     </message>
     <message>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -3165,7 +3165,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>Το όνομα σας</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Προσθέστε νέο κύκλο...</translation>
     </message>
     <message>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -3466,7 +3466,7 @@ okolo:</translation>
         <translation type="unfinished">Krei novan grupon...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Aldoni novan rondon...</translation>
     </message>
     <message>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -3039,7 +3039,7 @@ saciones:</translation>
         <translation>Crear un nuevo grupo...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Agregar un nuevo círculo...</translation>
     </message>
     <message>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -3053,7 +3053,7 @@ logi:</translation>
         <translation>Sinu nimi</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Lisa uus suhtlusring...</translation>
     </message>
     <message>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -3153,7 +3153,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">ساخت یک گروه جدید...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>اضافه کردن یک حلقه جدید...</translation>
     </message>
     <message>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -3065,7 +3065,7 @@ loki:</translation>
         <translation>Tila</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Lisää uusi piiri...</translation>
     </message>
     <message>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -3070,7 +3070,7 @@ sion&#xa0;:</translation>
         <translation>Statut</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Ajouter un nouveau cercle…</translation>
     </message>
     <message>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -3158,7 +3158,7 @@ de chat:</translation>
         <translation type="unfinished">Crear un grupo novo ...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Engade un novo círculo ...</translation>
     </message>
     <message>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -3670,7 +3670,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">השם שלך</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">הוסף מעגל חדש...</translation>
     </message>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -3140,7 +3140,7 @@ azgovora:</translation>
         <translation type="unfinished">Stvori novu grupu …</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Dodaj novi kružok …</translation>
     </message>
     <message>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -3134,7 +3134,7 @@ napló:</translation>
         <translation type="unfinished">Új csoport létrehozása...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Új kör hozzáadása...</translation>
     </message>
     <message>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -3668,7 +3668,7 @@ spjalldagskrár</translation>
         <translation type="unfinished">Búa til nýja ráðstefnu...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Bæta við nýjum hring...</translation>
     </message>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -3041,7 +3041,7 @@ chat:</translation>
         <translation>Occupato</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Aggiungi un nuovo circolo...</translation>
     </message>
     <message>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -3178,7 +3178,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>新しいグループを作成…</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>新しいサークルを追加…</translation>
     </message>
     <message>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -3645,7 +3645,7 @@ lo nu vi cmima cu rinka lo nu lo rokci bajra cu canci</translation>
         <translation type="unfinished">ko finti lo cnino nunfermi</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ko jmina lo cnino dinju</translation>
     </message>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -3679,7 +3679,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">ಹೊಸ ಸಮ್ಮೇಳನವನ್ನು ರಚಿಸಿ...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಹೊಸ ವಲಯವನ್ನು ಸೇರಿಸಿ...</translation>
     </message>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -3512,7 +3512,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">새 그룹 만들기...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">새 서클 추가...</translation>
     </message>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -3719,7 +3719,7 @@ chatlogboek</translation>
         <translation type="unfinished">Maak nuie conferentie...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Voeg nuie cirkel toe...</translation>
     </message>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -3053,7 +3053,7 @@ gabalo dydis</translation>
         <translation>Prisijungę</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Sukurti naują draugų ratą...</translation>
     </message>
     <message>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -3173,7 +3173,7 @@ s
         <translation type="unfinished">Izveidot jaunu konferenci...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Pievienot jaunu loku...</translation>
     </message>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -3215,7 +3215,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">Создај нова група…</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Додај нов круг...</translation>
     </message>
     <message>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -3046,7 +3046,7 @@ logg:</translation>
         <translation>Alle</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Legg til ny sirkel…</translation>
     </message>
     <message>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -3049,7 +3049,7 @@ ek:</translation>
         <translation>Status</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Nieuwe cirkel toevoegen…</translation>
     </message>
     <message>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -3017,7 +3017,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">Nieuwe groep aanmaken…</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Nieuwe cirkel toevoegen…</translation>
     </message>
     <message>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -3075,7 +3075,7 @@ czatu:</translation>
         <translation>Zajęty/a</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Dodaj nowy krąg...</translation>
     </message>
     <message>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -3041,7 +3041,7 @@ here may cause th&apos; scroll bar ta vanish.</translation>
         <translation type="unfinished">Start a new gatherin&apos;...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation type="unfinished">Add new guild...</translation>
     </message>
     <message>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -3051,7 +3051,7 @@ papo:</translation>
         <translation>Conectados</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Adicionar círculo novo...</translation>
     </message>
     <message>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -3077,7 +3077,7 @@ papo:</translation>
         <translation type="unfinished">Criar novo grupo...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Adicionar novo círculo...</translation>
     </message>
     <message>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -3070,7 +3070,7 @@ chat:</translation>
         <translation>Creați o nouă conferință...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Adăugați un cerc nou...</translation>
     </message>
     <message>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -3045,7 +3045,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>Создать новую конференцию...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Добавить новый список...</translation>
     </message>
     <message>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -3698,7 +3698,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">නව සම්මන්ත්‍රණයක් සාදන්න...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">නව කවයක් එක් කරන්න...</translation>
     </message>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -3080,7 +3080,7 @@ zhovoru:</translation>
         <translation type="unfinished">Vytvoriť novú skupinu...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Vytvoriť nový kruh...</translation>
     </message>
     <message>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -3325,7 +3325,7 @@ klepeta:</translation>
         <translation type="unfinished">Ustvari novo konferenco ...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Dodaj nov krog ...</translation>
     </message>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -3696,7 +3696,7 @@ bisedës:</translation>
         <translation type="unfinished">Krijo një konferencë të re...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Shto rreth të ri...</translation>
     </message>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -3160,7 +3160,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">Направи нову групу...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Додај нови круг...</translation>
     </message>
     <message>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -3022,7 +3022,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">Napravi novu grupu...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Dodaj novi krug...</translation>
     </message>
     <message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -3083,7 +3083,7 @@ för lågt nummer här kan göra att rullningslisten försvinner.</translation>
         <translation type="unfinished">Skapa ny grupp...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Lägg till ny cirkel...</translation>
     </message>
     <message>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -3701,7 +3701,7 @@ gumzo:</translation>
         <translation type="unfinished">Unda mkutano mpya...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ongeza mduara mpya...</translation>
     </message>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -3447,7 +3447,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>புதிய மாநாட்டை உருவாக்கவும் ...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>புதிய வட்டத்தைச் சேர்க்கவும் ...</translation>
     </message>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -3030,7 +3030,7 @@ günlüğü:</translation>
         <translation>Adınız</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Yeni çevre ekle...</translation>
     </message>
     <message>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -3208,7 +3208,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">توپ قۇرۇش...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>چەمبىرەككە چىقىرىش...</translation>
     </message>
     <message>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -3042,7 +3042,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>Зайнятий/зайнята</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Додати нове коло...</translation>
     </message>
     <message>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -3672,7 +3672,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">نئی کانفرنس بنائیں...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">نیا حلقہ شامل کریں...</translation>
     </message>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -3072,7 +3072,7 @@ chuyện:</translation>
         <translation type="unfinished">Tạo nhóm mới...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>Thêm kết nối...</translation>
     </message>
     <message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -3051,7 +3051,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation>创建新会议...</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>添加新圈子...</translation>
     </message>
     <message>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -3553,7 +3553,7 @@ number here may cause the scroll bar to disappear.</source>
         <translation type="unfinished">建立新群組…</translation>
     </message>
     <message>
-        <source>Add new circle...</source>
+        <source>Create new circle...</source>
         <translation>新增新圈子…</translation>
     </message>
     <message>


### PR DESCRIPTION
"Add" implies that the circle already exists and we're adding it. "Add new" doesn't make it much better. We already use "Create new conference", so this aligns the two.

https://github.com/TokTok/qTox/issues/497#issuecomment-2646309361

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/518)
<!-- Reviewable:end -->
