### PR TITLE
fix(chatform): stop call notification if the friend is going offline.

### DIFF
--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -97,6 +97,7 @@ ChatMessage::SystemMessageType getChatMessageType(const SystemMessage& systemMes
     case SystemMessageType::fileSendFailed:
     case SystemMessageType::messageSendFailed:
     case SystemMessageType::unexpectedCallEnd:
+    case SystemMessageType::userWentOffline:
         return ChatMessage::ERROR;
     case SystemMessageType::userJoinedConference:
     case SystemMessageType::userLeftConference:

--- a/src/model/systemmessage.h
+++ b/src/model/systemmessage.h
@@ -30,6 +30,7 @@ enum class SystemMessageType
     messageSendFailed,
     selfJoinedConference,
     selfLeftConference,
+    userWentOffline,
 };
 
 struct SystemMessage
@@ -70,6 +71,8 @@ struct SystemMessage
             return QObject::tr("You have joined the conference");
         case SystemMessageType::selfLeftConference:
             return QObject::tr("You have left the conference");
+        case SystemMessageType::userWentOffline:
+            return QObject::tr("%1 went offline during the call attempt").arg(args[0]);
         }
         return {};
     }

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -456,6 +456,14 @@ void ChatForm::onFriendStatusChanged(const ToxPk& friendPk, Status::Status statu
     if (!Status::isOnline(f->getStatus())) {
         // Hide the "is typing" message when a friend goes offline
         setFriendTyping(false);
+        // Handle the edge case when we are calling friend, who is going offline.
+        CoreAV* av = core.getAv();
+        if (av->isCallStarted(f)) {
+            av->cancelCall(f->getId());
+            emit stopNotification();
+            addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::userWentOffline,
+                                 {f->getDisplayedName()});
+        }
     }
 
     updateCallButtons();

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -343,6 +343,7 @@ QDateTime GenericChatForm::getLatestTime() const
         case SystemMessageType::messageSendFailed:
         case SystemMessageType::selfJoinedConference:
         case SystemMessageType::selfLeftConference:
+        case SystemMessageType::userWentOffline:
             return false;
         }
 

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -2589,6 +2589,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">فشل ارسال الرسالة</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 انقطع الاتصال أثناء محاولة الاتصال</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">التهيئة</translation>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -2518,6 +2518,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">Не атрымалася адправіць паведамленне</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 выйшаў у аўтаномны рэжым падчас спробы выкліку</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Ініцыялізацыя</translation>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -2897,6 +2897,11 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
         <translation type="unfinished">ⵜⴻⴵⴵⵉⴹ ⴰⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 ⴼⴼⵖⵏ ⴱⵕⵕⴰ ⴳ ⵓⵣⵎⵣ ⵏ ⵓⵔⵣⵣⵓ ⵏ ⵜⵖⵓⵔⵉ</translation>
