### PR TITLE
fix(Startup): Allow Tox Address in the friend address settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ target/
 /compile_commands.json
 /.lsp_tidy_cache
 /third_party/ci-tools
+/third_party/deps

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,7 +6,7 @@
       "binaryDir": "${sourceDir}/_build-release",
       "generator": "Ninja",
       "environment": {
-        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+        "PKG_CONFIG_PATH": "${sourceDir}/third_party/deps/lib/pkgconfig"
       },
       "cacheVariables": {
         "UBSAN": true,
@@ -15,9 +15,9 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake;${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/x86_64-linux-gnu/cmake",
+        "CMAKE_PREFIX_PATH": "${sourceDir}/third_party/deps/lib/cmake;${sourceDir}/third_party/deps/lib/x86_64-linux-gnu/cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12",
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/qt/lib/cmake/Qt6/qt.toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third_party/deps/qt/lib/cmake/Qt6/qt.toolchain.cmake"
       }
     },
     {
@@ -25,7 +25,7 @@
       "binaryDir": "${sourceDir}/_build-asan",
       "generator": "Ninja",
       "environment": {
-        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+        "PKG_CONFIG_PATH": "${sourceDir}/third_party/deps/lib/pkgconfig"
       },
       "cacheVariables": {
         "ASAN": true,
@@ -35,9 +35,9 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake;${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/x86_64-linux-gnu/cmake",
+        "CMAKE_PREFIX_PATH": "${sourceDir}/third_party/deps/lib/cmake;${sourceDir}/third_party/deps/lib/x86_64-linux-gnu/cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12",
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/qt-asan/lib/cmake/Qt6/qt.toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third_party/deps/qt-asan/lib/cmake/Qt6/qt.toolchain.cmake"
       }
     },
     {
@@ -45,7 +45,7 @@
       "binaryDir": "${sourceDir}/_build-tsan",
       "generator": "Ninja",
       "environment": {
-        "PKG_CONFIG_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/pkgconfig"
+        "PKG_CONFIG_PATH": "${sourceDir}/third_party/deps/lib/pkgconfig"
       },
       "cacheVariables": {
         "TSAN": true,
@@ -54,9 +54,9 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-        "CMAKE_PREFIX_PATH": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/cmake;${sourceDir}/.ci-scripts/dockerfiles/local-deps/lib/x86_64-linux-gnu/cmake",
+        "CMAKE_PREFIX_PATH": "${sourceDir}/third_party/deps/lib/cmake;${sourceDir}/third_party/deps/lib/x86_64-linux-gnu/cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12",
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/.ci-scripts/dockerfiles/local-deps/qt-tsan/lib/cmake/Qt6/qt.toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third_party/deps/qt-tsan/lib/cmake/Qt6/qt.toolchain.cmake"
       }
     },
     {

--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -32,8 +32,8 @@ ToxPk::ToxPk(QByteArray rawId)
     : ChatId(std::move(rawId))
 {
     if (id.length() != size) {
-        qFatal("ToxPk constructed with invalid length (%u instead of %d)",
-               static_cast<uint>(id.length()), size);
+        qCritical("ToxPk constructed with invalid length (%u instead of %d)",
+                  static_cast<uint>(id.length()), size);
     }
 }
 
@@ -57,8 +57,8 @@ ToxPk::ToxPk(const uint8_t* rawId)
 ToxPk::ToxPk(const QString& pk)
     : ToxPk([&pk]() {
         if (pk.length() != numHexChars) {
-            qFatal("ToxPk constructed with invalid length string (%u instead of %d)",
-                   static_cast<uint>(pk.length()), numHexChars);
+            qCritical("ToxPk constructed with invalid length string (%u instead of %d)",
+                      static_cast<uint>(pk.length()), numHexChars);
         }
         return QByteArray::fromHex(pk.toLatin1());
     }())

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -544,7 +544,7 @@ void Settings::loadPersonal(const Profile& profile, bool newProfile)
 
                 if (getEnableLogging())
                     fp.activity = ps.value("activity", QDateTime()).toDateTime();
-                friendLst.insert(ToxPk(fp.addr).getByteArray(), fp);
+                friendLst.insert(ToxPk(fp.addr.mid(0, ToxPk::numHexChars)).getByteArray(), fp);
             }
         });
     });


### PR DESCRIPTION
We parse it as Tox public key, but allow nospam+checksum suffixes.

Also, don't crash when the Tox public key is the wrong size. It'll probably do weird things afterwards, but there seem to be real users with those broken (0-sized) keys in their settings. I'd rather not load them, but the NDEBUG behaviour was to accept them, so we keep them like this for now.

Fixes #562. Fixes #567.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/563)
<!-- Reviewable:end -->
