### PR TITLE
cleanup: Move chatroom pointer instead of copying it.

### DIFF
--- a/src/widget/conferencewidget.cpp
+++ b/src/widget/conferencewidget.cpp
@@ -29,8 +29,8 @@
 ConferenceWidget::ConferenceWidget(std::shared_ptr<ConferenceRoom> chatroom_, bool compact_,
                                    Settings& settings_, Style& style_, QWidget* parent)
     : GenericChatroomWidget(compact_, settings_, style_, parent)
-    , conferenceId{chatroom_->getConference()->getPersistentId()}
-    , chatroom{chatroom_}
+    , chatroom{std::move(chatroom_)}
+    , conferenceId{chatroom->getConference()->getPersistentId()}
 {
     avatar->setPixmap(Style::scaleSvgImage(":img/conference.svg", avatar->width(), avatar->height()));
     statusPic.setPixmap(QPixmap(Status::getIconPath(Status::Status::Online)));

--- a/src/widget/conferencewidget.h
+++ b/src/widget/conferencewidget.h
@@ -59,9 +59,9 @@ private slots:
     void updateTitle(const QString& author, const QString& newName);
     void updateUserCount(int numPeers);
 
-public:
-    ConferenceId conferenceId;
-
 private:
     std::shared_ptr<ConferenceRoom> chatroom;
+
+public:
+    ConferenceId conferenceId;
 };


### PR DESCRIPTION
Coverity complains about this. It's really minor, but the fix is cheap.