### PR TITLE
cleanup: Remove unused enum; add some more parent pointers.

### DIFF
--- a/src/widget/conferencewidget.cpp
+++ b/src/widget/conferencewidget.cpp
@@ -27,8 +27,8 @@
 #include <QPalette>
 
 ConferenceWidget::ConferenceWidget(std::shared_ptr<ConferenceRoom> chatroom_, bool compact_,
-                                   Settings& settings_, Style& style_)
-    : GenericChatroomWidget(compact_, settings_, style_)
+                                   Settings& settings_, Style& style_, QWidget* parent)
+    : GenericChatroomWidget(compact_, settings_, style_, parent)
     , conferenceId{chatroom_->getConference()->getPersistentId()}
     , chatroom{chatroom_}
 {

--- a/src/widget/conferencewidget.h
+++ b/src/widget/conferencewidget.h
@@ -21,7 +21,7 @@ class ConferenceWidget final : public GenericChatroomWidget, public IFriendListI
     Q_OBJECT
 public:
     ConferenceWidget(std::shared_ptr<ConferenceRoom> chatroom_, bool compact, Settings& settings,
-                     Style& style);
+                     Style& style, QWidget* parent);
     ~ConferenceWidget() override;
     void setAsInactiveChatroom() final;
     void setAsActiveChatroom() final;

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -148,7 +148,7 @@ FriendWidget* ContentDialog::addFriend(std::shared_ptr<FriendChatroom> chatroom,
     auto* frnd = chatroom->getFriend();
     const auto& friendPk = frnd->getPublicKey();
     auto* friendWidget =
-        new FriendWidget(chatroom, compact, settings, style, messageBoxManager, profile);
+        new FriendWidget(chatroom, compact, settings, style, messageBoxManager, profile, this);
     emit connectFriendWidget(*friendWidget);
     chatWidgets[friendPk] = friendWidget;
     friendLayout->addFriendWidget(friendWidget, frnd->getStatus());
@@ -171,7 +171,7 @@ ConferenceWidget* ContentDialog::addConference(std::shared_ptr<ConferenceRoom> c
     auto* const g = chatroom->getConference();
     const auto& conferenceId = g->getPersistentId();
     const auto compact = settings.getCompactLayout();
-    auto* conferenceWidget = new ConferenceWidget(chatroom, compact, settings, style);
+    auto* conferenceWidget = new ConferenceWidget(chatroom, compact, settings, style, this);
     chatWidgets[conferenceId] = conferenceWidget;
     conferenceLayout.addSortedWidget(conferenceWidget);
     chatForms[conferenceId] = form;

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -44,8 +44,8 @@
  */
 FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom_, bool compact_,
                            Settings& settings_, Style& style_,
-                           IMessageBoxManager& messageBoxManager_, Profile& profile_)
-    : GenericChatroomWidget(compact_, settings_, style_)
+                           IMessageBoxManager& messageBoxManager_, Profile& profile_, QWidget* parent)
+    : GenericChatroomWidget(compact_, settings_, style_, parent)
     , chatroom{std::move(chatroom_)}
     , isDefaultAvatar{true}
     , settings{settings_}

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -26,7 +26,8 @@ class FriendWidget : public GenericChatroomWidget, public IFriendListItem
     Q_OBJECT
 public:
     FriendWidget(std::shared_ptr<FriendChatroom> chatroom, bool compact_, Settings& settings,
-                 Style& style, IMessageBoxManager& messageBoxManager, Profile& profile);
+                 Style& style, IMessageBoxManager& messageBoxManager, Profile& profile,
+                 QWidget* parent);
 
     void contextMenuEvent(QContextMenuEvent* event) final;
     void setAsActiveChatroom() final;

--- a/src/widget/genericchatitemwidget.h
+++ b/src/widget/genericchatitemwidget.h
@@ -14,15 +14,9 @@ class Style;
 class GenericChatItemWidget : public QFrame
 {
     Q_OBJECT
-public:
-    enum ItemType
-    {
-        ConferenceItem,
-        FriendOfflineItem,
-        FriendOnlineItem
-    };
 
-    GenericChatItemWidget(bool compact_, Style& style, QWidget* parent = nullptr);
+public:
+    GenericChatItemWidget(bool compact_, Style& style, QWidget* parent);
 
     bool isCompact() const;
     void setCompact(bool compact_);

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -22,7 +22,7 @@ class GenericChatroomWidget : public GenericChatItemWidget
 {
     Q_OBJECT
 public:
-    GenericChatroomWidget(bool compact, Settings& settings, Style& style, QWidget* parent = nullptr);
+    GenericChatroomWidget(bool compact, Settings& settings, Style& style, QWidget* parent);
 
 public slots:
     virtual void setAsActiveChatroom() = 0;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1180,7 +1180,8 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
         new FriendChatroom(newFriend, contentDialogManager.get(), *core, settings, *conferenceList);
     const std::shared_ptr<FriendChatroom> chatroom(rawChatroom);
     const auto compact = settings.getCompactLayout();
-    auto* widget = new FriendWidget(chatroom, compact, settings, style, *messageBoxManager, profile);
+    auto* widget =
+        new FriendWidget(chatroom, compact, settings, style, *messageBoxManager, profile, this);
     connectFriendWidget(*widget);
     auto* history = profile.getHistory();
 
@@ -2133,7 +2134,7 @@ Conference* Widget::createConference(uint32_t conferencenumber, const Conference
     const std::shared_ptr<ConferenceRoom> chatroom(rawChatroom);
 
     const auto compact = settings.getCompactLayout();
-    auto* widget = new ConferenceWidget(chatroom, compact, settings, style);
+    auto* widget = new ConferenceWidget(chatroom, compact, settings, style, this);
     auto messageDispatcher =
         std::make_shared<ConferenceMessageDispatcher>(*newConference,
                                                       MessageProcessor(*sharedMessageProcessorParams),


### PR DESCRIPTION
Qt parent pointers are useful for eventually being able to traverse the object tree. Right now we have a lot of floating objects only reachable through member pointers, not through child lists.