### PR TITLE
refactor: Make post-null cleanup code less trifa-specific.

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -51,8 +51,11 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QSt
     QString senderText = sender;
 
     auto textType = Text::NORMAL;
-    // TRIfA suffixes
-    text = TextFormatter::processTrifaSuffixes(text, settings.getHideTrifaSuffix());
+
+    // garbage after \0
+    if (settings.getHidePostNullSuffix()) {
+        text = TextFormatter::processPostNullSuffix(text, true);
+    }
 
     // smileys
     if (settings.getUseEmoticons())

--- a/src/chatlog/textformatter.h
+++ b/src/chatlog/textformatter.h
@@ -5,12 +5,12 @@
 
 #pragma once
 
-#include <QString>
+class QString;
 
 namespace TextFormatter {
 QString highlightURI(const QString& message);
 
 QString applyMarkdown(const QString& message, bool showFormattingSymbols);
 
-QString processTrifaSuffixes(const QString& message, bool hideTrifaSuffix);
+QString processPostNullSuffix(QString message, bool html);
 } // namespace TextFormatter

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -382,7 +382,7 @@ void Core::onFriendMessage(Tox* tox, uint32_t friendId, Tox_Message_Type type,
 {
     std::ignore = tox;
     const bool isAction = (type == TOX_MESSAGE_TYPE_ACTION);
-    const QString msg = ToxString(cMessage, cMessageSize, true).getQString();
+    const QString msg = ToxString(cMessage, cMessageSize).getQString();
     emit static_cast<Core*>(core)->friendMessageReceived(friendId, msg, isAction);
 }
 
@@ -492,7 +492,7 @@ void Core::onConferenceMessage(Tox* tox, uint32_t conferenceId, uint32_t peerId,
     std::ignore = tox;
     Core* core = static_cast<Core*>(vCore);
     const bool isAction = type == TOX_MESSAGE_TYPE_ACTION;
-    const QString message = ToxString(cMessage, length, true).getQString();
+    const QString message = ToxString(cMessage, length).getQString();
     emit core->conferenceMessageReceived(conferenceId, peerId, message, isAction);
 }
 

--- a/src/core/toxstring.cpp
+++ b/src/core/toxstring.cpp
@@ -12,7 +12,6 @@
 
 #include <cassert>
 #include <climits>
-#include <ctime>
 #include <utility>
 
 /**
@@ -44,61 +43,9 @@ ToxString::ToxString(QByteArray text)
  * @param length Number of bytes to read from the beginning.
  */
 ToxString::ToxString(const uint8_t* text, size_t length)
-    : ToxString(text, length, false)
 {
-}
-
-
-/**
- * @brief Creates a ToxString from the representation used by c-toxcore.
- * @param text Pointer to the beginning of the text.
- * @param length Number of bytes to read from the beginning.
- * @param fix_trifa if true, fix TRIfA messages v3, containing suffix after \0.
- */
-ToxString::ToxString(const uint8_t* text, size_t length, bool fix_trifa)
-{
-    if (length > SIZE_MAX) {
-        qCritical() << "The string has invalid length!";
-        return;
-    }
-    if (fix_trifa) {
-        // Try to detect TRIfA message v3 format:
-        // message itself
-        // \0\0 TOX_MSGV3_GUARD = 2
-        // random bytes TOX_MSGV3_MSGID_LENGTH = 32
-        // time stamp TOX_MSGV3_TIMESTAMP_LENGTH = 4
-        size_t actualLength = 0;
-        for (actualLength = 0; actualLength < length; actualLength++) {
-            if (*(text + actualLength) == 0)
-                break;
-        }
-        // Only trim string if its suffix looks like a TRIfA signature.
-        if (length - actualLength == 2 + 32 + 4 && *(text + actualLength + 1) == 0) {
-            // Convert the uint8[4] to timestamp to string
-            std::time_t trifa_timestamp = 0;
-            for (int i = 4; i > 0; i--) {
-                trifa_timestamp = trifa_timestamp << 8;
-                trifa_timestamp += *(text + length - i);
-            }
-            string = QByteArray(reinterpret_cast<const char*>(text), actualLength);
-            // Mark TRIFA suffix to remove it or replace by format symbol
-            string.append("[TRIfA_SUFFIX]");
-            // Skip two \0 symbols.
-            // The string contains random characters and we need to sanitize it.
-            QByteArray randomBt(reinterpret_cast<const char*>(text + actualLength + 2), 32);
-            string.append(getQString(randomBt).toLocal8Bit().constData());
-            // Convert time to string
-            char strTime[std::size("yyyy-mm-ddThh:mm:ssZ")];
-            std::strftime(std::data(strTime), std::size(strTime), "%Y-%m-%dT%H:%M:%SZ",
-                          std::gmtime(&trifa_timestamp));
-            string.append(strTime);
-            string.append("[/TRIfA_SUFFIX]");
-        } else {
-            string = QByteArray(reinterpret_cast<const char*>(text), length);
-        }
-    } else {
-        string = QByteArray(reinterpret_cast<const char*>(text), length);
-    }
+    assert(length <= INT_MAX);
+    string = QByteArray(reinterpret_cast<const char*>(text), length);
 }
 
 /**
@@ -122,39 +69,29 @@ size_t ToxString::size() const
 /**
  * @brief Interpret the string as UTF-8 encoded QString.
  *
- * Removes any non-printable characters from the string. This is a defense-in-depth measure to
- * prevent some potential security issues caused by bugs in client code or one of its dependencies.
- * @return the string with non printable symbols removed.
+ * Replaces any non-printable characters in the string with escape sequences. This is a defense-in-depth
+ * measure to prevent some potential security issues caused by bugs in client code or one of its dependencies.
  */
 QString ToxString::getQString() const
 {
-    return getQString(string);
-}
-
-
-/**
- * @brief Interpret the string as UTF-8 encoded QString.
- *
- * Removes any non-printable characters from the string. This is a defense-in-depth measure to
- * prevent some potential security issues caused by bugs in client code or one of its dependencies.
- * @param stringVal the buffer with bytes.
- * @return the string with non printable symbols removed.
- */
-QString ToxString::getQString(QByteArray stringVal) const
-{
-    const auto tainted = QString::fromUtf8(stringVal).toStdU32String();
+    const auto tainted = QString::fromUtf8(string).toStdU32String();
     QSet<std::pair<QChar::Category, char32_t>> removed;
     std::u32string cleaned;
-    std::copy_if(tainted.cbegin(), tainted.cend(), std::back_inserter(cleaned), [&removed](char32_t c) {
+    for (const char32_t c : tainted) {
         const auto category = QChar::category(c);
         // Cf (Other_Format) is to allow skin-color modifiers for emojis.
         // We also allow newlines and tabs, which are Other_Control, and covered by isSpace.
-        if (QChar::isPrint(c) || QChar::isSpace(c) || category == QChar::Category::Other_Format) {
-            return true;
+        // We also allow \0, so we can later use it to filter out post-NUL garbage.
+        if (c == 0 || QChar::isPrint(c) || QChar::isSpace(c)
+            || category == QChar::Category::Other_Format) {
+            cleaned.push_back(c);
+            continue;
         }
         removed.insert({category, c});
-        return false;
-    });
+        // Add a formatted escape sequence so non-printable characters are still
+        // visible in chat logs and can be easily identified.
+        cleaned += QStringLiteral("\\x%1").arg(c, 2, 16, QChar('0')).toStdU32String();
+    }
     if (!removed.isEmpty()) {
         qWarning() << "Removed non-printable characters from a string:" << removed;
     }

--- a/src/core/toxstring.h
+++ b/src/core/toxstring.h
@@ -16,12 +16,10 @@ public:
     explicit ToxString(const QString& text);
     explicit ToxString(QByteArray text);
     ToxString(const uint8_t* text, size_t length);
-    ToxString(const uint8_t* text, size_t length, bool fix_trifa);
 
     const uint8_t* data() const;
     size_t size() const;
     QString getQString() const;
-    QString getQString(QByteArray stringVal) const;
     const QByteArray& getBytes() const;
 
 private:

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -11,9 +11,6 @@
 
 namespace {
 
-const QRegularExpression TRIFA_WRAPPER(QStringLiteral("[[]TRIfA_SUFFIX[]](.+)[[]/TRIfA_SUFFIX[]]$"),
-                                       QRegularExpression::DotMatchesEverythingOption);
-
 QString generateContent(const QHash<const Conference*, size_t>& conferenceNotifications,
                         QString lastMessage, const ToxPk& sender)
 {
@@ -54,9 +51,7 @@ NotificationData NotificationGenerator::friendMessageNotification(const Friend* 
     }
 
     ret.title = f->getDisplayedName();
-    // Make sure we have removed the TRIfA suffix if any.
-
-    ret.message = QString(message).remove(TRIFA_WRAPPER);
+    ret.message = message;
     ret.pixmap = getSenderAvatar(profile, f->getPublicKey());
 
     return ret;

--- a/src/persistence/inotificationsettings.h
+++ b/src/persistence/inotificationsettings.h
@@ -40,4 +40,7 @@ public:
 
     virtual bool getConferenceAlwaysNotify() const = 0;
     virtual void setConferenceAlwaysNotify(bool newValue) = 0;
+
+    virtual bool getHidePostNullSuffix() const = 0;
+    virtual void setHidePostNullSuffix(bool newValue) = 0;
 };

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -236,7 +236,7 @@ void Settings::loadGlobal()
         imagePreview = s.value("imagePreview", true).toBool();
         chatMaxWindowSize = s.value("chatMaxWindowSize", 100).toInt();
         chatWindowChunkSize = s.value("chatWindowChunkSize", 50).toInt();
-        hideTrifaSuffix = s.value("hideTrifaSuffix", true).toBool();
+        hidePostNullSuffix = s.value("hidePostNullSuffix", false).toBool();
     });
 
     inGroup(s, "Chat", [this, &s] {
@@ -691,7 +691,7 @@ void Settings::saveGlobal()
         s.setValue("statusChangeNotificationEnabled", statusChangeNotificationEnabled);
         s.setValue("showConferenceJoinLeaveMessages", showConferenceJoinLeaveMessages);
         s.setValue("spellCheckingEnabled", spellCheckingEnabled);
-        s.setValue("hideTrifaSuffix", hideTrifaSuffix);
+        s.setValue("hidePostNullSuffix", hidePostNullSuffix);
     });
 
     inGroup(s, "Chat", [this, &s] { //
@@ -1445,16 +1445,16 @@ void Settings::setChatMessageFont(const QFont& font)
     }
 }
 
-bool Settings::getHideTrifaSuffix() const
+bool Settings::getHidePostNullSuffix() const
 {
     const QMutexLocker<QRecursiveMutex> locker(&bigLock);
-    return hideTrifaSuffix;
+    return hidePostNullSuffix;
 }
 
-void Settings::setHideTrifaSuffix(bool hide)
+void Settings::setHidePostNullSuffix(bool hide)
 {
-    if (setVal(hideTrifaSuffix, hide)) {
-        emit hideTrifaSuffixChanged(hide);
+    if (setVal(hidePostNullSuffix, hide)) {
+        emit hidePostNullSuffixChanged(hide);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -222,7 +222,7 @@ signals:
     void dateFormatChanged(const QString& format);
     void statusChangeNotificationEnabledChanged(bool enabled);
     void spellCheckingEnabledChanged(bool enabled);
-    void hideTrifaSuffixChanged(bool show);
+    void hidePostNullSuffixChanged(bool show);
 
     // Privacy
     void typingNotificationChanged(bool enabled);
@@ -459,8 +459,8 @@ public:
     bool getSpellCheckingEnabled() const;
     void setSpellCheckingEnabled(bool newValue);
 
-    bool getHideTrifaSuffix() const;
-    void setHideTrifaSuffix(bool hide);
+    bool getHidePostNullSuffix() const override;
+    void setHidePostNullSuffix(bool hide) override;
 
     // Privacy
     bool getTypingNotification() const;
@@ -675,7 +675,7 @@ private:
     bool statusChangeNotificationEnabled;
     bool showConferenceJoinLeaveMessages;
     bool spellCheckingEnabled;
-    bool hideTrifaSuffix;
+    bool hidePostNullSuffix;
 
     // Privacy
     bool typingNotification;

--- a/src/platform/desktop_notifications/desktopnotify.cpp
+++ b/src/platform/desktop_notifications/desktopnotify.cpp
@@ -6,6 +6,7 @@
 
 #include "desktopnotifybackend.h"
 
+#include "src/chatlog/textformatter.h"
 #include "src/persistence/inotificationsettings.h"
 
 #include <QDebug>
@@ -45,10 +46,14 @@ void DesktopNotify::notifyMessage(const NotificationData& notificationData)
         return;
     }
 
+    const QString message = d->settings.getHidePostNullSuffix()
+                                ? TextFormatter::processPostNullSuffix(notificationData.message, false)
+                                : notificationData.message;
+
     // Try system-backends first.
     if (d->settings.getNotifySystemBackend()) {
-        if (d->dbus->showMessage(notificationData.title, notificationData.message,
-                                 notificationData.category, notificationData.pixmap)) {
+        if (d->dbus->showMessage(notificationData.title, message, notificationData.category,
+                                 notificationData.pixmap)) {
             return;
         }
     }
@@ -64,5 +69,5 @@ void DesktopNotify::notifyMessage(const NotificationData& notificationData)
     }
 
     // Fallback to QSystemTrayIcon.
-    d->icon->showMessage(notificationData.title, notificationData.message, notificationData.pixmap);
+    d->icon->showMessage(notificationData.title, message, notificationData.pixmap);
 }

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -80,7 +80,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings
     bodyUI->chatLogMaxTxt->setValue(settings.getChatMaxWindowSize());
     bodyUI->chatLogChunkTxt->setValue(settings.getChatWindowChunkSize());
     bodyUI->cbImagePreview->setChecked(settings.getImagePreview());
-    bodyUI->cbHideTrifaSuffix->setChecked(settings.getHideTrifaSuffix());
+    bodyUI->cbHidePostNullSuffix->setChecked(settings.getHidePostNullSuffix());
 
     bodyUI->cbConferencePosition->setChecked(settings.getConferencePosition());
     bodyUI->cbCompactLayout->setChecked(settings.getCompactLayout());
@@ -400,9 +400,9 @@ void UserInterfaceForm::on_cbImagePreview_stateChanged()
     settings.setImagePreview(bodyUI->cbImagePreview->isChecked());
 }
 
-void UserInterfaceForm::on_cbHideTrifaSuffix_stateChanged()
+void UserInterfaceForm::on_cbHidePostNullSuffix_stateChanged()
 {
-    settings.setHideTrifaSuffix(bodyUI->cbHideTrifaSuffix->isChecked());
+    settings.setHidePostNullSuffix(bodyUI->cbHidePostNullSuffix->isChecked());
 }
 
 void UserInterfaceForm::on_chatLogChunkTxt_valueChanged(int value)

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -56,7 +56,7 @@ private slots:
     void on_txtChatFontSize_valueChanged(int px);
     void on_useNameColors_stateChanged(int value);
     void on_cbImagePreview_stateChanged();
-    void on_cbHideTrifaSuffix_stateChanged();
+    void on_cbHidePostNullSuffix_stateChanged();
     void on_chatLogMaxTxt_valueChanged(int value);
     void on_chatLogChunkTxt_valueChanged(int value);
 

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -232,7 +232,7 @@ number here may cause the scroll bar to disappear.</string>
            </layout>
           </item>
           <item row="4" column="1">
-           <widget class="QCheckBox" name="cbHideTrifaSuffix">
+           <widget class="QCheckBox" name="cbHidePostNullSuffix">
             <property name="text">
              <string>Hide suffix after NULL symbol</string>
             </property>

--- a/test/chatlog/textformatter_test.cpp
+++ b/test/chatlog/textformatter_test.cpp
@@ -259,53 +259,15 @@ const QVector<QPair<QString, QString>> URL_CASES{
         "[&quot;" MAKE_LINK("https://en.wikipedia.org/wiki/Seal_(East_Asia)") "&quot;]?"),
 };
 
-const QVector<StringPair> TRIFA_CASE{
-    // Test case when user decided to hide TRIfA suffixes.
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Hello<font color=#228B22>[...]</font>"),
-    PAIR_FORMAT("Hello[TRIfA_SUFFIX]xxxxxxxxxxxxx[/HTML]xxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/"
-                "TRIfA_SUFFIX]",
-                "Hello<font color=#228B22>[...]</font>"),
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxx\nxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Hello<font color=#228B22>[...]</font>"),
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxx\rxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Hello<font color=#228B22>[...]</font>"),
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxx\n\rxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Hello<font color=#228B22>[...]</font>")};
+const QVector<StringPair> POST_NULL_HTML_CASE{
+    // Test case for HTML output (in chat log).
+    PAIR_FORMAT("Hello\x00\x00some garbage here", "Hello<font color=\"#228B22\">[...]</font>"),
+};
 
-const QVector<StringPair> TRIFA_CASE_OPT_OUT{
-    // Test case when user decided to show TRIfA suffixes as is.
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
-    PAIR_FORMAT("Hello[TRIfA_SUFFIX]xxxxxxxxxxxxx[/HTML]xxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/"
-                "TRIfA_SUFFIX]",
-                "Helloxxxxxxxxxxxxx[/HTML]xxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxx\nxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Helloxxxxxxx\nxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxx\rxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Helloxxxxxxx\rxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z"),
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxx\n\rxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]",
-        "Helloxxxxxxx\n\rxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z")};
-
-const QVector<StringPair> TRIFA_CASES_NEGATIVE{
-    // Test cases when TRIfA suffix is not formed correctly
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]x",
-        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]x"),
-    PAIR_FORMAT(
-        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[TRIfA_SUFFIX]",
-        "Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[TRIfA_SUFFIX]")};
-
-const QVector<StringPair> ALL_TRIFA_CASES = concat(TRIFA_CASE, TRIFA_CASES_NEGATIVE);
-const QVector<StringPair> ALL_TRIFA_OPT_OUT_CASES = concat(TRIFA_CASE_OPT_OUT, TRIFA_CASES_NEGATIVE);
+const QVector<StringPair> POST_NULL_PLAIN_CASE{
+    // Test case for plain text output (in notifications).
+    PAIR_FORMAT("Hello\x00\x00some garbage here", "Hello[...]"),
+};
 
 #undef PAIR_FORMAT
 
