### PR TITLE
refactor(UpdateCheck): Extract version logic and add tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,8 @@ set(${BINARY_NAME}_SOURCES
     src/net/toxuri.h
     src/net/updatecheck.cpp
     src/net/updatecheck.h
+    src/net/updateversion.cpp
+    src/net/updateversion.h
     src/persistence/db/rawdatabase.cpp
     src/persistence/db/rawdatabase.h
     src/persistence/db/rawdatabaseimpl.cpp

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -53,6 +53,7 @@ auto_test(model messageprocessor "" "")
 auto_test(model notificationgenerator "" "mock_library")
 auto_test(model sessionchatlog "" "")
 auto_test(net bsu "${${BINARY_NAME}_RESOURCES}" "") # needs nodes list
+auto_test(net updateversion "" "")
 auto_test(persistence dbschema "" "dbutility_library")
 auto_test(persistence/dbupgrade dbTo11 "" "dbutility_library")
 auto_test(persistence offlinemsgengine "" "")

--- a/src/net/updateversion.cpp
+++ b/src/net/updateversion.cpp
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2026 The TokTok team.
+ */
+
+#include "src/net/updateversion.h"
+
+#include <QRegularExpression>
+
+namespace {
+const QRegularExpression versionRegex{QStringLiteral(R"(^v([0-9]+)\.([0-9]+)\.([0-9]+)$)")};
+} // namespace
+
+QDebug& operator<<(QDebug& stream, const Version& version)
+{
+    stream.noquote()
+        << QStringLiteral("v%1.%2.%3").arg(version.major).arg(version.minor).arg(version.patch);
+    return stream.quote();
+}
+
+std::optional<Version> tagToVersion(const QString& tagName)
+{
+    const auto& matches = versionRegex.match(tagName);
+    if (matches.lastCapturedIndex() != 3) {
+        return std::nullopt;
+    }
+
+    bool ok;
+    const auto major = matches.captured(1).toInt(&ok);
+    if (!ok) {
+        return std::nullopt;
+    }
+
+    const auto minor = matches.captured(2).toInt(&ok);
+    if (!ok) {
+        return std::nullopt;
+    }
+
+    const auto patch = matches.captured(3).toInt(&ok);
+    if (!ok) {
+        return std::nullopt;
+    }
+
+    return Version{major, minor, patch};
+}
+
+bool isUpdateAvailable(const Version& current, const Version& available)
+{
+    if (current.major < available.major) {
+        return true;
+    }
+    if (current.major > available.major) {
+        return false;
+    }
+
+    if (current.minor < available.minor) {
+        return true;
+    }
+    if (current.minor > available.minor) {
+        return false;
+    }
+
+    if (current.patch < available.patch) {
+        return true;
+    }
+    if (current.patch > available.patch) {
+        return false;
+    }
+
+    return false;
+}
+
+bool isVersionStable(const QString& gitDescribeExact)
+{
+    return versionRegex.match(gitDescribeExact).hasMatch();
+}

--- a/src/net/updateversion.h
+++ b/src/net/updateversion.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2026 The TokTok team.
+ */
+
+#pragma once
+
+#include <QDebug>
+#include <QString>
+
+#include <optional>
+
+struct Version
+{
+    int major;
+    int minor;
+    int patch;
+
+    bool operator==(const Version& other) const
+    {
+        return major == other.major && minor == other.minor && patch == other.patch;
+    }
+};
+
+QDebug& operator<<(QDebug& stream, const Version& version);
+
+std::optional<Version> tagToVersion(const QString& tagName);
+
+bool isUpdateAvailable(const Version& current, const Version& available);
+
+bool isVersionStable(const QString& gitDescribeExact);

--- a/test/net/updateversion_test.cpp
+++ b/test/net/updateversion_test.cpp
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2026 The TokTok team.
+ */
+
+#include "src/net/updateversion.h"
+
+#include <QtTest/QtTest>
+
+class TestUpdateVersion : public QObject
+{
+    Q_OBJECT
+private slots:
+    void testTagToVersion();
+    void testIsUpdateAvailable();
+    void testIsVersionStable();
+};
+
+void TestUpdateVersion::testTagToVersion()
+{
+    QCOMPARE(tagToVersion("v1.2.3"), (std::optional<Version>{{1, 2, 3}}));
+    QCOMPARE(tagToVersion("v0.0.0"), (std::optional<Version>{{0, 0, 0}}));
+    QCOMPARE(tagToVersion("v10.20.30"), (std::optional<Version>{{10, 20, 30}}));
+
+    QCOMPARE(tagToVersion("1.2.3"), std::nullopt);
+    QCOMPARE(tagToVersion("v1.2"), std::nullopt);
+    QCOMPARE(tagToVersion("v1.2.3-rc1"), std::nullopt);
+    QCOMPARE(tagToVersion("v1.2.3.4"), std::nullopt);
+    QCOMPARE(tagToVersion("va.b.c"), std::nullopt);
+}
+
+void TestUpdateVersion::testIsUpdateAvailable()
+{
+    Version v123{1, 2, 3};
+    Version v124{1, 2, 4};
+    Version v130{1, 3, 0};
+    Version v200{2, 0, 0};
+
+    QVERIFY(isUpdateAvailable(v123, v124));
+    QVERIFY(isUpdateAvailable(v123, v130));
+    QVERIFY(isUpdateAvailable(v123, v200));
+
+    QVERIFY(!isUpdateAvailable(v124, v123));
+    QVERIFY(!isUpdateAvailable(v130, v123));
+    QVERIFY(!isUpdateAvailable(v200, v123));
+
+    QVERIFY(!isUpdateAvailable(v123, v123));
+}
+
+void TestUpdateVersion::testIsVersionStable()
+{
+    QVERIFY(isVersionStable("v1.2.3"));
+    QVERIFY(isVersionStable("v0.0.0"));
+    QVERIFY(isVersionStable("v10.20.30"));
+
+    QVERIFY(!isVersionStable("1.2.3"));
+    QVERIFY(!isVersionStable("v1.2"));
+    QVERIFY(!isVersionStable("v1.2.3-rc1"));
+    QVERIFY(!isVersionStable("v1.2.3-4-g1234567"));
+}
+
+QTEST_MAIN(TestUpdateVersion)
+#include "updateversion_test.moc"


### PR DESCRIPTION
Move version parsing and comparison logic from UpdateCheck into a new UpdateVersion utility.

Additionally, UpdateCheck now handles version parsing failures gracefully using std::optional instead of assertions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/637)
<!-- Reviewable:end -->
