### PR TITLE
fix(downloads): Correct 404 download links for macOS 10.12 files

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -397,6 +397,17 @@ cmake --install _build
 `qTox.dmg` should be in your `_build` directory. You can install qTox from the dmg
 to your Applications folder, or run qTox directly from the dmg.
 
+### Troubleshooting on macOS
+
+If you get the error: **"qTox" is damaged and can't be opened. You should move it to the Trash.** This usually happens because macOS **Gatekeeper** security blocks the unsigned application. You can fix this by removing the "quarantine" flag from the app bundle using the terminal.
+
+Run the following command, adjusting the path if you haven't moved it to `/Applications`:
+
+```bash
+xattr -drs com.apple.quarantine /Applications/qtox.app
+
+```
+
 <a name="windows" />
 
 ## Windows

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ AED3 1134 9C23 A123 E5C4  AA4B 139C A045 3DA2 D773
 [Contributing]: /CONTRIBUTING.md#how-to-start-contributing
 [Debian]: https://packages.debian.org/search?keywords=qtox
 [easy issues]: https://github.com/qTox/qTox/labels/E-easy
-[Latest ARM64 release 12+]: https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-arm64.dmg
-[Latest Intel release 12+]: https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-x86_64.dmg
+[Latest ARM64 release 12+]: https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.arm64-12.0.dmg
+[Latest Intel release 12+]: https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.x86_64-12.0.dmg
 [Latest ARM64 nightly 12+]: https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64-12.0.dmg
 [Latest Intel nightly 12+]: https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64-12.0.dmg
 [Latest ARM64 nightly 10.15+]: https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64-10.15.dmg


### PR DESCRIPTION
The previous URLs for macOS 10.12 (both ARM and Intel architectures) were pointing to an incorrect location, resulting in 404 errors.

This commit updates the download URLs to the correct path in the releases section, where the files actually reside.

Fixes #609 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/614)
<!-- Reviewable:end -->