@@ -343,12 +305,12 @@ void workCasesTest(MarkdownFunction applyMarkdown, const QVector<MarkdownToTags>
 /*
  * @brief Testing cases for TRIfA suffix.
  * @param testData Test data - string pairs "Source message - Message after formatting"
- * @param True if suffixes  should be replaced by [...]
+ * @param True if suffixes should be replaced by [...]
  */
-void trifaCasesTest(const QVector<StringPair>& testData, bool hideTrifaSuffix)
+void postNullCasesTest(const QVector<StringPair>& testData, bool html)
 {
     for (const StringPair& data : testData) {
-        QString result = TextFormatter::processTrifaSuffixes(data.first, hideTrifaSuffix);
+        QString result = TextFormatter::processPostNullSuffix(data.first, html);
         QCOMPARE(data.second, result);
     }
 }
@@ -469,8 +431,8 @@ private slots:
     void singleAndDoubleMarkdownExceptionsShowSymbols();
     void singleAndDoubleMarkdownExceptionsHideSymbols();
     void mixedFormattingSpecialCases();
-    void trifaTags();
-    void trifaTagsOptOut();
+    void postNullTagsHtml();
+    void postNullTagsPlain();
     void urlTest();
 
 private:
@@ -568,14 +530,14 @@ void TestTextFormatter::urlTest()
     urlHighlightTest(urlHighlightFunction, URL_CASES);
 }
 
