### PR TITLE
cleanup: Fix compilation under C++17.

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -69,6 +69,7 @@ QDebug operator<<(QDebug dbg, const AVDictionary* const* dict)
     return dbg << options.join(", ").toUtf8().constData();
 }
 
+#ifdef Q_OS_MACOS
 constexpr int numDigits(uint32_t num)
 {
     int digits = 0;
@@ -91,7 +92,10 @@ constexpr auto toCharArray()
 }
 
 // Compile-time unit test for the above function.
+#if __cplusplus >= 202002L
 static_assert(toCharArray<12345>() == std::array<char, 6>{'1', '2', '3', '4', '5', '\0'});
+#endif
+#endif // Q_OS_MACOS
 } // namespace
 
 QHash<QString, CameraDevice*> CameraDevice::openDevices;


### PR DESCRIPTION
`std::array`'s equality is constexpr only in C++20 and later.

Fixes https://github.com/TokTok/qTox/issues/548

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/549)
<!-- Reviewable:end -->
