### PR TITLE
fix(core): Improve filename sanitization and error handling.

### DIFF
--- a/audio/src/backend/openal.cpp
+++ b/audio/src/backend/openal.cpp
@@ -473,7 +473,10 @@ void OpenAL::playMono16Sound(AlSink& sink, const IAudioSink::Sound& sound)
         return;
     }
 
-    sndFile.open(QIODevice::ReadOnly);
+    if (!sndFile.open(QIODevice::ReadOnly)) {
+        qCDebug(logcat::audio) << "Failed to open sound file";
+        return;
+    }
     const QByteArray data{sndFile.readAll()};
     if (data.isEmpty()) {
         qCDebug(logcat::audio) << "Sound file contained no data";

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -206,8 +206,6 @@ cc_library(
     hdrs = ["platform/stacktrace.h"],
     copts = COPTS + [
         "-DQTOX_USE_LIBUNWIND",
-        "-Iexternal/libunwind/include",
-        "-I$(GENDIR)/external/libunwind/include",
     ],
     tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -290,7 +290,7 @@ bool Core::checkConnection()
 {
     ASSERT_CORE_THREAD;
     auto selfConnection = tox_self_get_connection_status(tox.get());
-    const char* connectionName;
+    const char* connectionName = "unknown";
     bool toxConnected = false;
     switch (selfConnection) {
     case TOX_CONNECTION_NONE:

--- a/src/core/corefile.h
+++ b/src/core/corefile.h
@@ -81,6 +81,7 @@ private:
     static void onFileRecvChunkCallback(Tox* tox, uint32_t friendId, uint32_t fileId, uint64_t position,
                                         const uint8_t* data, size_t length, void* vCore);
 
+public:
     static QString getCleanFileName(QString filename);
 
 private slots:

--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -284,8 +284,7 @@ IProfileInfo::SetAvatarResult ProfileInfo::setAvatar(const QString& path)
     }
 
     QFile file(path);
-    file.open(QIODevice::ReadOnly);
-    if (!file.isOpen()) {
+    if (!file.open(QIODevice::ReadOnly)) {
         return SetAvatarResult::CanNotOpen;
     }
     QByteArray avatar;

--- a/src/net/bootstrapnodeupdater.cpp
+++ b/src/net/bootstrapnodeupdater.cpp
@@ -194,7 +194,10 @@ void createExampleBootstrapNodesFile(const Paths& paths)
     auto serializedNodes = serialize(buildInNodes);
 
     QFile outFile(paths.getExampleNodesFilePath());
-    outFile.open(QIODevice::WriteOnly | QIODevice::Text);
+    if (!outFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "createExampleBootstrapNodesFile: Can't open file";
+        return;
+    }
     outFile.write(serializedNodes.data(), serializedNodes.size());
     outFile.close();
 }

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -79,18 +79,18 @@ QString secondsToDHMS(quint32 duration)
 
     // I assume no one will ever have call longer than a month
     if (days != 0u) {
-        return cD + QString::asprintf("%dd%02dh %02dm %02ds", days, hours, minutes, seconds);
+        return cD + QString::asprintf("%ud%02uh %02um %02us", days, hours, minutes, seconds);
     }
 
     if (hours != 0u) {
-        return cD + QString::asprintf("%02dh %02dm %02ds", hours, minutes, seconds);
+        return cD + QString::asprintf("%02uh %02um %02us", hours, minutes, seconds);
     }
 
     if (minutes != 0u) {
-        return cD + QString::asprintf("%02dm %02ds", minutes, seconds);
+        return cD + QString::asprintf("%02um %02us", minutes, seconds);
     }
 
-    return cD + QString::asprintf("%02ds", seconds);
+    return cD + QString::asprintf("%02us", seconds);
 }
 } // namespace
 


### PR DESCRIPTION
- Sanitize incoming filenames on all platforms to prevent path traversal and invalid characters.
- Add error checking for `QFile::open()` in audio backend, profile info, and bootstrap node updater.
- Fix printf format specifiers for unsigned integers in logging.
- Remove redundant/broken libunwind includes in BUILD.bazel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/626)
<!-- Reviewable:end -->