+    </message>
+    <message>
         <source>Failed to load chat history</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⵥⴻⵎ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ</translation>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -2450,6 +2450,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Съобщението не е изпратено</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 излезе офлайн по време на опита за обаждане</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Подготвяне</translation>
     </message>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -2939,6 +2939,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">বার্তা পাঠাতে ব্যর্থ হয়েছে</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">কল করার সময় %1 অফলাইন হয়ে গেছে</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">শুরু করা হচ্ছে</translation>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -2455,6 +2455,11 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
         <translation type="unfinished">Nepodařilo se odeslat zprávu</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 přešel během pokusu o volání do režimu offline</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicializace</translation>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -2762,6 +2762,11 @@ Dette ID inkluderer NoSpam-koden (i blåt) og kontrolsummen (i gråt).</translat
         <translation type="unfinished">Meddelelse kunne ikke afsendes</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 gik offline under opkaldsforsøget</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Initialiserer</translation>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -2442,6 +2442,11 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
         <translation>Nachricht konnte nicht gesendet werden</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 ist während des Anrufversuchs offline gegangen</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Initialisierung</translation>
     </message>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -2536,6 +2536,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">Αποτυχία αποστολής μηνύματος</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">Το %1 βγήκε εκτός σύνδεσης κατά την προσπάθεια κλήσης</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Αρχικοποίηση</translation>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -2776,6 +2776,11 @@ Kunhavigu ĝin kun viaj amikoj por komenci babili.
         <translation type="unfinished">Mesaĝo fiaskis dum sendado</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 malkonektas dum la vokoprovo</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicializante</translation>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -2440,6 +2440,11 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
         <translation>Falla en el envío del mensaje</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 se desconectó durante el intento de llamada</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Inicializando</translation>
     </message>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -2453,6 +2453,11 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
         <translation type="unfinished">Sõnumi saatmine luhtus</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 läks helistamiskatse ajal võrguühenduseta</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Initsialiseerimine</translation>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -2505,6 +2505,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">ارسال پیام موفق نبود</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">در طول تلاش برای تماس، %1 آفلاین شد</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">مقدار دهی اولیه</translation>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -2450,6 +2450,11 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
         <translation type="unfinished">Viestin lähetys epäonnistui</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 siirtyi offline-tilaan soittoyrityksen aikana</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Alustus</translation>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -2449,6 +2449,11 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
         <translation>L&apos;envoi du message a échoué</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 s&apos;est déconnecté pendant la tentative d&apos;appel</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Initialisation</translation>
     </message>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -2506,6 +2506,11 @@ Este ID inclúe o código NoSpam (en azul) e a suma de verificación (en gris).<
         <translation type="unfinished">Non se puido enviar a mensaxe</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 quedou sen conexión durante o intento de chamada</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicialización</translation>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -2922,6 +2922,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">שליחת ההודעה נכשלה</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 יצא למצב לא מקוון במהלך ניסיון השיחה</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">אתחול</translation>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -2508,6 +2508,11 @@ Ovaj ID uključuje NoSpam kod (plavo) i kontrolni zbroj (sivo).</translation>
         <translation type="unfinished">Poruka nije uspješno poslana</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 je bio izvan mreže tijekom pokušaja poziva</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicijaliziranje</translation>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -2502,6 +2502,11 @@ Ez az azonosító tartalmazza a NoSpam kódot (kék színnel) és az ellenőrző
         <translation type="unfinished">Üzenet küldése sikertelen</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 offline állapotba került a hívási kísérlet során</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicializálás</translation>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -2914,6 +2914,11 @@ Deildu því með vinum þínum til að byrja að spjalla.
         <translation type="unfinished">Ekki tókst að senda skilaboð</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 fór án nettengingar meðan á símtalstilrauninni stóð</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Frumstillir</translation>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -2448,6 +2448,11 @@ Questo ID include una sezione NoSpam (in colore blu) e il controllo checksum (in
         <translation>Impossibile inviare il messaggio</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 è andato offline durante il tentativo di chiamata</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Inizializzando</translation>
     </message>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -2541,6 +2541,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>メッセージの送信に失敗</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 は通話試行中にオフラインになりました</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>初期化中</translation>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -2911,6 +2911,11 @@ le samselcmi cu mapti le blanu zoi gy. NoSpam .gy. joi le checksum zoi gy. gray<
         <translation type="unfinished">do ba&apos;o cliva le nunji&apos;i</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">la&apos;oi %1. jorne pu cliva va va&apos;o lo nu fonjorne troci</translation>
+    </message>
+    <message>
         <source>Failed to load chat history</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">pu fliba lo nu kargau lo casnu citri</translation>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -2929,6 +2929,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">ಸಂದೇಶವನ್ನು ಕಳುಹಿಸಲು ವಿಫಲವಾಗಿದೆ</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ಕರೆ ಪ್ರಯತ್ನದ ಸಮಯದಲ್ಲಿ %1 ಆಫ್‌ಲೈನ್‌ಗೆ ಹೋಗಿದೆ</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಪ್ರಾರಂಭಿಸಲಾಗುತ್ತಿದೆ</translation>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -2778,6 +2778,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">메시지 전송에 실패하였습니다</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">통화 시도 중 %1이(가) 오프라인 상태가 되었습니다</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">초기화 중</translation>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -2877,6 +2877,11 @@ Deze ID umvat de NoSpam-code (in blauw) en de checksum (in gries).</translation>
         <translation type="unfinished">Geer höb de conferentie verlaote</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 ging offline tijdens de oproeppoging</translation>
+    </message>
+    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translatorcomment>Automated translation.</translatorcomment>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -2457,6 +2457,11 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
         <translation type="unfinished">Nepavyko nusiųsti žinutės</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 atsijungė per bandymą skambinti</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicijuoja</translation>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -2499,6 +2499,11 @@ Kopīgojiet to ar draugiem, lai sāktu tērzēšanu.
         <translation type="unfinished">Ziņojumu neizdevās nosūtīt</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 zvanīšanas mēģinājuma laikā pārgāja bezsaistē</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicializēšana</translation>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -2546,6 +2546,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">Неуспешно праќање на пораката</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 отиде офлајн за време на обидот за повик</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Иницијализирање</translation>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -2451,6 +2451,11 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
         <translation type="unfinished">Mislyktes å sende melding</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 gikk frakoblet under oppringingsforsøket</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation type="unfinished">Igangsetter</translation>
     </message>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -2439,6 +2439,11 @@ Deze ID bevat de NoSpam-code (in het blauw) en de checksum (in het grijs).</tran
         <translation>Bericht kon niet verstuurd worden</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 ging offline tijdens de oproeppoging</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Initialiseren</translation>
     </message>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -2417,6 +2417,10 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">Bericht kon niet verstuurd worden</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -2479,6 +2479,11 @@ To ID zawiera kod NoSpam (w kolorze niebieskim) oraz sumę kontrolną (w kolorze
         <translation>Nie udało się wysłać wiadomości</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 przeszedł w tryb offline podczas próby połączenia</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Inicjowanie</translation>
     </message>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -2435,6 +2435,10 @@ This ID has th&apos; NoSpam code (in blue), &apos;n&apos; th&apos; checksum (in 
         <translation type="unfinished">Ye&apos;ve left th&apos; gatherin&apos;</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Failed to load chat history</source>
         <translation type="unfinished">Couldn&apos;t hoist th&apos; ol&apos; messages</translation>
     </message>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -2450,6 +2450,11 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
         <translation>Falha no envio da mensagem</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 ficou offline durante a tentativa de chamada</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>A inicializar</translation>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -2451,6 +2451,11 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
         <translation>Falha no envio da mensagem</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 ficou offline durante a tentativa de chamada</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Inicializando</translation>
     </message>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -2445,6 +2445,11 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
         <translation type="unfinished">Mesajul nu a putut fi trimis</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 a fost offline în timpul încercării de apel</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Inițializare</translation>
     </message>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -2447,6 +2447,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Не удалось отправить сообщение</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 вышел из сети во время попытки звонка</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Подготовка к работе</translation>
     </message>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -2942,6 +2942,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">පණිවිඩය යැවීමට අසමත් විය</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">ඇමතුම් උත්සාහයේදී %1 නොබැඳි විය</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ආරම්භ කිරීම</translation>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -2455,6 +2455,11 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
         <translation>Správu sa nepodarilo odoslať</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 prešlo počas pokusu o volanie do režimu offline</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Inicializácia</translation>
     </message>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -2629,6 +2629,11 @@ Ta ID vključuje kodo NoSpam (v modri barvi) in kontrolno vsoto (v sivi barvi).<
         <translation type="unfinished">Sporočilo ni bilo poslano</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 je bil med poskusom klica brez povezave</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Inicializacija</translation>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -2937,6 +2937,11 @@ Ky ID përfshin kodin NoSpam (në blu) dhe kontrollin (në gri).</translation>
         <translation type="unfinished">Dërgimi i mesazhit dështoi</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 doli jashtë linje gjatë përpjekjes së telefonatës</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Duke inicializuar</translation>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -2510,6 +2510,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">Није успело слање поруке</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 је био ван мреже током покушаја позива</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Иницијализација</translation>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -2422,6 +2422,10 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">Neuspelo slanje poruke</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -2454,6 +2454,11 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
         <translation type="unfinished">Misslyckades att skicka meddelande</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 gick offline under samtalsförsöket</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Initierar</translation>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -2944,6 +2944,11 @@ Kitambulisho hiki kinajumuisha msimbo wa NoSpam (wa bluu), na hundi (ya kijivu).
         <translation type="unfinished">Ujumbe umeshindwa kutumwa</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 aliondoka mtandaoni wakati wa jaribio la kupiga simu</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Kuanzisha</translation>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -2711,6 +2711,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>செய்தி அனுப்பத் தவறிவிட்டது</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">அழைப்பு முயற்சியின் போது %1 ஆஃப்லைனில் சென்றார்</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation>துவக்குதல்</translation>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -2449,6 +2449,11 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
         <translation>İleti gönderilemedi</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 arama girişimi sırasında çevrimdışı oldu</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Başlatılıyor</translation>
     </message>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -2543,6 +2543,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">ئۇچۇر يوللانمىدى</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 چاقىرىش جەريانىدا تورسىز قالدى</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Initializing</translation>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -2452,6 +2452,11 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
         <translation>Не вдалося надіслати повідомлення</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 вийшов із мережі під час спроби виклику</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Підготовка до роботи</translation>
     </message>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -2918,6 +2918,10 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">پیغام بھیجنے میں ناکام</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translation type="unfinished">کال کی کوشش کے دوران %1 آف لائن گیا&apos;</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">شروع کر رہا ہے۔</translation>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -2446,6 +2446,11 @@ ID này bao gồm mã NoSpam (màu xanh lam) và checksum (màu xám).</translat
         <translation>Không thể gửi tin nhắn</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 ngoại tuyến trong khi thử cuộc gọi</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>Khởi tạo</translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2435,6 +2435,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>消息发送失败</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 在呼叫尝试期间离线</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translation>初始化中</translation>
     </message>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2824,6 +2824,11 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished">訊息傳送失敗</translation>
     </message>
     <message>
+        <source>%1 went offline during the call attempt</source>
+        <translatorcomment>Automated translation.</translatorcomment>
+        <translation type="unfinished">%1 在呼叫嘗試期間離線</translation>
+    </message>
+    <message>
         <source>Initializing</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">正在初始化</translation>


### PR DESCRIPTION
Fix the bug when friend is going offline during the call.
Steps to reproduce:
- Call the friend
- Shutdown the network `sudo ifconfig $INTERFACE down`

qTox will keep calling friend, who is off-line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/618)
<!-- Reviewable:end -->
