### PR TITLE
chore(ci): remove macos-13 and add macos-15-intel

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -182,7 +182,7 @@ jobs:
         arch: [arm64, x86_64]
         exclude:
           - arch: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'packaging') && 'arm64' }}
-    runs-on: ${{ matrix.arch == 'arm64' && 'macos-14' || 'macos-13' }}
+    runs-on: ${{ matrix.arch == 'x86_64' && 'macos-15-intel' || 'macos-14' }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout ci-tools


### PR DESCRIPTION
Looks like the is no free macos-14 intel runner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/616)
<!-- Reviewable:end -->
