### PR TITLE
fix: Build failures on Qt 6.9

### DIFF
--- a/src/core/toxstring.cpp
+++ b/src/core/toxstring.cpp
@@ -90,7 +90,9 @@ QString ToxString::getQString() const
         removed.insert({category, c});
         // Add a formatted escape sequence so non-printable characters are still
         // visible in chat logs and can be easily identified.
-        cleaned += QStringLiteral("\\x%1").arg(c, 2, 16, QChar('0')).toStdU32String();
+        cleaned += QStringLiteral("\\x%1")
+                       .arg(static_cast<std::uint_least32_t>(c), 2, 16, QChar('0'))
+                       .toStdU32String();
     }
     if (!removed.isEmpty()) {
         qWarning() << "Removed non-printable characters from a string:" << removed;

--- a/src/model/exiftransform.cpp
+++ b/src/model/exiftransform.cpp
@@ -67,24 +67,40 @@ QImage applyTransformation(QImage image, Orientation orientation)
     case Orientation::TopLeft:
         break;
     case Orientation::TopRight:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        image = image.flipped(Qt::Horizontal);
+#else
         image = image.mirrored(true, false);
+#endif
         break;
     case Orientation::BottomRight:
         exifTransform.rotate(180);
         break;
     case Orientation::BottomLeft:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        image = image.flipped(Qt::Vertical);
+#else
         image = image.mirrored(false, true);
+#endif
         break;
     case Orientation::LeftTop:
         exifTransform.rotate(-90);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        image = image.flipped(Qt::Horizontal);
+#else
         image = image.mirrored(true, false);
+#endif
         break;
     case Orientation::RightTop:
         exifTransform.rotate(90);
         break;
     case Orientation::RightBottom:
         exifTransform.rotate(90);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        image = image.flipped(Qt::Horizontal);
+#else
         image = image.mirrored(true, false);
+#endif
         break;
     case Orientation::LeftBottom:
         exifTransform.rotate(-90);


### PR DESCRIPTION
Fixing some compile errors/warnings that came up when cross-compiling to Windows with Qt 6.9.0.

I have also double-checked the exif image rotating and flipping logic in the function that I have touched, as it seemed a bit weird in how asymmetric the operations in the switch-case are -- it looks correct to me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/589)
<!-- Reviewable:end -->