-void TestTextFormatter::trifaTags()
+void TestTextFormatter::postNullTagsHtml()
 {
-    trifaCasesTest(ALL_TRIFA_CASES, true);
+    postNullCasesTest(POST_NULL_HTML_CASE, true);
 }
 
-void TestTextFormatter::trifaTagsOptOut()
+void TestTextFormatter::postNullTagsPlain()
 {
-    trifaCasesTest(ALL_TRIFA_OPT_OUT_CASES, false);
+    postNullCasesTest(POST_NULL_PLAIN_CASE, false);
 }
 
 QTEST_GUILESS_MAIN(TestTextFormatter)

--- a/test/core/toxstring_test.cpp
+++ b/test/core/toxstring_test.cpp
@@ -30,7 +30,6 @@ private slots:
     void combiningCharacterTest();
     void multiLineTest();
     void tabTest();
-    void trifaFormatTest();
 
 private:
     /* Test Strings */
@@ -271,10 +270,10 @@ void TestToxString::filterTest()
         QString expected;
     } testCases[] = {
         {QStringLiteral("Hello, World!"), QStringLiteral("Hello, World!")},
-        {QStringLiteral("Hello, \x00World!"), QStringLiteral("Hello, World!")},
-        {QStringLiteral("Hello, \x01World!"), QStringLiteral("Hello, World!")},
-        {QStringLiteral("Hello, \x7FWorld!"), QStringLiteral("Hello, World!")},
-        {QStringLiteral("Hello, \x80World!"), QStringLiteral("Hello, World!")},
+        {QStringLiteral("Hello, \x00World!"), QStringLiteral("Hello, \x00World!")},
+        {QStringLiteral("Hello, \x01World!"), QStringLiteral("Hello, \\x01World!")},
+        {QStringLiteral("Hello, \x7FWorld!"), QStringLiteral("Hello, \\x7fWorld!")},
+        {QStringLiteral("Hello, \x80World!"), QStringLiteral("Hello, \\x80World!")},
     };
     for (const auto& testCase : testCases) {
         QCOMPARE(ToxString(testCase.input).getQString(), testCase.expected);
@@ -351,33 +350,6 @@ void TestToxString::combiningCharacterTest()
 
     for (const auto& testCase : testCases) {
         QCOMPARE(ToxString(testCase.input).getQString(), testCase.expected);
-    }
-}
-
-/**
- * @brief Check that we trim TRIfA suffix only if it has a right shape and user set this option.
- */
-void TestToxString::trifaFormatTest()
-{
-    const struct TestCase
-    {
-        const uint8_t* text;
-        const size_t length;
-        const bool fix_trifa;
-        const QString expected;
-    } testCases[] = {
-        {reinterpret_cast<const uint8_t*>("Hello\0\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 43,
-         true, QStringLiteral("Hello[TRIfA_SUFFIX]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1997-10-02T23:54:28Z[/TRIfA_SUFFIX]")},
-        {reinterpret_cast<const uint8_t*>("Hello\0\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 43,
-         false, QStringLiteral("Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444")},
-        {reinterpret_cast<const uint8_t*>("Hello\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 42, true,
-         QStringLiteral("Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444")},
-        {reinterpret_cast<const uint8_t*>("Hello\0\0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444"), 42, true,
-         QStringLiteral("Helloxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4444")},
-    };
-    for (const auto& testCase : testCases) {
-        QCOMPARE(ToxString(testCase.text, testCase.length, testCase.fix_trifa).getQString(),
-                 testCase.expected);
     }
 }
 

--- a/test/model/notificationgenerator_test.cpp
+++ b/test/model/notificationgenerator_test.cpp
@@ -88,6 +88,15 @@ class MockNotificationSettings : public INotificationSettings
         std::ignore = newValue;
     }
 
+    bool getHidePostNullSuffix() const override
+    {
+        return true;
+    }
+    void setHidePostNullSuffix(bool newValue) override
+    {
+        std::ignore = newValue;
+    }
+
 private:
     bool notifyHide = false;
 };


### PR DESCRIPTION
We now remove any suffixes after a double `\0` instead of looking for a specific trifa suffix. This is not ideal, but still less risky than the current implementation.

The current implementation allows anyone (including qTox users) to put text into a `[TRIfA_SUFFIX]text here[/TRIfA_SUFFIX]` message, which could be quite annoying.

Also, this change makes the `hidePostNullSuffix` setting default to false, because this should be an opt-in. TCS requires that we display incoming messages as much like the original as possible, so this default makes sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/570)
<!-- Reviewable:end -->
