### PR TITLE
docs: Improve Tamazight translation.

### DIFF
--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -5,17 +5,15 @@
     <name>AVForm</name>
     <message>
         <source>Audio/Video</source>
-        <translation>ⴰⵎⵙⵍⴰⵢ/ⴰⴼⵉⴷⵢⵓ</translation>
+        <translation>ⵉⵎⵙⵍⵉ/ⴰⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Default resolution</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⵔⴰⵢ ⴰⵎⴻⵙⵍⵓⴳⴻⵏ</translation>
+        <translation type="unfinished">ⵜⴰⵙⵡⵍⴰ ⵜⴰⴳⵉⵍⴰⵍⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵄⵉⴱⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵔⵓⵔⵎⵉⴷ</translation>
     </message>
     <message>
         <source>Select region</source>
@@ -23,27 +21,23 @@
     </message>
     <message>
         <source>Screen %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⴽⵉⵍ %1.</translation>
+        <translation type="unfinished">ⴰⴳⴷⵉⵍ %1</translation>
     </message>
     <message>
         <source>Audio Settings</source>
-        <translation>ⵜⵉⵙⵖⴰⵍ ⵏ ⵓⵎⵙⵍⴰⵢ</translation>
+        <translation>ⵉⵙⵖⵡⴰⵕⵏ ⵏ ⵓⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>Gain</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵔⴱⴻⵃ</translation>
+        <translation type="unfinished">ⵜⴰⵎⵔⵏⵉⵡⵜ</translation>
     </message>
     <message>
         <source>Playback device</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵍⵍⴰⵍ ⵏ ⵓⵥⴰⵡⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵍⵍⴰⵍ ⵏ ⵜⵖⵓⵔⵉ</translation>
     </message>
     <message>
         <source>Capture device</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵍⵍⴰⵍ ⵏ ⵜⵓⵟⵟⴼⴰ</translation>
+        <translation type="unfinished">ⴰⵍⵍⴰⵍ ⵏ ⵓⵟⵟⴰⴼ</translation>
     </message>
     <message>
         <source>Volume</source>
@@ -51,12 +45,11 @@
     </message>
     <message>
         <source>Video Settings</source>
-        <translation>ⵜⵉⵙⵖⴰⵍ ⵉ ⵓⴽⵙⴰⵢ</translation>
+        <translation>ⵉⵙⵖⵡⴰⵕⵏ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Video device</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵍⵍⴰⵍ ⵏ Vidyu</translation>
+        <translation type="unfinished">ⴰⵍⵍⴰⵍ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Set resolution of your camera.
@@ -64,22 +57,19 @@ The higher values, the better video quality your friends may get.
 Note though that with better video quality there is needed better internet connection.
 Sometimes your connection may not be good enough to handle higher video quality,
 which may lead to problems with video calls.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⴳⵣⵉⴷ ⵍⵇⴻⴷⴷ ⵏ ⵜⴽⴰⵎⵔⴰⵉⵏⴻⴽ.
-ⴰⴽⴽⴻⵏ ⵜⵜⵏⴻⵔⵏⵉⵏ ⵡⴰⵣⴰⵍⴻⵏ, ⵜⵜⵏⴻⵔⵏⵉⵏⵜ ⵜⵖⴰⵡⵙⵉⵡⵉⵏ ⵏ tvidyut ⵉ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵜⵜⵉⴷⴰⴼⴻⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍⵉⴽ.
-ⴰⴽⴽⴻⵏ ⴰⴷ ⵏⵡⴰⵍⵉ ⴱⴻⵍⵍⵉ ⵙ ⵜⵖⴰⵔⴰ ⵏ tvidyut ⵢⴻⵍⵀⴰⵏ ⵉⵍⴰⵇⴰⵙ ⵜⵓⵇⵇⵏⴰ ⵏ ⵉⵏⵜⴻⵔⵏⴻⵜ ⵢⴻⵍⵀⴰⵏ.
-ⵜⵉⴽⵡⴰⵍ, ⵜⵓⵇⵇⵏⴰⵉⵏⴻⴽ ⵜⴻⵣⵎⴻⵔ ⵓⵔ ⵜⴻⵍⵀⵉ ⴰⵔⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⵍⵃⵓ ⵜⴰⵖⴰⵔⴰ ⵏ tvidyut ⵢⵓⴳⴰⵔⴻⵏ ⵜⴰⵢⴻⴹ,
-ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⴷⵢⴰⵡⵉ ⵓⴳⵓⵔⴻⵏ ⴷⴻⴳ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵏ tvidyut.</translation>
+        <translation type="unfinished">ⵙⴱⴷⴷ ⵜⴰⵙⵡⵍⴰ ⵏ ⵜⴽⴰⵎⵔⴰⵉⵏⴻⴽ.
+ⴰⴽⴽⴻⵏ ⵜⵜⵏⴻⵔⵏⵉⵏ ⵡⴰⵣⴰⵍⴻⵏ, ⵜⵜⵏⴻⵔⵏⵉⵏⵜ ⵜⵖⴰⵡⵙⵉⵡⵉⵏ ⵏ ⴰⴼⵉⴷⵢⵓ ⵉ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵜⵜⵉⴷⴰⴼⴻⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍⵉⴽ.
+ⴰⴽⴽⴻⵏ ⴰⴷ ⵏⵡⴰⵍⵉ ⴱⴻⵍⵍⵉ ⵙ ⵜⵖⴰⵔⴰ ⵏ ⴰⴼⵉⴷⵢⵓ ⵢⴻⵍⵀⴰⵏ ⵉⵍⴰⵇⴰⵙ ⵜⵓⵇⵇⵏⴰ ⵏ ⵉⵏⵜⴻⵔⵏⴻⵜ ⵢⴻⵍⵀⴰⵏ.
+ⵜⵉⴽⵡⴰⵍ, ⵜⵓⵇⵇⵏⴰⵉⵏⴻⴽ ⵜⴻⵣⵎⴻⵔ ⵓⵔ ⵜⴻⵍⵀⵉ ⴰⵔⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⵍⵃⵓ ⵜⴰⵖⴰⵔⴰ ⵏ ⴰⴼⵉⴷⵢⵓ ⵢⵓⴳⴰⵔⴻⵏ ⵜⴰⵢⴻⴹ,
+ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⴷⵢⴰⵡⵉ ⵓⴳⵓⵔⴻⵏ ⴷⴻⴳ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵏ ⴰⴼⵉⴷⵢⵓ.</translation>
     </message>
     <message>
         <source>Resolution</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵡⴻⵏⵏⵣⵄ</translation>
+        <translation type="unfinished">ⵜⴰⵙⵡⵍⴰ</translation>
     </message>
     <message>
         <source>Rescan devices</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵄⵉⵡⴻⴷ ⵏ ⵓⵙⴽⴰⵏ ⵏ ⵡⴰⵍⵍⴰⵍⴻⵏ</translation>
+        <translation type="unfinished">ⴰⵍⴻⵙ ⴰⵙⵏⵓⴱⴱⴻⵛ ⵏ ⵡⴰⵍⵍⴰⵍⴻⵏ</translation>
     </message>
     <message>
         <source>Test Sound</source>
@@ -87,7 +77,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Audio quality</source>
-        <translation>ⵜⴰⵖⴰⵔⴰ ⵏ ⵓⵎⵙⵍⴰⵢ</translation>
+        <translation>ⵜⴰⵖⴰⵔⴰ ⵏ ⵓⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>High (64 kBps)</source>
@@ -95,32 +85,27 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Medium (32 kBps)</source>
-        <translation>ⵜⴰⵏⴰⵎⵎⴰⵙⵜ (32ⴽⴱⵉⵙⵏ)</translation>
+        <translation>ⵜⴰⵏⴰⵎⵎⴰⵙⵜ (32 ⴽⴱⵉⵙⵏ)</translation>
     </message>
     <message>
         <source>Low (16 kBps)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴷⴷⴰⵡ (16 kBps)</translation>
+        <translation>ⵜⴰⴷⵔⴰⵏⵜ (16 ⴽⴱⵉⵙⵏ)</translation>
     </message>
     <message>
         <source>Very low (8 kBps)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴷⵔⵓⵙ ⴰⵟⴰⵙ (8 kBps)</translation>
+        <translation>ⵜⴰⴷⵔⴰⵏⵜ ⵎⵍⵉⵃ (8 ⴽⴱⵉⵙⵏ)</translation>
     </message>
     <message>
         <source>Threshold</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵣⵡⴰⵔⴰ</translation>
+        <translation type="unfinished">ⴰⵎⵏⴰⵔ</translation>
     </message>
     <message>
         <source>Use slider to set the volume of your speakers.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵙⵍⵉⴷⴻⵔ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴱⴻⴷⴷⴻⴹ ⵍⵃⴻⵙⵙ ⵏ ⵢⵉⵎⴻⵙⵍⴰⵢⴻⵏⵉⴽ.</translation>
+        <translation type="unfinished">ⵙⵙⵎⵔⵙ ⴰⵙⵍⴽⵉⵎ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵙⴳⴳⵎⴷ ⴰⴱⵍⵖ ⵏ ⵢⵉⵎⵙⵙⴰⵡⵍⵏ.</translation>
     </message>
     <message>
         <source>Transmitted audio quality. Lower this setting if your bandwidth is not high enough or if you want to reduce bandwidth usage.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵖⴰⵔⴰ ⵏ ⵚⵚⵓⵜ ⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⵏ. ⵙⵙⴻⵅⵙⵉ ⴰⵙⴻⴱⵜⴻⵔⴰ ⵎⴰ ⵢⴻⵍⵍⴰ ⵓⵔ ⵜⴻⵍⵍⵉ ⴰⵔⴰ ⵜⵎⴻⵥⴷⵉⵜⵉⴽ ⴷ ⵜⴰⵎⴻⵇⵇⵔⴰⵏⵜ ⵏⴻⵖ ⵎⴰ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⵙⵏⴻⵇⵙⴻⴹ ⴰⵙⴻⵇⴷⴻⵛ ⵏ ⵜⵎⴻⵥⴷⵉⵜ.</translation>
+        <translation type="unfinished">ⵜⴰⵖⴰⵔⴰ ⵏ ⵓⵎⵙⵍⵉ ⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⵏ. ⵙⵙⴻⵅⵙⵉ ⴰⵙⴻⴱⵜⴻⵔⴰ ⵎⴰ ⵢⴻⵍⵍⴰ ⵓⵔ ⵜⴻⵍⵍⵉ ⴰⵔⴰ ⵜⵎⴻⵥⴷⵉⵜⵉⴽ ⴷ ⵜⴰⵎⴻⵇⵇⵔⴰⵏⵜ ⵏⴻⵖ ⵎⴰ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⵙⵏⴻⵇⵙⴻⴹ ⴰⵙⴻⵇⴷⴻⵛ ⵏ ⵜⵎⴻⵥⴷⵉⵜ.</translation>
     </message>
     <message>
         <source>Set resolution of your camera.
@@ -128,27 +113,23 @@ The higher values, the better video quality your friends may get.
 Note that with better video quality, you use more bandwidth.
 Sometimes your connection may not be good enough to handle higher video quality,
 which may lead to problems with video calls.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⴳⵣⵉⴷ ⵍⵇⴻⴷⴷ ⵏ ⵜⴽⴰⵎⵔⴰⵉⵏⴻⴽ.
-ⴰⴽⴽⴻⵏ ⵜⵜⵏⴻⵔⵏⵉⵏ ⵡⴰⵣⴰⵍⴻⵏ, ⵜⵜⵏⴻⵔⵏⵉⵏⵜ ⵜⵖⴰⵡⵙⵉⵡⵉⵏ ⵏ tvidyut ⵉ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵜⵜⵉⴷⴰⴼⴻⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍⵉⴽ.
-ⴰⴷ ⵜⵡⴰⵍⵉⴹ ⴱⴻⵍⵍⵉ ⵙ ⵜⵖⴰⵔⴰ ⵏ tvidyut ⵢⴻⵍⵀⴰⵏ, ⵜⴻⵙⵇⴻⴷⵛⴻⴹ ⵓⴳⴰⵔ ⵏ ⵜⵎⴻⵥⴷⵉⵢⵉⵏ.
-ⵜⵉⴽⵡⴰⵍ, ⵜⵓⵇⵇⵏⴰⵉⵏⴻⴽ ⵜⴻⵣⵎⴻⵔ ⵓⵔ ⵜⴻⵍⵀⵉ ⴰⵔⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⵍⵃⵓ ⵜⴰⵖⴰⵔⴰ ⵏ tvidyut ⵢⵓⴳⴰⵔⴻⵏ ⵜⴰⵢⴻⴹ,
-ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⴷⵢⴰⵡⵉ ⵓⴳⵓⵔⴻⵏ ⴷⴻⴳ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵏ tvidyut.</translation>
+        <translation type="unfinished">ⵙⴱⴷⴷ ⵜⴰⵙⵡⵍⴰ ⵏ ⵜⴽⴰⵎⵔⴰⵉⵏⴻⴽ.
+ⴰⴽⴽⴻⵏ ⵜⵜⵏⴻⵔⵏⵉⵏ ⵡⴰⵣⴰⵍⴻⵏ, ⵜⵜⵏⴻⵔⵏⵉⵏⵜ ⵜⵖⴰⵡⵙⵉⵡⵉⵏ ⵏ ⴰⴼⵉⴷⵢⵓ ⵉ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵜⵜⵉⴷⴰⴼⴻⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍⵉⴽ.
+ⴰⴷ ⵜⵡⴰⵍⵉⴹ ⴱⴻⵍⵍⵉ ⵙ ⵜⵖⴰⵔⴰ ⵏ ⴰⴼⵉⴷⵢⵓ ⵢⴻⵍⵀⴰⵏ, ⵜⴻⵙⵇⴻⴷⵛⴻⴹ ⵓⴳⴰⵔ ⵏ ⵜⵎⴻⵥⴷⵉⵢⵉⵏ.
+ⵜⵉⴽⵡⴰⵍ, ⵜⵓⵇⵇⵏⴰⵉⵏⴻⴽ ⵜⴻⵣⵎⴻⵔ ⵓⵔ ⵜⴻⵍⵀⵉ ⴰⵔⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⵍⵃⵓ ⵜⴰⵖⴰⵔⴰ ⵏ ⴰⴼⵉⴷⵢⵓ ⵢⵓⴳⴰⵔⴻⵏ ⵜⴰⵢⴻⴹ,
+ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⴷⵢⴰⵡⵉ ⵓⴳⵓⵔⴻⵏ ⴷⴻⴳ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵏ ⴰⴼⵉⴷⵢⵓ.</translation>
     </message>
     <message>
         <source>Play a test sound while changing the output volume.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔⴰⵔⴷ ⵚⵚⵓⵜ ⵏ ⵜⴻⵙⵍⴻⴹⵜ ⴷⴻⴳ ⵡⴰⴽⵓⴷ ⴰⵢⴷⴻⴳ ⵜⴱⴻⴷⴷⴻⵍⴻⴹ ⴰⵥⴰⵡⴰⵏ ⵏ ⵓⵙⵍⵓⴳⴻⵏ.</translation>
+        <translation type="unfinished">ⵓⵔⴰⵔⴷ ⵉⵎⵙⵍⵉ ⵏ ⵜⴻⵙⵍⴻⴹⵜ ⴷⴻⴳ ⵡⴰⴽⵓⴷ ⴰⵢⴷⴻⴳ ⵜⵙⵏⴼⵍⴷ ⴰⵥⴰⵡⴰⵏ ⵏ ⵓⵙⵍⵓⴳⴻⵏ.</translation>
     </message>
     <message>
         <source>Use slider to set the gain of your input device ranging from %1dB to %2dB.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⴰⵙⴻⵍⴽⵉⵎ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴱⴻⴷⴷⴻⴹ ⵍⴼⴰⵢⴷⴰ ⵏ ⵓⵙⵎⴻⵍⵉⴽ ⵏ ⵓⵙⵎⴻⵍ ⵙⴻⴳ %1dB ⴰⵔ %2dB.</translation>
+        <translation type="unfinished">ⵙⵙⵎⵔⵙ ⴰⵙⵍⴽⵉⵎ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵙⴳⴳⵎⴷ ⵜⴰⵎⵔⵏⵉⵡⵜ ⵏ ⵡⴰⵍⵍⴰⵍ ⵏ ⵓⵏⴽⵛⵓⵎ ⵙⴳ %1dB ⴰⵔ %2dB.</translation>
     </message>
     <message>
         <source>Use slider to set the activation volume for your input device.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵙⵍⵉⴷⴻⵔ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴱⴻⴷⴷⴻⴹ ⴰⵣⴰⵍ ⵏ ⵓⵙⵙⴻⵇⴷⴻⵛ ⵉ ⵜⵎⴻⵥⴷⵉⵜⵉⴽ ⵏ ⵓⵙⵎⴻⵍ.</translation>
+        <translation type="unfinished">ⵙⵙⵎⵔⵙ ⴰⵙⵍⴽⵉⵎ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵙⴳⴳⵎⴷ ⴰⴱⵍⵖ ⵏ ⵓⵔⵎⴰⴷ ⵉ ⵡⴰⵍⵍⴰⵍ ⵏ ⵓⵏⴽⵛⵓⵎ.</translation>
     </message>
 </context>
 <context>
@@ -159,39 +140,33 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Original author: %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵎⴻⵙⴽⴰⵔ ⴰⵙⴰⵍⵉ: %1.</translation>
+        <translation type="unfinished">ⴰⵎⵙⴽⴰⵔ ⴰⵥⴰⵕⴰⵏ: %1.</translation>
     </message>
     <message>
         <source>You are using qTox version %1.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴻⵙⵙⴻⵇⴷⴰⵛⴻⴹ qTox ⵜⴰⵍⵖⴰ %1.</translation>
+        <translation type="unfinished">ⵜⵙⵙⵎⵔⴰⵙⴷ ⵜⴰⵙⴽⴰⵏⵜ %1 ⵏ qTox.</translation>
     </message>
     <message>
         <source>Commit hash: %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴻⴳⴳ ⵀⴰⵙⵀ: %1.</translation>
+        <translation type="unfinished">ⴰⵣⵡⵉⵍ ⵏ ⵓcommit: %1</translation>
     </message>
     <message>
         <source>toxcore version: %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵍⵖⴰ ⵏ tukskur: %1.</translation>
+        <translation type="unfinished">ⵜⴰⵙⴽⴰⵏⵜ ⵏ toxcore: %1</translation>
     </message>
     <message>
         <source>Qt version: %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵍⵖⴰ Qt: %1.</translation>
+        <translation type="unfinished">ⵜⴰⵙⴽⴰⵏⵜ ⵏ Qt: %1</translation>
     </message>
     <message>
         <source>A list of all known issues may be found at our %1 at Github. If you discover a bug or security vulnerability within qTox, please report it according to the guidelines in our %2 wiki article.</source>
         <comment>`%1` is replaced by translation of `bug tracker`
 `%2` is replaced by translation of `Writing Useful Bug Reports`</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⴹⵔⵉⵙ ⵏ ⵡⴰⴽⴽ ⵜⵉⵎⵙⴰⵍ ⵢⴻⵜⵜⵡⴰⵙⵙⵏⴻⵏ ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵜⵜⵡⴰⴼ ⴷⴻⴳ %1nneɣ ⴷⴻⴳ ⴳⵉⵜⵀⵓⴱ. ⵎⴰ ⵜⵓⴼⵉⴹⴷ ⴰⵖⴱⴻⵍ ⵏⴻⵖ ⴰⵖⴱⴻⵍ ⵏ ⵜⵖⴻⵍⵍⵉⵙⵜ ⴷⴰⵅⴻⵍ ⵏ qTox, ⵜⵜⵅⵉⵍⴽ ⵙⵙⵉⵡⴹⵉⵜⵉⴷ ⵙ ⵍⵎⴻⵏⴷⴰⴷ ⵏ ⵜⵎⵓⵖⵍⵉⵡⵉⵏ ⵢⴻⵍⵍⴰⵏ ⴷⴻⴳ ⵓⵎⴰⴳⵔⴰⴷⵏⵏⴻⵖ ⵏ ⵡⵉⴽⵉ %2.</translation>
+        <translation type="unfinished">ⵓⴹⵔⵉⵙ ⵏ ⵡⴰⴽⴽ ⵜⵉⵎⵙⴰⵍ ⵢⴻⵜⵜⵡⴰⵙⵙⵏⴻⵏ ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵜⵜⵡⴰⴼ ⴷⴻⴳ %1nneɣ ⴷⴻⴳ ⴳⵉⵜⵀⵓⴱ. ⵎⴰ ⵜⵓⴼⵉⴹⴷ ⴰⵖⴱⴻⵍ ⵏⴻⵖ ⴰⵖⴱⴻⵍ ⵏ ⵜⵖⴻⵍⵍⵉⵙⵜ ⴷⴰⵅⴻⵍ ⵏ qTox, ⵜⵜⵅⵉⵍⴽ ⵙⵙⵉⵡⴹⵉⵜⵉⴷ ⵙ ⵍⵎⴻⵏⴷⴰⴷ ⵏ ⵜⵎⵓⵖⵍⵉⵡⵉⵏ ⵢⴻⵍⵍⴰⵏ ⴷⴻⴳ ⵓⴳⵉⵍⴰⵍⵔⴰⴷⵏⵏⴻⵖ ⵏ ⵡⵉⴽⵉ %2.</translation>
     </message>
     <message>
         <source>Click here to report a bug.</source>
-        <translation>ⴽⵍⵉⴽⵉ ⴷⴰ ⴰⴼⴰⴷ ⴰⴷ ⵜⵎⵍⵍⴷ ⵢⴰⵏ ⵓⵔⵎⵉⴷⵉ.</translation>
+        <translation>ⴽⵏⴻⴷ ⴷⴰ ⴰⴼⴰⴷ ⴰⴷ ⵜⵎⵍⵍⴷ ⵢⴰⵏ ⵓⵔⵎⵉⴷⵉ.</translation>
     </message>
     <message>
         <source>See a full list of %1 at Github</source>
@@ -201,68 +176,60 @@ which may lead to problems with video calls.</source>
     <message>
         <source>bug-tracker</source>
         <comment>Replaces `%1` in the `A list of all known…`</comment>
-        <translation type="unfinished">ⴰⵏⴹⴼⴰⵕ ⵏ ⵓⵔⵎⵉⴷⵉ</translation>
+        <translation type="unfinished">ⴰⵏⴹⴼⴰⵕ ⵏ ⵉⴱⵓⴳⴻⵏ</translation>
     </message>
     <message>
         <source>Writing Useful Bug Reports</source>
         <comment>Replaces `%2` in the `A list of all known…`</comment>
-        <translation type="unfinished">ⵜⵉⵔⴰ ⵏ ⵓⵍⵖⵓ ⵏ ⵡⵓⴳⵓⵔⴻⵏ ⵉⵍⴰⵏ ⵏⵏⴼⴻⵄ</translation>
+        <translation type="unfinished">ⵜⵉⵔⴰ ⵏ ⵉⵍⵖⴰ ⵏ ⵉⴱⵓⴳⴻⵏ ⵉⵍⴰⵏ ⵏⴼⵄ</translation>
     </message>
     <message>
         <source>contributors</source>
         <comment>Replaces `%1` in `See a full list of…`</comment>
-        <translation type="unfinished">ⵉⵎⵜⵜⴻⴽⴽⵉⵢⴻⵏ</translation>
+        <translation type="unfinished">ⵉⵎⵜⵜⵉⴽⵉⵢⵏ</translation>
     </message>
     <message>
         <source>This version of qTox is being maintained by the TokTok team following the archiving of the original qTox project.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵣⵔⴰⵔⵜⴰ ⵏ qTox ⵜⴻⵜⵜⵡⴰⵃⵔⴻⵣ ⵙⵖⵓⵔ ⵜⴻⵔⴱⴰⵄⵜ ⵏ TokTok ⵙⴷⴻⴼⴼⵉⵔ ⵏ ⵓⵙⵎⴻⵍ ⵏ ⵓⵙⴻⵏⴼⴰⵔ ⵏ qTox ⴰⵥⴰⵢⴰⵏ.</translation>
+        <translation type="unfinished">ⵜⴰⵙⴽⴰⵏⵜ ⴰ ⵏ qTox ⵜⴻⵜⵜⵡⴰⵃⵔⴻⵣ ⵙⵖⵓⵔ ⵜⵔⴱⴰⵄⵜ ⵏ TokTok ⴷⴼⴼⵉⵔ ⵓⵙⴼⵔⵓ ⵏ ⵓⵙⵏⴼⴰⵔ ⴰⵥⴰⵕⴰⵏ ⵏ qTox.</translation>
     </message>
 </context>
 <context>
     <name>AboutFriendForm</name>
     <message>
         <source>Automatically accept files from contact if set</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵇⴱⴻⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ ⵉⴼⵓⵢⵍⴰ ⵙⴻⴳ ⵓⵎⴻⵙⵍⴰⵢ ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ</translation>
+        <translation type="unfinished">ⵙⵔⴳ ⵙ ⵡⵓⴷⵎ ⴰⵡⵓⵔⵎⴰⵏ ⵉⴼⵓⵢⵍⴰ ⵙⴳ ⵓⵏⴻⵔⵎⵉⵙ ⵎⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴷⴷ</translation>
     </message>
     <message>
         <source>Default directory to save files:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴹⵔⵉⵙ ⴰⵎⴻⵙⵍⵓⴳⴻⵏ ⵉ ⵓⵙⴻⵍⴽⴻⵎ ⵏ ⵢⵉⴼⵓⵢⵍⴰ:</translation>
+        <translation type="unfinished">ⴰⴽⴰⵔⴰⵎ ⴰⵎⴻⵙⵍⵓⴳⴻⵏ ⵉ ⵓⵃⵔⴰⵣ ⵏ ⵢⵉⴼⵓⵢⵍⴰ:</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙ ⵓⴼⵓⵙ</translation>
     </message>
     <message>
         <source>Audio</source>
-        <translation>ⴰⵎⵙⵍⴰⵢ</translation>
+        <translation>ⵉⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>Audio + Video</source>
-        <translation>ⴰⵎⵙⵍⴰⵢ + ⴰⴼⵉⴷⵢⵓ</translation>
+        <translation>ⵉⵎⵙⵍⵉ + ⴰⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Automatically accept conference invitations from this contact if set.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵇⴱⴻⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ ⵉⵏⴻⴹⵔⵓⵢⴻⵏ ⵏ ⵓⵙⴰⵔⴰⴳ ⵙⴻⴳ ⵓⵎⵙⴰⵡⴰⵍⴰ ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ.</translation>
+        <translation type="unfinished">ⵙⵔⴳ ⵙ ⵡⵓⴷⵎ ⴰⵡⵓⵔⵎⴰⵏ ⵜⵉⵏⴱⴳⵉⵡⵉⵏ ⵏ ⵓⵙⴰⵔⴰⴳ ⵙⴳ ⵓⵏⴻⵔⵎⵉⵙ ⴰ ⵎⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴷⴷ.</translation>
     </message>
     <message>
         <source>Remove history (operation can not be undone!)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵎⴻⵣⵔⵓⵢ (ⵜⴰⵎⵀⴻⵍⵜ ⵓⵔ ⵜⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵜⴻⵜⵜⵡⴰⴽⴽⴻⵙ!)</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵎⵣⵔⵓⵢ (ⵜⴰⵎⵀⵍⵜ ⴰ ⵓⵔ ⵜⵜⵡⴰⵙⵙⵓⴼⵖ!)</translation>
     </message>
     <message>
         <source>Notes</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵉⴳⵏⴰⵜⵉⵏ</translation>
+        <translation type="unfinished">ⵜⵉⵏⴼⵓⴽⴰ</translation>
     </message>
     <message>
         <source>Input field for notes about the contact</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⴳⵔ ⵏ ⵓⵙⴻⴽⵛⴻⵎ ⵉ ⵜⵉⵙⵎⴻⴽⵜⵉⵡⵉⵏ ⵖⴻⴼ ⵓⵎⵙⴰⵡⴰⵍ</translation>
+        <translation type="unfinished">ⵜⴰⵎⵏⴰⴹⵜ ⵏ ⵜⵉⵔⴰ ⵉ ⵜⵏⴼⵓⴽⴰ ⵖⴼ ⵓⵏⴻⵔⵎⵉⵙ</translation>
     </message>
     <message>
         <source>History removed</source>
@@ -270,107 +237,88 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>This is the public key of your friend, use it to verify their identity via another channel. You can not send this to other people so they can add this contact.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵡⴰⴷ ⴰⵢⴷ ⵉⴳⴰⵏ ⵜⴰⵙⵓⵔⵉⴼⵜ ⵜⴰⴳⴷⵓⴷⴰⵏⵜ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵏⵏⵓⵏ, ⵙⵙⵎⵔⵙ ⵜ ⵃⵎⴰ ⴰⴷ ⵜⵙⵙⵎⵔⵙⵎ ⵜⴰⵎⴰⴳⵉⵜ ⵏⵏⵙⵏ ⵙ ⵜⴱⵔⵉⴷⵜ ⵏ ⵢⴰⵏ ⵓⴱⵔⵉⴷ ⵢⴰⴹⵏ. ⵓⵔ ⵜⵣⵎⵉⵔⴷ ⴰⴷ ⵜⵣⵔⵉⴷ ⴰⵢⴰ ⵉ ⵉⵡⴷⴰⵏ ⵢⴰⴹⵏⵉⵏ ⵃⵎⴰ ⴰⴷ ⵥⴹⴰⵕⵏ ⴰⴷ ⵔⵏⵓⵏ ⴰⵙⵖⵍ ⴰⴷ.</translation>
+        <translation type="unfinished">ⵡⴰ ⴷ ⵜⴰⵙⴰⵔⵓⵜ ⵜⴰⵣⴰⵢⵣⵜ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵉⵏⴽ, ⵙⵙⵎⵔⵙ ⵉⵜ ⴰⴽⴽⵏ ⴰⴷ ⵜⵙⵙⵏ ⵜⴰⴳⵉⵍⴰⵍⵉⵜ ⵏⵏⵙ ⵙ ⵓⴱⵔⵉⴷ ⵏⵉⴹⵏ. ⵓⵔ ⵜⵣⵎⵉⵔⴷ ⴰⴷ ⵜ ⵜⴰⵣⵏⴷ ⵉ ⵢⵉⵡⴷⴰⵏ ⵏⵉⴹⵏ ⴰⴽⴽⵏ ⴰⴷ ⵔⵏⵓⵏ ⴰⵏⴻⵔⵎⵉⵙ ⴰ.</translation>
     </message>
     <message>
         <source>Public key (not ToxID):</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵙⴰⵔⵓⵜ ⵜⴰⵣⴰⵢⴻⵣⵜ (ⵎⴰⵞⵞⵉ ⴷ ToxID):</translation>
+        <translation type="unfinished">ⵜⴰⵙⴰⵔⵓⵜ ⵜⴰⵣⴰⵢⵣⵜ (ⵎⴰⵞⵞⵉ ⴷ ToxID):</translation>
     </message>
     <message>
         <source>Confirmation</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵖⵜⵉ</translation>
+        <translation type="unfinished">ⴰⵙⴷⴷⵉⴷ</translation>
     </message>
     <message>
         <source>Are you sure to remove %1 chat history?</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙ ⵜⴻⵜⵜⵡⴰⴽⴽⵙⴻⴹ ⴰⴷ ⵜⴻⴽⴽⵙⴻⴹ %1 ⵏ ⵓⵎⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ?</translation>
+        <translation type="unfinished">ⵉⵙ ⵜⴻⴱⵖⵉⴷ ⴰⴷ ⵜⴽⴽⵙⴷ ⴰⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ ⴰⴽⴷ %1?</translation>
     </message>
     <message>
         <source>Failed to remove chat history with %1!</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴽⴽⴻⵙ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⴰⵢⵜ ⵙ %1!</translation>
+        <translation type="unfinished">ⴰⵔⵎⵎⵓⵙ ⵏ ⵜⵓⴽⴽⵙⴰ ⵏ ⵓⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ ⴰⴽⴷ %1!</translation>
     </message>
     <message>
         <source>Auto-accept files</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⵏ ⵢⵉⴼⵓⵢⵍⴰ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⴰⵡⵓⵔⵎⴰⵏ ⵏ ⵉⴼⵓⵢⵍⴰ</translation>
     </message>
     <message>
         <source>Auto-accept for this contact is disabled</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵃⵉⴷ ⵉ ⵓⵎⵙⴰⵡⴰⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴼⴻⴹ</translation>
+        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⴰⵡⵓⵔⵎⴰⵏ ⵉ ⵓⵏⴻⵔⵎⵉⵙ ⴰ ⵢⴻⵏⵙⴰ</translation>
     </message>
     <message>
         <source>Auto-accept call:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⵏ ⵓⵙⵉⵡⴻⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ:</translation>
+        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⴰⵡⵓⵔⵎⴰⵏ ⵏ ⵓⵙⵉⵡⵍ:</translation>
     </message>
     <message>
         <source>Auto-accept conference invites</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⵏ ⵓⵙⴰⵔⴰⴳ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵙⵔⴳ ⴰⵡⵓⵔⵎⴰⵏ ⵏ ⵜⵏⴱⴳⵉⵡⵉⵏ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>You can save comments about this contact here.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵣⴻⵎⵔⴻⴹ ⴰⴷ ⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵉⵎⴻⵙⵍⴰⵢⴻⵏ ⵖⴻⴼ ⵓⵙⵎⴻⵍⴰ ⴷⴰⴳⵉ.</translation>
+        <translation type="unfinished">ⵜⵣⵎⵔⴷ ⴰⴷ ⵜⵃⵔⵣⴷ ⵉⵡⵏⵏⵉⵜⵏ ⵖⴼ ⵓⵏⴻⵔⵎⵉⵙ ⴰ ⴷⴰ.</translation>
     </message>
 </context>
 <context>
     <name>AboutSettings</name>
     <message>
         <source>Version</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵙⴻⵏⴼⴻⵍⵜ</translation>
+        <translation type="unfinished">ⵜⴰⵙⴽⴰⵏⵜ</translation>
     </message>
     <message>
         <source>License</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵜⴻⵙⵔⵉⵃ</translation>
+        <translation type="unfinished">ⵜⵓⵔⴰⴳⵜ</translation>
     </message>
     <message>
         <source>Authors</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵎⵢⵓⵔⴰ</translation>
+        <translation type="unfinished">ⵉⵎⵙⴽⴰⵔⵏ</translation>
     </message>
     <message>
         <source>Known Issues</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵉⵎⵙⴰⵍ ⵢⴻⵜⵜⵡⴰⵙⵏⴻⵏ</translation>
+        <translation type="unfinished">ⵉⵅⵓⵚⵚⴰ ⵢⴻⵜⵜⵡⴰⵙⵙⵏⴻⵏ</translation>
     </message>
     <message>
         <source>Open update download link</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴻⵏⵇⴻⴷ ⵏ ⵓⵙⴻⴽⵍⴻⵙ ⵏ ⵓⵙⴻⵖⵏⴻⵡ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵣⴷⴰⵢ ⵏ ⵓⵙⵉⵙⵢ ⵏ ⵓⵙⵎⴰⵢⵏⵓ</translation>
     </message>
     <message>
         <source>Update available</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵎⴰⵢⵏⵓ ⵢⴻⵍⵍⴰ</translation>
+        <translation type="unfinished">ⴰⵙⵎⴰⵢⵏⵓ ⵢⵍⵍⴰ</translation>
     </message>
     <message>
         <source>qTox is up to date ✓</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">qTox ⴷ ⴰⵙⵙⴰ ✓</translation>
+        <translation type="unfinished">qTox ⵉⵎⴰⵢⵏⵓ ✓</translation>
     </message>
     <message>
         <source>Currently running an untested/unstable version of qTox</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵓⵔⴰ ⵢⴻⵜⵜⵡⴰⵅⴷⴻⵎ ⵢⵉⵡⴻⵏ ⵏ ⵓⵍⵇⴻⵎ ⵓⵔ ⵢⴻⵜⵜⵡⴰⵊⴻⵔⴷⴻⵏ ⴰⵔⴰ/ⵓⵔ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷⴻⵏ ⴰⵔⴰ ⵏ qTox</translation>
+        <translation type="unfinished">ⵜⵙⵙⵎⵔⴰⵙⴷ ⵜⴰⵙⴽⴰⵏⵜ ⵓⵔ ⵏⴻⵜⵜⵡⴰⵔⵎ/ⵓⵔ ⵏⴻⵔⴽⵉⴷ ⵏ qTox</translation>
     </message>
 </context>
 <context>
     <name>AddFriendForm</name>
     <message>
         <source>Add Friends</source>
-        <translation>ⵔⵏⵓ ⴰⵎⴷⴷⴰⴽⴽⵯⵍ</translation>
+        <translation>ⵔⵏⵓ ⵉⵎⴷⴷⵓⴽⴽⴰⵍ</translation>
     </message>
     <message>
         <source>Invalid Tox ID format</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵍⵖⴰ ⵏ ID ⵏ Tox ⵓⵔ ⵜⴻⵜⵜⵇⴰⴷⴰⵔ ⴰⵔⴰ</translation>
     </message>
     <message>
@@ -379,211 +327,173 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Friend requests</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⵓⵜⴻⵔ ⵏ ⵉⵎⴷⵓⴽⴰⵍ</translation>
     </message>
     <message>
         <source>Accept</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵇⴱⴻⵍ</translation>
+        <translation type="unfinished">ⵙⵔⴳ</translation>
     </message>
     <message>
         <source>Reject</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵜⵜⵯⵢⴻⵇⴱⵉⵍ ⴰⵔⴰ</translation>
+        <translation type="unfinished">ⴰⴳⵉ</translation>
     </message>
     <message>
         <source>Couldn&apos;t add friend</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵣⵎⵉⵔⴻⵖ ⴰⵔⴰ ⴰⴷ ⵔⵏⵓⵖ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵣⵎⵉⵔⴻⵖ ⴰⵔⴰ ⴰⴷ ⵔⵏⵓⵖ ⴰⵎⴷⴷⴰⴽⴽⵍ.</translation>
     </message>
     <message>
         <source>Type in Tox ID of your friend</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵔⵓⴷ Tox ID ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍⵉⴽ</translation>
+        <translation type="unfinished">ⴰⵔⵓⴷ Tox ID ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍⵉⴽ</translation>
     </message>
     <message>
         <source>Friend request message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵣⴻⵏ ⵏ ⵓⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ</translation>
+        <translation type="unfinished">ⵉⵣⴻⵏ ⵏ ⵓⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ</translation>
     </message>
     <message>
         <source>Type message to send with the friend request or leave empty to send a default message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵔⵓⴷ ⵉⵣⴻⵏ ⴰⵔⴰ ⵜⴻⵙⵙⵉⵡⴹⴻⴹ ⵙ ⵓⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ ⵏⴻⵖ ⴵⴵⵉⵜ ⴷ ⵉⵍⴻⵎ ⵉⵡⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⵉⵡⴹⴻⴹ ⵉⵣⴻⵏ ⴰⵎⴻⵙⵍⵓⴳⴻⵏ</translation>
+        <translation type="unfinished">ⴰⵔⵓⴷ ⵉⵣⴻⵏ ⴰⵔⴰ ⵜⴻⵙⵙⵉⵡⴹⴻⴹ ⵙ ⵓⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵏⴻⵖ ⴵⴵⵉⵜ ⴷ ⵉⵍⴻⵎ ⵉⵡⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⵉⵡⴹⴻⴹ ⵉⵣⴻⵏ ⴰⵎⴻⵙⵍⵓⴳⴻⵏ</translation>
     </message>
     <message>
         <source>You can&apos;t add yourself as a friend!</source>
         <extracomment>When trying to add your own Tox ID as friend</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵜⴻⵣⵎⵉⵔⴻⴹ ⴰⵔⴰ ⴰⴷ ⵜⴻⵔⵏⵓⴹ ⵉⵎⴰⵏⵉⴽ ⴷ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ!</translation>
+        <translation type="unfinished">ⵓⵔ ⵜⴻⵣⵎⵉⵔⴻⴹ ⴰⵔⴰ ⴰⴷ ⵜⴻⵔⵏⵓⴹ ⵉⵎⴰⵏⵉⴽ ⴷ ⴰⵎⴷⴷⴰⴽⴽⵍ!</translation>
     </message>
     <message>
         <source>Open contact list</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⵓⵎⵓⵖ ⵏ ⵓⵙⵉⵡⴻⴹ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⵜⴰⵍⴳⴰⵎⵜ ⵏ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ</translation>
     </message>
     <message>
         <source>Couldn&apos;t open file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Couldn&apos;t open the contact file</source>
         <extracomment>Error message when trying to open a contact list file to import</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ ⴰⴼⴰⵢⵍⵓ ⵏ ⵓⵎⴻⵙⵍⴰⵢ</translation>
     </message>
     <message>
         <source>Invalid file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵓⵔ ⵢⴻⵜⵜⵡⴰⵇⴱⴰⵍ ⴰⵔⴰ</translation>
     </message>
     <message>
         <source>We couldn&apos;t find any contacts to import in this file!</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔ ⵏⵓⴼⵉ ⴰⵔⴰ ⴽⵔⴰ ⵏ ⵢⵉⵙⴰⵍⵍⴻⵏ ⴰⵔⴰ ⴷⵏⴻⵙⵙⴻⴽⵛⴻⵎ ⴷⴻⴳ ⵓⴼⴰⵢⵍⵓⴰ!</translation>
     </message>
     <message>
         <source>Tox ID</source>
         <extracomment>Tox ID of the person you&apos;re sending a friend request to</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵎⴰⴳⵉⵜ ⵏ Tuks</translation>
+        <translation type="unfinished">ⵜⴰⴳⵉⵍⴰⵍⵉⵜ ⵏ Tox</translation>
     </message>
     <message>
         <source>Message</source>
         <extracomment>The message you send in friend requests</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Open</source>
         <extracomment>Button to choose a file with a list of contacts to import</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⵍⴷⵉ</translation>
     </message>
     <message>
         <source>Send friend requests</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵣⴻⵏ ⵉⵙⵓⵜⴻⵔ ⵏ ⵉⵎⴷⵓⴽⴰⵍ</translation>
     </message>
     <message>
         <source>%1 here! Tox me maybe?</source>
         <extracomment>Default message in friend requests if the field is left blank. Write something appropriate!</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 ⴷⴰⴳⵉ! Tox ⵎⴻ ⴰⵀⴰⵜ?</translation>
     </message>
     <message>
         <source>Import a list of contacts, one Tox ID per line</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵓⵎⵓⵖ ⵏ ⵢⵉⵙⴰⵍⵍⴻⵏ, ⵢⵉⵡⴻⵏ ⵏ Tox ID ⵉ ⵢⴰⵍ ⴰⴹⵔⵉⵙ</translation>
+        <translation type="unfinished">ⵙⴽⵛⵎ ⵜⴰⵍⴳⴰⵎⵜ ⵏ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ, ⵢⴰⵏ Tox ID ⴳ ⵓⵣⵔⵉⵔⵉ</translation>
     </message>
     <message numerus="yes">
         <source>Ready to import %n contact(s), click send to confirm</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">
-            <numerusform>ⵀⴻⴳⴳⴰⴷ ⵉ ⵓⵙⴻⴽⵛⴻⵎ ⵏ %ⵏ ⵏ ⵢⵉⵎⴷⴰⵏⴻⵏ, ⵜⵜⴻⴽⵙⴻⴹ ⴰⵣⴻⵏ ⵉⵡⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵜⴻⵙⵙⴻⴽⵏⴻⴹ</numerusform>
+            <numerusform>ⵀⴻⴳⴳⴰⴷ ⵉ ⵓⵙⴻⴽⵛⴻⵎ ⵏ %n ⵏ ⵢⵉⵎⴷⴰⵏⴻⵏ, ⵜⵜⴻⴽⵙⴻⴹ ⴰⵣⴻⵏ ⵉⵡⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵜⴻⵙⵙⴻⴽⵏⴻⴹ</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
         <source>Import contacts</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵉⵎⴻⵙⵍⴰⵢⴻⵏ</translation>
+        <translation type="unfinished">ⵙⴽⵛⵎ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ</translation>
     </message>
     <message>
         <source>Tox ID, 76 hexadecimal characters</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Tox ID, 76 ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵏ ⵙⴹⵉⵙ ⵏ ⵜⵎⴻⵔⵡⵉⵏ</translation>
+        <translation type="unfinished">Tox ID, 76 ⵏ ⵢⵉⵙⴽⴽⵉⵍⵏ ⵉⵙⴹⵉⵙⵎⵔⴰⵡⴰⵏⵏ</translation>
     </message>
     <message>
         <source>%1 Tox ID is invalid</source>
         <comment>Tox address error</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 Tamagit ⵏ Tox ⵓⵔ ⵜⴻⵜⵜⵇⴰⴷⴰⵔ ⴰⵔⴰ</translation>
+        <translation type="unfinished">%1 Tox ID ⵓⵔ ⵢⵖⴱⵉⵍ</translation>
     </message>
     <message>
         <source>76 hexadecimal characters</source>
         <extracomment>Tox ID format description</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">76 ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵏ ⵙⴹⵉⵙ ⵏ ⵜⵎⴻⵔⵡⵉⵏ</translation>
+        <translation type="unfinished">76 ⵏ ⵢⵉⵙⴽⴽⵉⵍⵏ ⵉⵙⴹⵉⵙⵎⵔⴰⵡⴰⵏⵏ</translation>
     </message>
     <message>
         <source>Add friend</source>
-        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ</translation>
+        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴷⴷⴰⴽⴽⵍ</translation>
     </message>
 </context>
 <context>
     <name>AdvancedForm</name>
     <message>
         <source>Advanced</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵉⵣⵡⵉⵔⵜ</translation>
+        <translation type="unfinished">ⵓⵏⵎⵉⴳ</translation>
     </message>
     <message>
         <source>really</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙ ⵜⵉⴷⴻⵜ</translation>
+        <translation type="unfinished">ⵙ ⵜⵉⴷⵜ</translation>
     </message>
     <message>
         <source>not</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵅⴰⵜⵉ</translation>
+        <translation type="unfinished">ⵓⵀⵓ</translation>
     </message>
     <message>
         <source>IMPORTANT NOTE</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">TAƔEWSA TAƔELNAWT</translation>
+        <translation type="unfinished">ⵜⴰⵏⴼⵓⴽⵜ ⵜⴰⵅⴰⵜⴰⵔⵜ</translation>
     </message>
     <message>
         <source>Reset settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴱⴻⴷⴷ ⵉⵙⴻⵖⵡⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵍⵙ ⵉⵙⵖⵡⴰⵕⵏ</translation>
     </message>
     <message>
         <source>All settings will be reset to default. Are you sure?</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴽⴽ ⵉⵙⴻⴼⴽⴰ ⴰⴷ ⵜⵜⵡⴰⴱⴻⴷⴷⵍⴻⵏ ⵙ ⵜⵖⴰⵡⵍⴰ. ⵜⴻⵜⵜⵡⴰⴽⴽⴻⴷ ?</translation>
+        <translation type="unfinished">ⴰⴽⴽ ⵉⵙⵖⵡⴰⵕⵏ ⴰⴷ ⵜⵜⵡⴰⵍⵙⵏ ⵖⵔ ⵡⴰⴷⴷⴰⴷ ⴰⴳⵉⵍⴰⵍⵏⵓ. ⵜⵙⵙⵉⴷⵜⴷ?</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵀ</translation>
     </message>
     <message>
         <source>No</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵍⴰ</translation>
     </message>
     <message>
         <source>Logs (*.log)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵖⵎⵉⵙⴻⵏ (*.ⴰⵖⵎⵉⵙ)</translation>
+        <translation type="unfinished">ⵉⵖⵎⵉⵙⵏ (*.log)</translation>
     </message>
     <message>
         <source>Unless you %1 know what you are doing, please do %2 change anything here. Changes made here may lead to problems with qTox, and even to loss of your data, e.g. history.%3</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⵓⵔ ⵜⴻⵥⵔⵉⴹ ⴰⵔⴰ %1 ⴰⵢⴻⵏ ⵜⵅⴻⴷⵎⴻⴹ, ⵜⵜⵅⵉⵍⴽ %2 ⵜⴱⴻⴷⴷⴻⵍⴻⴹ ⴽⵔⴰ ⴷⴰⴳⵉ. ⵉⴱⴻⴷⴷⴰⵍⴻⵏ ⵢⴻⵜⵜⵡⴰⵅⴻⴷⵎⴻⵏ ⴷⴰⴳⵉ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⴷⴰⵡⵉⵏ ⵓⴳⵓⵔⴻⵏ ⵙ qTox, ⵢⴻⵔⵏⴰ ⵓⵍⴰ ⴷ ⴰⵖⴻⵍⵍⵓⵢ ⵏ ⵢⵉⵙⴻⴼⴽⴰⵉⵏⴻⴽ, ⴰⵎⴻⴷⵢⴰ. ⴰⵎⴻⵣⵔⵓⵢ.%3.</translation>
+        <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⵓⵔ ⵜⴻⵥⵔⵉⴹ ⴰⵔⴰ %1 ⴰⵢⴻⵏ ⵜⵅⴻⴷⵎⴻⴹ, ⵜⵜⵅⵉⵍⴽ %2 ⵜⵙⵏⴼⵍⴷ ⴽⵔⴰ ⴷⴰⴳⵉ. ⵉⴱⴻⴷⴷⴰⵍⴻⵏ ⵢⴻⵜⵜⵡⴰⵅⴻⴷⵎⴻⵏ ⴷⴰⴳⵉ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⴷⴰⵡⵉⵏ ⵓⴳⵓⵔⴻⵏ ⵙ qTox, ⵢⴻⵔⵏⴰ ⵓⵍⴰ ⴷ ⴰⵖⴻⵍⵍⵓⵢ ⵏ ⵢⵉⵙⴻⴼⴽⴰⵉⵏⴻⴽ, ⴰⵎⴻⴷⵢⴰ. ⴰⵎⴻⵣⵔⵓⵢ.%3.</translation>
     </message>
     <message>
         <source>Changes here are applied only after restarting qTox.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⴱⴻⴷⴷⴰⵍⴻⵏ ⴷⴰⴳⵉ ⵜⵜⵡⴰⵅⴻⴷⵎⴻⵏ ⴽⴰⵏ ⴷⴻⴼⴼⵉⵔ ⵎⴰ ⵜⵉⴷⵜⴻⵔⵔⴻⴹ qTox.</translation>
+        <translation type="unfinished">ⵉⵙⵏⴼⵍⵏ ⴷⴰ ⴰⴷ ⴱⴷⵓⵏ ⴰⵙⵏⴰⵙ ⴰⵔ ⴷⴼⴼⵉⵔ ⵓⵍⴰⵙ ⵏ ⵓⵙⴽⴽⵔ ⵏ qTox.</translation>
     </message>
     <message>
         <source>Save file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵃⵔⴻⵣ ⴰⴼⴰⵢⵍⵓ</translation>
+        <translation type="unfinished">ⵃⵔⵣ ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Invalid proxy address</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵏⵙⴰ ⵏ ⴱⵔⵓⴽⵙⵉⵍ ⵓⵔ ⵉⵏⵏⴼⵍⵏ</translation>
+        <translation type="unfinished">ⵜⴰⵏⵙⴰ ⵏ ⵓⴱⵔⵓⴽⵙⵉ ⵓⵔ ⵢⵖⴱⵉⵍ</translation>
     </message>
     <message>
         <source>Please enter a valid IP address or hostname for the proxy setting.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵔ ⵜⵜⵔⴰⵔⴰⵏ ⵢⴰⵏ ⵓⵏⵙⴰ ⵏ IP ⵏⵖ ⵢⴰⵏ ⵉⵙⵎ ⵏ ⵓⵎⵙⵏⵓⴱⴳ ⵍⵍⵉ ⵔⴰⴷ ⴽⵏ ⵢⴰⵡⵙ.</translation>
+        <translation type="unfinished">ⵜⵜⵅⵉⵍⴽ ⵙⵙⴽⵛⵎ ⵜⴰⵏⵙⴰ ⵏ IP ⵜⴰⵎⵖⴱⵓⵍⵜ ⵏⵖ ⵉⵙⵎ ⵏ ⵓⵙⵏⵓⴱⴳ ⵉ ⵓⵙⵖⵡⴰⵕ ⵏ ⵓⴱⵔⵓⴽⵙⵉ.</translation>
     </message>
 </context>
 <context>
@@ -591,92 +501,75 @@ which may lead to problems with video calls.</source>
     <message>
         <source>Save settings to the working directory instead of the usual conf dir</source>
         <extracomment>describes makeToxPortable checkbox</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵃⵔⴻⵣ ⵉⵙⴻⵖⵡⴰⵏ ⴷⴻⴳ ⵓⴹⵔⵉⵙ ⵏ ⵓⵅⴻⴷⴷⵉⵎ ⴷⴻⴳ ⵓⵎⴹⵉⵇ ⵏ conf ⴷⵉⵔ ⵏ ⵣⵉⴽ</translation>
+        <translation type="unfinished">ⵃⵔⵣ ⵉⵙⵖⵡⴰⵕⵏ ⴷⴳ ⵓⴽⴰⵔⴰⵎ ⵏ ⵓⵎⴰⵀⵉⵍ ⴳ ⵓⵎⴹⵉⵇ ⵏ ⵓⴽⴰⵔⴰⵎ ⵏ conf ⴰⴳⵉⵍⴰⵍⵏⵓ</translation>
     </message>
     <message>
         <source>Make Tox portable</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴽⴻⵔ Tux ⴷ ⴰⵄⴻⵙⵙⴰⵙ</translation>
+        <translation type="unfinished">ⵔⵔ Tox ⴷ ⴰⵣⵉⵣⴷⴰⵏ</translation>
     </message>
     <message>
         <source>Reset to default settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵔⴻⵙ ⵖⴻⵔ ⵉⵙⴻⵖⵡⴰⵏ ⵉⵎⴻⵣⵡⵓⵔⴰ</translation>
+        <translation type="unfinished">ⴰⵍⵙ ⵉ ⵉⵙⵖⵡⴰⵕⵏ ⵉⵎⴰⴳⵏⵓⵜⵏ</translation>
     </message>
     <message>
         <source>Portable</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵜⵜⵡⴰⵟⵟⴼⴻⵏ</translation>
+        <translation type="unfinished">ⴰⵣⵉⵣⴷⴰⵏ</translation>
     </message>
     <message>
         <source>Enable IPv6 (recommended)</source>
         <extracomment>Text on a checkbox to enable IPv6</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⴻⴽⵛⴻⵎ IPv6 (ⵢⴻⵜⵜⵡⴰⵙⵙⵓⵎⵎⴻⵍ)</translation>
+        <translation type="unfinished">ⵔⵎⴷ IPv6 (ⵢⴻⵜⵜⵡⴰⵙⵎⵢⴰⵔ)</translation>
     </message>
     <message>
         <source>Enable UDP (recommended)</source>
         <extracomment>Text on checkbox to disable UDP</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⴻⴽⵛⴻⵎ UDP (ⵢⴻⵜⵜⵡⴰⵙⵙⵓⵎⵎⴻⵍ)</translation>
+        <translation type="unfinished">ⵔⵎⴷ UDP (ⵢⴻⵜⵜⵡⴰⵙⵎⵢⴰⵔ)</translation>
     </message>
     <message>
         <source>Proxy type:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵚⵚⴻⵏⴼ ⵏ ⵓⵄⴻⴳⴳⴰⵍ:</translation>
+        <translation type="unfinished">ⴰⵏⴰⵡ ⵏ ⵓⴱⵔⵓⴽⵙⵉ:</translation>
     </message>
     <message>
         <source>Address:</source>
         <extracomment>Text on proxy addr label</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵣⴻⵏ:</translation>
+        <translation type="unfinished">ⵜⴰⵏⵙⴰ:</translation>
     </message>
     <message>
         <source>Port:</source>
         <extracomment>Text on proxy port label</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴰⴳⴻⵏ:</translation>
+        <translation type="unfinished">ⵜⴰⵡⵡⵓⵔⵜ:</translation>
     </message>
     <message>
         <source>None</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵍⴰⵛ</translation>
     </message>
     <message>
         <source>Debug</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴷⴻⴱⵓⴳ</translation>
+        <translation type="unfinished">ⵜⴰⵙⵖⵉⵢⵜ</translation>
     </message>
     <message>
         <source>Export Debug Log</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵓⴼⴻⵖ ⵏ ⵓⵖⵎⵉⵙ ⵏ ⵓⵖⴻⵍⵍⴻⵜ</translation>
+        <translation type="unfinished">ⵙⵙⵉⴼⴹ ⴰⵖⵎⵉⵙ ⵏ ⵜⵙⵖⵉⵢⵜ</translation>
     </message>
     <message>
         <source>Copy Debug Log</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⴰⵖⵎⵉⵙ ⵏ ⵓⵙⴻⵖⵜⵉ</translation>
+        <translation type="unfinished">ⵏⵖⵍ ⴰⵖⵎⵉⵙ ⵏ ⵜⵙⵖⵉⵢⵜ</translation>
     </message>
     <message>
         <source>Enable LAN discovery</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⴻⴽⵛⴻⵎ ⵜⵓⴼⴼⵖⴰ ⵏ LAN</translation>
+        <translation type="unfinished">ⵔⵎⴷ ⴰⵙⵍⵍⵉ ⵏ LAN</translation>
     </message>
     <message>
         <source>Enable Debug Tools (developers only)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⴻⵅⴷⴻⵎ ⴰⵍⵍⴰⵍⴻⵏ ⵏ ⵓⵙⴻⵖⵜⵉ (ⵉⵎⵙⴻⵏⴼⴰⵔⴻⵏ ⴽⴰⵏ)</translation>
     </message>
     <message>
         <source>Connection settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵖⵡⴰⵏ ⵏ ⵜⵓⵇⵇⵏⴰ</translation>
+        <translation type="unfinished">ⵉⵙⵖⵡⴰⵕⵏ ⵏ ⵜⵓⵇⵇⵏⴰ</translation>
     </message>
     <message>
         <source>Disabling this allows, e.g., Tox over Tor. It adds load to the Tox network however, so uncheck only when necessary.</source>
         <extracomment>force tcp checkbox tooltip</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵡⴰⵢⴰ ⵢⴻⵜⵜⴰⴵⴵⴰ, ⴰⵎⴻⴷⵢⴰ, Tox ⵖⴻⴼ Tor. ⵢⴻⵔⵏⴰⴷ ⵍⵃⴻⴱⵙ ⵉ ⵓⵥⴻⴹⴹⴰ ⵏ Tox ⴷ ⴰⵛⵓ ⴽⴰⵏ, ⵉⵀⵉ ⵙⴼⴻⴹ ⴽⴰⵏ ⵎⵉ ⴰⵔⴰ ⵉⵍⴰⵇ.</translation>
     </message>
 </context>
@@ -688,39 +581,35 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">ⵢⴻⴱⴷⴰ ⵉⵏⵙⵜⴰⵏⵛⴻ ⴰⵎⴰⵢⵏⵓⵜ ⵢⴻⵔⵏⴰ ⵢⴻⵜⵜⵃⴰⴷⴰⵔ ⴰⴼⴻⵔⴷⵉⵙ ⵢⴻⵜⵜⵡⴰⵙⵏⴻⵏ.</translation>
+        <translation type="unfinished">ⵢⴻⴱⴷⴰ ⵉⵏⵙⵜⴰⵏⵛⴻ ⴰⵎⴰⵢⵏⵓⵜ ⵢⴻⵔⵏⴰ ⵢⴻⵜⵜⵃⴰⴷⴰⵔ ⴰⴳⵉⵍⴰⵍ ⵢⴻⵜⵜⵡⴰⵙⵏⴻⵏ.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">ⴰⵍⴻⴳⴷⵉⵙ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">ⵢⴻⴱⴷⴰ ⵉⵏⵙⵜⴰⵏⵛⴻ ⴰⵎⴰⵢⵏⵓⵜ ⵢⴻⵔⵏⴰ ⵢⴻⵍⴷⵉ ⴰⴹⵔⵉⵙ ⵏ ⵜⵓⴽⴽⵙⴰ.</translation>
+        <translation type="unfinished">ⵢⴻⴱⴷⴰ ⵉⵏⵙⵜⴰⵏⵛⴻ ⴰⵎⴰⵢⵏⵓⵜ ⵢⴻⵔⵏⴰ ⵢⴻⵍⴷⵉ ⴰⴳⴷⵉⵍ ⵏ ⵓⵏⴻⴽⵛⵓⵎ.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
         <comment>&apos;on&apos; and &apos;off&apos; should not be translated, they are flag values</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ IPv6 &lt;ⵢⴻⵙⴱⴻⴷⴷ&gt;/&lt;ⵢⴻⵙⴱⴻⴷⴷ&gt;. ⴰⵎⴻⵏⵣⵓ ⴷ ON.</translation>
+        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ IPv6 &lt;on&gt;/&lt;off&gt;. ⴰⵎⴻⵏⵣⵓ ⴷ ON.</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
         <comment>&apos;on&apos; and &apos;off&apos; should not be translated, they are flag values</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ UDP &lt;ⴰⴷ ⴷⵢⴻⵙⴱⴻⴷⴷ&gt;/&lt;ⵢⴻⵙⴱⴻⴷⴷ&gt;. ⴰⵎⴻⵏⵣⵓ ⴷ ON.</translation>
+        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ UDP &lt;on&gt;/&lt;off&gt;. ⴰⵎⴻⵏⵣⵓ ⴷ ON.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
         <comment>&apos;on&apos; and &apos;off&apos; should not be translated, they are flag values</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ ⵜⵓⴼⴼⵖⴰ ⵏ LAN &lt;ⵙ&gt;/&lt;ⵙ&gt;. UDP ⵏ ⵜⵎⴻⵥⵥⵓⵖⵜ. ⴰⵎⴻⵏⵣⵓ ⴷ ON.</translation>
+        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ ⵜⵓⴼⴼⵖⴰ ⵏ LAN &lt;on&gt;/&lt;off&gt;. UDP off ⵉⵣⵔⵉ. ⴰⵎⴻⵏⵣⵓ ⴷ ON.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
         <comment>NONE should not be translated, it is a flag value</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ ⵉⵙⴻⵖⵡⴰⵏ ⵏ proxy. ⵜⴰⵎⴻⵥⵍⴰ ⴷ NONE.</translation>
+        <translation type="unfinished">ⵢⴻⵙⴱⴻⴷⴷ ⵉⵙⵖⵡⴰⵕⵏ ⵏ proxy. ⵜⴰⵎⴻⵥⵍⴰ ⴷ NONE.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -728,22 +617,19 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵙⵙⵉⵡⴻⴹ ⴰⴼⴻⵔⴷⵉⵙ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵙⵙⵉⵡⴻⴹ ⴰⴳⵉⵍⴰⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ.</translation>
     </message>
     <message>
         <source>Checks whether this program is running the latest qTox version.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⵜⵜⵡⴰⵍⵉ ⵎⴰ ⵢⴻⵍⵍⴰ ⴰⵀⵉⵍⴰ ⵢⴻⵜⵜⴽⴻⵎⵎⵉⵍ ⵙ ⵜⴰⵍⵖⴰ ⵜⴰⵏⴻⴳⴳⴰⵔⵓⵜ ⵏ qTox.</translation>
     </message>
     <message>
         <source>Starts in portable mode; loads profile from this directory.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⴱⴷⴰ ⴷⴻⴳ ⵜⴻⴳⵏⵉⵜ ⵏ ⵜⵎⴻⵥⴷⵉⵜ; ⵢⴻⵜⵜⵃⴰⴷⴰⵔ ⴰⴼⴻⵔⴷⵉⵙ ⵙⴻⴳ ⵓⴹⵔⵉⵙⴰ.</translation>
+        <translation type="unfinished">ⵢⴻⴱⴷⴰ ⴷⴻⴳ ⵜⴻⴳⵏⵉⵜ ⵏ ⵜⵎⴻⵥⴷⵉⵜ; ⵢⴻⵜⵜⵃⴰⴷⴰⵔ ⴰⴳⵉⵍⴰⵍ ⵙⴻⴳ ⵓⴽⴰⵔⴰⵎⴰ.</translation>
     </message>
     <message>
         <source>path</source>
         <comment>directory in file system</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴱⵔⵉⴷ</translation>
     </message>
 </context>
@@ -751,159 +637,131 @@ which may lead to problems with video calls.</source>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵣⴻⵏ ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>qTox wasn&apos;t able to open %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">qTox ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ %1.</translation>
     </message>
     <message>
         <source>Unable to open</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ</translation>
     </message>
     <message>
         <source>Bad idea</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⵉⵔ ⵜⵉⴽⵜⵉ</translation>
     </message>
     <message>
         <source>Failed to open temporary file</source>
         <comment>Temporary file for screenshot</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ ⴰⴼⴰⵢⵍⵓ ⴰⵄⵍⴰⵢⴰⵏ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ ⴰⴼⴰⵢⵍⵓ ⴰⴽⵓⴷⴰⵏ</translation>
     </message>
     <message>
         <source>qTox wasn&apos;t able to save the screenshot</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">qTox ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⵙⴻⵍⵍⴻⴽ ⵜⵓⴳⵏⴰ ⵏ ⵓⵙⵎⴻⵍ</translation>
+        <translation type="unfinished">qTox ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵃⵔⴻⵣ ⵜⵓⴳⵏⴰ ⵏ ⵓⴳⴷⵉⵍ</translation>
     </message>
     <message>
         <source>Call duration: </source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴻⵖⵣⵉ ⵏ ⵓⵙⵉⵡⴻⵍ:</translation>
     </message>
     <message>
         <source>Copy</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ</translation>
+        <translation type="unfinished">ⵏⵖⵍ</translation>
     </message>
     <message>
         <source>You&apos;re trying to send a sequential file, which is not going to work!</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵄⴻⵔⴹⴻⴹ ⴰⴷ ⵜⴻⵙⵙⵉⵡⴹⴻⴹ ⴰⴼⴰⵢⵍⵓ ⵏ ⵜⵎⴻⵣⵡⴰⵔⵓⵜ, ⵓⵔ ⵉⵅⴻⴷⴷⴻⵎ ⴰⵔⴰ!</translation>
     </message>
     <message>
         <source>Filename contained illegal characters</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵏ ⵓⴼⴰⵢⵍⵓ ⵢⴻⵙⵄⴰ ⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵉⵅⵓⵚⵚⴻⵏ</translation>
+        <translation type="unfinished">ⵉⵙⵎ ⵏ ⵓⴼⴰⵢⵍⵓ ⵢⵙⵄⴰ ⵉⵙⴽⴽⵉⵍⵏ ⴰⵔⵓⵍⴳⵉⵏⵏ</translation>
     </message>
     <message>
         <source>Illegal characters have been changed to _
 so you can save the file on Windows.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵓⵔ ⵏⴻⵍⵍⵉ ⴰⵔⴰ ⴷ ⵉⵣⴻⵔⴼⴰⵏ ⵜⵜⵡⴰⴱⴻⴷⴷⵍⴻⵏ ⵖⴻⵔ _
-ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵣⴻⵎⵔⴻⴹ ⴰⴷ ⵜⴻⵙⵙⴻⴽⵍⴻⵙⴹ ⴰⴼⴰⵢⵍⵓ ⴷⴻⴳ Windows.</translation>
+        <translation type="unfinished">ⵉⵙⴽⴽⵉⵍⵏ ⴰⵔⵓⵍⴳⵉⵏⵏ ⵜⵜⵡⴰⵙⵏⴼⵍⵏ ⵖⵔ _
+ⴰⴽⴽⵏ ⴰⴷ ⵜⵉⵣⵎⵉⵔⴷ ⴰⴷ ⵜⵃⵔⵣⴷ ⴰⴼⴰⵢⵍⵓ ⴷⴳ Windows.</translation>
     </message>
 </context>
 <context>
     <name>ChatFormHeader</name>
     <message>
         <source>Can&apos;t start audio call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴱⴷⵓ ⴰⵙⵉⵡⴻⵍ ⵙ ⵚⵚⵓⵜ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵉⵣⵎⵉⵔ ⴰⴷ ⵉⴱⴷⵓ ⴰⵙⵉⵡⵍ ⵉⵎⵙⵍⵉ.</translation>
     </message>
     <message>
         <source>Start audio call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴷⵓ ⴰⵙⵉⵡⴻⵍ ⵙ ⵚⵚⵓⵜ</translation>
+        <translation type="unfinished">ⴱⴷⵓ ⴰⵙⵉⵡⵍ ⵉⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>End audio call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴼⵓ ⴰⵙⵉⵡⴻⵍ ⵙ ⵚⵚⵓⵜ</translation>
+        <translation type="unfinished">ⴼⴽⴽ ⴰⵙⵉⵡⵍ ⵉⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>Cancel audio call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⵟⴻⵍ ⴰⵙⵉⵡⴻⵍ ⵙ ⵚⵚⵓⵜ</translation>
+        <translation type="unfinished">ⴱⵟⴻⵍ ⴰⵙⵉⵡⵍ ⵉⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>Accept audio call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵇⴱⴻⵍ ⴰⵙⵉⵡⴻⵍ ⵙ ⵚⵚⵓⵜ</translation>
+        <translation type="unfinished">ⵙⵔⴳ ⴰⵙⵉⵡⵍ ⵉⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>Can&apos;t start video call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵣⵎⵉⵔⴻⵖ ⴰⵔⴰ ⴰⴷ ⴱⴷⵓⵖ ⴰⵙⵉⵡⴻⵍ ⵙ vidyu</translation>
+        <translation type="unfinished">ⵓⵔ ⵉⵣⵎⵉⵔ ⴰⴷ ⵉⴱⴷⵓ ⴰⵙⵉⵡⵍ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Start video call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴷⵓ ⴰⵙⵉⵡⴻⵍ ⵙ vidyu</translation>
+        <translation type="unfinished">ⴱⴷⵓ ⴰⵙⵉⵡⵍ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>End video call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴻⵎⵎⴻⵍ ⴰⵙⵉⵡⴻⵍ ⵙ vidyu</translation>
+        <translation type="unfinished">ⴼⴽⴽ ⴰⵙⵉⵡⵍ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Cancel video call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⵟⴻⵍ ⵜⵉⵖⵔⵉ ⵙ vidyu</translation>
+        <translation type="unfinished">ⴱⵟⴻⵍ ⴰⵙⵉⵡⵍ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Accept video call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵇⴱⴻⵍ ⴰⵙⵉⵡⴻⵍ ⵙ vidyu</translation>
+        <translation type="unfinished">ⵙⵔⴳ ⴰⵙⵉⵡⵍ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Sound can be disabled only during a call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵜⵜⵡⴰⵙⴼⴻⴹ ⵚⵚⵓⵜ ⴰⵍⴰ ⴷⴻⴳ ⵍⴰⵡⴰⵏ ⵏ ⵓⵙⵉⵡⴻⵍ.</translation>
+        <translation type="unfinished">ⵉⵎⵙⵍⵉ ⵉⵣⵎⵔ ⴰⴷ ⵢⴻⵏⵙ ⴽⴰⵏ ⴳ ⵓⵙⵉⵡⵍ.</translation>
     </message>
     <message>
         <source>Unmute call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⵓⴼⵖⴻⴹ ⵜⵉⵖⵔⵉ</translation>
+        <translation type="unfinished">ⵙⵙⵉⵡⵍ ⴰⵙⵉⵡⵍ</translation>
     </message>
     <message>
         <source>Mute call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵓⵙⴻⵎ ⵏ ⵓⵙⵉⵡⴻⵍ</translation>
+        <translation type="unfinished">ⵙⵙⵓⵙⵎ ⴰⵙⵉⵡⵍ</translation>
     </message>
     <message>
         <source>Microphone can be muted only during a call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵎⵉⴽⵔⵓⴼⵓⵏ ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵜⵜⵡⴰⵙⵙⵓⵙⴻⵎ ⴰⵍⴰ ⴷⴻⴳ ⵍⴰⵡⴰⵏ ⵏ ⵓⵙⵉⵡⴻⵍ.</translation>
+        <translation type="unfinished">ⴰⵙⵎⵙⴰⵡⴰⵍ ⵉⵣⵎⵔ ⴰⴷ ⵢⴻⵜⵜⵡⴰⵙⵙⵓⵙⵎ ⴽⴰⵏ ⴳ ⵓⵙⵉⵡⵍ.</translation>
     </message>
     <message>
         <source>Unmute microphone</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⵓⵙⵎ ⴰⵎⵉⴽⵔⵓⴼⵓⵏ</translation>
+        <translation type="unfinished">ⵙⵙⵉⵡⵍ ⴰⵙⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Mute microphone</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⵓⵙⵎ ⴰⵎⵉⴽⵔⵓⴼⵓⵏ</translation>
+        <translation type="unfinished">ⵙⵙⵓⵙⵎ ⴰⵙⵎⵙⴰⵡⴰⵍ</translation>
     </message>
 </context>
 <context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵔⵓⴷ ⵉⵣⴻⵏⵉⴽ ⴷⴰⴳⵉ...</translation>
+        <translation type="unfinished">ⴰⵔⵓ ⵉⵣⵏ ⵉⵏⴽ ⴷⴰ...</translation>
     </message>
 </context>
 <context>
     <name>ChatWidget</name>
     <message>
         <source>pending</source>
-        <translation type="unfinished">ⴰⵔ ⵎⴰⵔⴰ</translation>
+        <translation type="unfinished">ⵉⵜⵜⵔⵊⵓ</translation>
     </message>
     <message>
         <source>%1 is typing</source>
@@ -911,7 +769,7 @@ so you can save the file on Windows.</source>
     </message>
     <message>
         <source>Copy</source>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ</translation>
+        <translation type="unfinished">ⵏⵖⵍ</translation>
     </message>
     <message>
         <source>Select all</source>
@@ -923,18 +781,15 @@ so you can save the file on Windows.</source>
     <message>
         <source>Rename circle</source>
         <comment>Menu for renaming a circle</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵎ ⵏ ⵜⴻⵖⵣⵉⵔⵜ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⵉⵙⵎ ⵏ ⵜⵔⴱⴰⵄⵜ</translation>
     </message>
     <message>
         <source>Remove circle</source>
         <comment>Menu for removing a circle</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⵜⴰⵖⴻⵛⵜ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⵜⴰⵔⴱⴰⵄⵜ</translation>
     </message>
     <message>
         <source>Open all in new window</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵍⴷⵉ ⴰⴽⴽ ⴷⴻⴳ ⵟⵟⴰⵇ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
 </context>
@@ -956,117 +811,98 @@ so you can save the file on Windows.</source>
     <message numerus="yes">
         <source>%n user(s) in chat</source>
         <comment>Number of users in chat</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">
-            <numerusform>%ⵏ ⴰⵙⴻⵇⴷⴰⵛ (ⵏ) ⴷⴻⴳ ⵓⵎⴻⵙⵍⴰⵢ</numerusform>
-            <numerusform></numerusform>
+            <numerusform>%n ⵓⵙⴻⵇⴷⴰⵛ ⴷⴻⴳ ⵓⵎⵙⵍⴰⵢ</numerusform>
+            <numerusform>%n ⵢⵉⵙⴻⵇⴷⴰⵛⴻⵏ ⴷⴻⴳ ⵓⵎⵙⵍⴰⵢ</numerusform>
         </translation>
     </message>
     <message>
         <source>mute</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴷ ⴰⵙⵓⵙⵎⴰⵏ</translation>
     </message>
     <message>
         <source>unmute</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⵓⵙⴻⵎ</translation>
     </message>
     <message>
         <source>copy peer ID</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ID ⵏ ⵓⵎⴷⴰⴽⴽⴻⵍ</translation>
+        <translation type="unfinished">ⵏⵖⵍ ID ⵏ ⵓⵎⴷⴰⴽⴽⴻⵍ</translation>
     </message>
 </context>
 <context>
     <name>ConferenceInviteForm</name>
     <message>
         <source>Conferences</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴰⵔⴰⴳⴻⵏ</translation>
     </message>
     <message>
         <source>Create new conference</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⴰⵙⴰⵔⴰⴳ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Conference invites</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵄⵔⴰⴹ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
+        <translation type="unfinished">ⵜⵉⵏⴱⴳⵉⵡⵉⵏ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
     </message>
 </context>
 <context>
     <name>ConferenceInviteWidget</name>
     <message>
         <source>Invited by %1 on %2 at %3.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⵜⵜⵡⴰⵄⵔⴻⴹ ⵙⵖⵓⵔ %1 ⵖⴻⴼ %2 ⵖⴻⴼ %3.</translation>
     </message>
     <message>
         <source>Join</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵔⵏⵓ ⵖⴻⵔ</translation>
     </message>
     <message>
         <source>Decline</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵏⵏⴳⴻⵔ</translation>
+        <translation type="unfinished">ⴰⴳⵉ</translation>
     </message>
 </context>
 <context>
     <name>ConferenceWidget</name>
     <message>
         <source>Set title...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴱⴻⴷⴷ ⴰⵣⵡⴻⵍ...</translation>
     </message>
     <message>
         <source>Open chat in new window</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵎⴻⵙⵍⴰⵢ ⴷⴻⴳ ⵟⵟⴰⵇ ⴰⵎⴰⵢⵏⵓⵜ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵎⵙⴰⵡⴰⵍ ⴷⴻⴳ ⵟⵟⴰⵇ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Remove chat from this window</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵎⴻⵙⵍⴰⵢ ⵙⴻⴳ ⵟⵟⴰⵇⴰ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵎⵙⴰⵡⴰⵍ ⵙⴳ ⵟⵟⴰⵇⴰ</translation>
     </message>
     <message>
         <source>Quit conference</source>
         <comment>Menu to quit a conference</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵃⴱⴻⵙ ⴰⵙⴰⵔⴰⴳ</translation>
     </message>
     <message numerus="yes">
         <source>%n user(s) in chat</source>
         <comment>Number of users in chat</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">
-            <numerusform>%ⵏ ⴰⵙⴻⵇⴷⴰⵛ (ⵏ) ⴷⴻⴳ ⵓⵎⴻⵙⵍⴰⵢ</numerusform>
-            <numerusform></numerusform>
+            <numerusform>%n ⵓⵙⴻⵇⴷⴰⵛ ⴷⴻⴳ ⵓⵎⵙⵍⴰⵢ</numerusform>
+            <numerusform>%n ⵢⵉⵙⴻⵇⴷⴰⵛⴻⵏ ⴷⴻⴳ ⵓⵎⵙⵍⴰⵢ</numerusform>
         </translation>
     </message>
     <message>
         <source>New message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓ</translation>
     </message>
     <message>
         <source>Online</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Oⵏⵍⴰⵢⵏ</translation>
+        <translation type="unfinished">ⵢⵍⵍⴰ</translation>
     </message>
 </context>
 <context>
     <name>Core</name>
     <message>
         <source>/me offers friendship, &quot;%1&quot;</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">/ⵎⴻ ⵢⴻⵜⵜⴰⴽⴷ ⵜⴰⵎⴷⴰⴽⴻⵍⵜ, &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Conference %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴰⵔⴰⴳ %1.</translation>
     </message>
     <message>
@@ -1087,32 +923,28 @@ so you can save the file on Windows.</source>
     <message>
         <source>Friend is already added</source>
         <comment>Error while sending friend request</comment>
-        <translation type="unfinished">ⴰⵎⴻⴷⴷⴰⴽⴻⵍ ⵢⴻⵔⵏⴰⴷ ⵢⴰⴽⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵎⴷⴷⴰⴽⴽⵍ ⵢⴻⵔⵏⴰⴷ ⵢⴰⴽⴰⵏ</translation>
     </message>
 </context>
 <context>
     <name>DebugLog</name>
     <message>
         <source>Debug Log</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵖⵎⵉⵙ ⵏ ⵓⵙⴻⴳⴳⴻⵎ</translation>
     </message>
     <message>
         <source>Auto-reload</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵄⵉⵡⴻⴷ ⵏ ⵓⵄⴻⴱⴱⵓⴹ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
     </message>
     <message>
         <source>Auto-scroll</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵍⴻⵙ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵣⵓⵖⴻⵔ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
     </message>
 </context>
 <context>
     <name>DebugLogForm</name>
     <message>
         <source>Debug Log</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵖⵎⵉⵙ ⵏ ⵓⵙⴻⴳⴳⴻⵎ</translation>
     </message>
 </context>
@@ -1121,86 +953,71 @@ so you can save the file on Windows.</source>
     <message>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵜⵔⴰⴵⵓⵖ ⴰⴷ ⴰⵣⵏⴻⵖ...</translation>
     </message>
     <message>
         <source>Accept to receive this file</source>
         <comment>file transfer widget</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵇⴱⴻⵍ ⴰⴷ ⵜⴽⴻⵛⵎⴻⴹ ⴰⴼⴰⵢⵍⵓⴰ</translation>
+        <translation type="unfinished">ⵙⵔⴳ ⴰⴷ ⵜⴽⴻⵛⵎⴻⴹ ⴰⴼⴰⵢⵍⵓⴰ</translation>
     </message>
     <message>
         <source>Resuming...</source>
         <comment>file transfer widget</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴽⴻⵎⵎⴻⵍ...</translation>
     </message>
     <message>
         <source>Cancel transfer</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴱⵟⴻⵍ ⴰⵙⵉⵡⴻⴹ</translation>
     </message>
     <message>
         <source>Pause transfer</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵃⴱⴻⵙ ⴰⵙⵉⵡⴻⴹ</translation>
     </message>
     <message>
         <source>Paused</source>
         <comment>file transfer widget</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⵃⴱⴻⵙ</translation>
     </message>
     <message>
         <source>Open file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵍⴷⵉ ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Open file directory</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⴹⵔⵉⵙ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⴽⴰⵔⴰⵎ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Resume transfer</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴽⴻⵎⵎⴻⵍ ⴰⵙⵉⵡⴻⴹ</translation>
     </message>
     <message>
         <source>Accept transfer</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵇⴱⴻⵍ ⴰⵙⵉⵡⴻⴹ</translation>
+        <translation type="unfinished">ⵙⵔⴳ ⴰⵙⵉⵡⴻⴹ</translation>
     </message>
     <message>
         <source>Save a file</source>
         <comment>Title of the file saving dialog</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵃⵔⴻⵣ ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Remote paused</source>
         <comment>file transfer widget</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵍⴽⵉⵎ ⵢⴻⵃⴱⴻⵙ</translation>
+        <translation type="unfinished">ⵢⴻⵃⴱⴻⵙ ⵙⵖⵓⵔ ⵓⵏⴻⵔⵎⵉⵙ</translation>
     </message>
 </context>
 <context>
     <name>FilesForm</name>
     <message>
         <source>Downloads</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵍⴻⵙ</translation>
+        <translation type="unfinished">ⴰⵣⵓⵖⴻⵔ</translation>
     </message>
     <message>
         <source>Uploads</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ</translation>
+        <translation type="unfinished">ⴰⵙⴰⵍⵉ</translation>
     </message>
     <message>
         <source>Transferred files</source>
         <comment>&quot;Headline&quot; of the window</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⴼⵓⵢⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⵏⴻⴼⵍⵉⵏ</translation>
     </message>
 </context>
@@ -1208,32 +1025,26 @@ so you can save the file on Windows.</source>
     <name>FriendListWidget</name>
     <message>
         <source>Today</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⵙⴰ</translation>
     </message>
     <message>
         <source>Yesterday</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⴹⴻⵍⵍⵉ</translation>
     </message>
     <message>
         <source>Last 7 days</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵡⵓⵙⵙⴰⵏ ⵉⵏⴻⴳⴳⵓⵔⴰ</translation>
     </message>
     <message>
         <source>This month</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵢⵢⵓⵔⴰ</translation>
     </message>
     <message>
         <source>Never</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔⵊⵓⵏ</translation>
     </message>
     <message>
         <source>Older than 6 months</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⴳⴰⵔ ⵏ 6 ⵡⴰⴳⴳⵓⵔⴻⵏ</translation>
     </message>
 </context>
@@ -1242,99 +1053,81 @@ so you can save the file on Windows.</source>
     <message>
         <source>Invite to conference</source>
         <comment>Menu to invite a friend to a conference</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵄⵔⴰⴹ ⵖⴻⵔ ⵓⵙⴰⵔⴰⴳ</translation>
+        <translation type="unfinished">ⴰⵙⵏⴻⴱⴳⵉ ⵖⴻⵔ ⵓⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>Move to circle...</source>
         <comment>Menu to move a friend into a different circle</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵎⵓⵇⴻⵍ ⵖⴻⵔ ⵜⴻⵖⵣⵉ...</translation>
+        <translation type="unfinished">ⵙⵎⵓⵜⵜⵉ ⵖⴻⵔ ⵜⵔⴱⴰⵄⵜ...</translation>
     </message>
     <message>
         <source>To new circle</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵖⴻⵔ ⵜⴰⵖⴻⵛⵜ ⵜⴰⵎⴰⵢⵏⵓⵜ</translation>
+        <translation type="unfinished">ⵖⴻⵔ ⵜⵔⴱⴰⵄⵜ ⵜⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Remove from circle &apos;%1&apos;</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⵙⴻⴳ ⵜⴻⵖⵣⵉ &apos;%1&apos;.</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⵙⴳ ⵜⵔⴱⴰⵄⵜ &apos;%1&apos;.</translation>
     </message>
     <message>
         <source>Open chat in new window</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵎⴻⵙⵍⴰⵢ ⴷⴻⴳ ⵟⵟⴰⵇ ⴰⵎⴰⵢⵏⵓⵜ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵎⵙⴰⵡⴰⵍ ⴷⴻⴳ ⵟⵟⴰⵇ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Remove chat from this window</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵎⴻⵙⵍⴰⵢ ⵙⴻⴳ ⵟⵟⴰⵇⴰ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵎⵙⴰⵡⴰⵍ ⵙⴳ ⵟⵟⴰⵇⴰ</translation>
     </message>
     <message>
         <source>To new conference</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵖⴻⵔ ⵓⵙⴰⵔⴰⴳ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Invite to conference &apos;%1&apos;</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⵏⴻⴱⴳⵉ ⵖⴻⵔ ⵓⵙⴰⵔⴰⴳ &apos;%1&apos;.</translation>
     </message>
     <message>
         <source>Set alias...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴱⴻⴷⴷ ⵉⵙⴻⵎ ⵏⵏⵉⴹⴻⵏ...</translation>
     </message>
     <message>
         <source>Auto accept files from this friend</source>
         <comment>context menu entry</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵇⴱⴻⵍ ⵙ ⵜⵉⵎⴰⴷⵉⴽ ⵉⴼⵓⵢⵍⴰ ⵙⴻⴳ ⵓⵎⴻⴷⴷⴰⴽⴻⵍⴰ</translation>
+        <translation type="unfinished">ⵇⴱⴻⵍ ⵙ ⵜⵉⵎⴰⴷⵉⴽ ⵉⴼⵓⵢⵍⴰ ⵙⴻⴳ ⵓⵎⴷⴷⴰⴽⴽⵍⴰ</translation>
     </message>
     <message>
         <source>Show details</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴽⴻⵏ ⵜⵉⴼⴻⵙⵙⴰⵙⵉⵏ</translation>
+        <translation type="unfinished">ⵙⴽⵏ ⵜⵉⴼⵙⵙⴰⵙⵉⵏ</translation>
     </message>
     <message>
         <source>New message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓ</translation>
     </message>
     <message>
         <source>Online</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Oⵏⵍⴰⵢⵏ</translation>
+        <translation type="unfinished">ⵢⵍⵍⴰ</translation>
     </message>
     <message>
         <source>Away</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⴱⵄⴻⴷ</translation>
+        <translation type="unfinished">ⵉⴱⵄⴷ</translation>
     </message>
     <message>
         <source>Busy</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵄⵎⴻⵔ</translation>
+        <translation type="unfinished">ⵢⵛⵖⵍ</translation>
     </message>
     <message>
         <source>Offline</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⵕⵕⴰ ⵉ ⵍⴰⵏⵜⵉⵔⵏⴰⵜ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵍⵍⵉ</translation>
     </message>
     <message>
         <source>Move to circle &quot;%1&quot;</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⴻⵇⵙ ⵖⴻⵔ ⵜⵖⴻⵔⵖⴻⵔⵜ &quot;%1&quot;</translation>
+        <translation type="unfinished">ⵙⵎⵓⵜⵜⵉ ⵖⴻⵔ ⵜⵔⴱⴰⵄⵜ &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Remove friend</source>
         <comment>Menu to remove the friend from the friend list</comment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵎⴷⴷⴰⴽⴽⵍ</translation>
     </message>
     <message>
         <source>Blocked</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⵜⵜⵡⴰⵃⴱⴻⵙ</translation>
     </message>
 </context>
@@ -1342,17 +1135,14 @@ so you can save the file on Windows.</source>
     <name>GeneralForm</name>
     <message>
         <source>General</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵎⴰⵜⴰ</translation>
+        <translation type="unfinished">ⴰⵎⴰⵜⵓ</translation>
     </message>
     <message>
         <source>%1 (no fonts)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 (ⵓⵍⴰⵛ ⵜⵉⵙⴻⴽⴽⵉⵔⵉⵏ)</translation>
     </message>
     <message>
         <source>Auto select</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⵜⴰⵢ ⵏ ⵓⴼⵔⴰⴳ</translation>
     </message>
 </context>
@@ -1360,126 +1150,102 @@ so you can save the file on Windows.</source>
     <name>GeneralSettings</name>
     <message>
         <source>General Settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵖⵥⴰⵏ ⴰⵎⴰⵜⵓ</translation>
+        <translation type="unfinished">ⵉⵙⵖⵡⴰⵕⵏ ⵉⵎⴰⵜⵓⵜⵏ</translation>
     </message>
     <message>
         <source>The translation may not load until qTox restarts.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵙⵓⵇⵉⵍⵜ ⵜⴻⵣⵎⴻⵔ ⵓⵔ ⵜⴻⵜⵜⴽⴻⵎⵎⵉⵍ ⴰⵔⴰ ⴰⵍⴰⵎⵎⴰ ⵢⴻⵇⵇⴻⵍ qTox.</translation>
     </message>
     <message>
         <source>Language:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵓⵜⵍⴰⵢⵜ:</translation>
     </message>
     <message>
         <source>Show system tray icon</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴽⴻⵏ ⵜⴰⵙⵖⵓⵏⵜ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵏⴰⴳⵔⴰⵡ</translation>
+        <translation type="unfinished">ⵙⴽⵏ ⵜⴰⵎⴰⵜⴰⵔⵜ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵏⴳⵔⴰⵡ</translation>
     </message>
     <message>
         <source>Enable light tray icon.</source>
         <comment>toolTip for light icon setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⴻⵅⴷⴻⵎ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵜⴰⴼⴰⵜ.</translation>
     </message>
     <message>
         <source>Light icon</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵙⴻⴽⴽⵉⵔⵜ ⵏ ⵜⴰⴼⴰⵜ</translation>
     </message>
     <message>
         <source>qTox will start minimized in tray.</source>
         <comment>toolTip for Start in tray setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">qTox ⴰⴷ ⵢⴻⴱⴷⵓ ⵢⴻⵜⵜⵡⴰⵙⵏⴻⴼⵍⵉ ⴷⴻⴳ ⵜⴼⴻⵍⵡⵉⵜ.</translation>
+        <translation type="unfinished">qTox ⴰⴷ ⵉⴱⴷⵓ ⵉⵙⵎⵥⵉ ⵖⵔ ⵜⴼⴻⵍⵡⵉⵜ.</translation>
     </message>
     <message>
         <source>Start in tray</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴷⵓ ⴷⴻⴳ ⵓⴹⴻⴱⵙⵉ</translation>
+        <translation type="unfinished">ⴱⴷⵓ ⴳ ⵜⴼⴻⵍⵡⵉⵜ</translation>
     </message>
     <message>
         <source>Close to tray</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵇⵔⵉⴱ ⵏ ⵜⴼⴻⵍⵡⵉⵜ</translation>
     </message>
     <message>
         <source>Minimize to tray</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵏⴻⵇⵙ ⵖⴻⵔ ⵜⴼⴻⵍⵡⵉⵜ</translation>
     </message>
     <message>
         <source>Autostart</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴱⴷⵓ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
     </message>
     <message>
         <source>Set where files will be saved.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⴳⵣⵉⴷ ⴰⵏⴷⴰ ⴰⵔⴰ ⵜⵜⵡⴰⵃⴻⵔⵣⴻⵏ ⵢⵉⴼⵓⵢⵍⴰ.</translation>
     </message>
     <message>
         <source>Autoaccept files</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵇⴱⴰⵍ ⵏ ⵢⵉⴼⵓⵢⵍⴰ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵙⵔⴳ ⵏ ⵢⵉⴼⵓⵢⵍⴰ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
     </message>
     <message>
         <source>Set to 0 to disable</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴱⴻⴷⴷ ⵖⴻⵔ 0 ⵉⵡⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴼⴻⴹ</translation>
     </message>
     <message>
         <source>Your status is changed to Away after set period of inactivity.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴷⴷⵓⴷⵉⴽ ⵢⴻⵜⵜⵡⴰⴱⴻⴷⴷⴻⵍ ⵖⴻⵔ Away ⴷⴻⴼⴼⵉⵔ ⵜⴰⵍⵍⵉⵜ ⵏ ⵓⵔ ⵏⵅⴻⴷⴷⴻⵎ ⴰⵔⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷⴻⵏ.</translation>
+        <translation type="unfinished">ⴰⴷⴷⵓⴷⵉⴽ ⵢⴻⵜⵜⵡⴰⵙնⴼⵍ ⵖⴻⵔ ⵉⴱⵄⴷ ⴷⴻⴼⴼⵉⵔ ⵜⴰⵍⵍⵉⵜ ⵏ ⵓⵔ ⵏⵅⴻⴷⴷⴻⵎ ⴰⵔⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷⴻⵏ.</translation>
     </message>
     <message>
         <source>Auto away after (0 to disable):</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵃⵉⴷ ⴷⴻⴼⴼⵉⵔ (0 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵜⴻⵙⴼⴻⴹ):</translation>
     </message>
     <message>
         <source>Show contacts&apos; status changes</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴽⴻⵏⴷ ⵉⴱⴻⴷⴷⴰⵍⴻⵏ ⵏ ⵜⴻⴳⵏⵉⵜ ⵏ ⵢⵉⵎⴻⵙⵍⴰⵢⴻⵏ</translation>
     </message>
     <message>
         <source>Start qTox on operating system startup (current profile).</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴷⵓ qTox ⴷⴻⴳ ⵓⵙⴱⴰⴷⵓ ⵏ ⵓⵏⴰⴳⵔⴰⵡ ⵏ ⵓⵙⴻⵍⴽⵉⵎ (ⴰⴼⴻⵔⴷⵉⵙ ⵏ ⵜⵓⵔⴰ).</translation>
+        <translation type="unfinished">ⴱⴷⵓ qTox ⴷⴻⴳ ⵓⵙⴱⴰⴷⵓ ⵏ ⵓⵏⴰⴳⵔⴰⵡ ⵏ ⵓⵙⴻⵍⴽⵉⵎ (ⴰⴳⵉⵍⴰⵍ ⵏ ⵜⵓⵔⴰ).</translation>
     </message>
     <message>
         <source>Default directory to save files:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴹⵔⵉⵙ ⴰⵎⴻⵙⵍⵓⴳⴻⵏ ⵉ ⵓⵙⴻⵍⴽⴻⵎ ⵏ ⵢⵉⴼⵓⵢⵍⴰ:</translation>
+        <translation type="unfinished">ⴰⴽⴰⵔⴰⵎ ⴰⵎⴻⵙⵍⵓⴳⴻⵏ ⵉ ⵓⵃⵔⴰⵣ ⵏ ⵢⵉⴼⵓⵢⵍⴰ:</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵡⴰⵍⵉ ⵎⴰ ⵢⴻⵍⵍⴰ ⴷ ⵉⵎⴰⵢⵏⵓⵜⴻⵏ</translation>
     </message>
     <message>
         <source>Spell checking</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵜⵉⵔⴰ</translation>
     </message>
     <message>
         <source>Max autoaccept file size (0 to disable):</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ ⵜⴰⵎⴻⵇⵔⴰⵏⵜ ⵏ ⵓⴼⴰⵢⵍⵓ ⵏ ⵓⵇⴱⴰⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵃⵉⴷ (0 ⵉ ⵓⵙⴻⵖⵍⵉ):</translation>
     </message>
     <message>
         <source> MB</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished"> ⵎⴱ</translation>
     </message>
     <message>
         <source>After pressing minimize (_) qTox will minimize to tray,
 instead of system taskbar.</source>
         <comment>toolTip for minimize to tray setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⵏⴷ ⵎⴰ ⵜⴹⴻⴳⴳⵔⴻⴹ ⵙⵏⴻⵇⵙ (_) qTox ⴰⴷ ⵢⴻⵙⵏⴻⵇⵙ ⵖⴻⵔ ⵜⴼⴻⵍⵡⵉⵜ,
 ⴷⴻⴳ ⵓⵎⴹⵉⵇ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵎⴰⵀⵉⵍ ⵏ ⵓⵏⴰⴳⵔⴰⵡ.</translation>
     </message>
@@ -1487,34 +1253,28 @@ instead of system taskbar.</source>
         <source>After pressing close (X) qTox will close to tray,
 instead of closing entirely.</source>
         <comment>toolTip for close to tray setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⵏⴷ ⴰⴷ ⵜⵜⴻⵟⵟⴼⴻⴹ ⵙ ⵓⵇⴻⵍⵍⴻⵇ (X) qTox ⴰⴷ ⵢⴻⵇⵇⴻⵍ ⵖⴻⵔ ⵜⴼⴻⵍⵡⵉⵜ,
 ⴷⴻⴳ ⵓⵎⴽⴰⵏ ⵏ ⵜⵖⴻⵍⵍⵉⵙⵜ ⵙ ⵍⴻⴽⵎⴰⵍⵉⵙ.</translation>
     </message>
     <message>
         <source>Add a chat message when a user joins or leaves a conference</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵔⵏⵓ ⵉⵣⴻⵏ ⵏ ⵓⵎⴻⵙⵍⴰⵢ ⵎⵉ ⴰⵔⴰ ⵢⴻⴽⵛⴻⵎ ⵓⵙⴻⵇⴷⴰⵛ ⵏⴻⵖ ⴰⴷ ⵢⴻⴼⴼⴻⵖ ⵙⴻⴳ ⵓⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>You can set this on a per-friend basis by right clicking individual friends.</source>
         <comment>autoaccept cb tooltip</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵣⴻⵎⵔⴻⴹ ⴰⴷ ⵜⴻⵙⴱⴻⴷⴷⴻⴹ ⴰⵢⴰ ⵙ ⵍⵙⴰⵙ ⵏ ⵢⴰⵍ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ ⵙ ⵜⵎⴻⵥⵥⵓⵖⵜ ⵏ ⵢⵉⴷⵉⵙ ⴰⵢⴻⴼⴼⵓⵙ ⵖⴻⴼ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ ⵉⵎⴰⵢⵏⵓⵜⴻⵏ.</translation>
+        <translation type="unfinished">ⵜⵣⴻⵎⵔⴻⴹ ⴰⴷ ⵜⴻⵙⴱⴻⴷⴷⴻⴹ ⴰⵢⴰ ⵙ ⵍⵙⴰⵙ ⵏ ⵢⴰⵍ ⴰⵎⴷⴷⴰⴽⴽⵍ ⵙ ⵜⵎⴻⵥⵥⵓⵖⵜ ⵏ ⵢⵉⴷⵉⵙ ⴰⵢⴻⴼⴼⵓⵙ ⵖⴻⴼ ⵢⵉⵎⴷⴷⵓⴽⴽⴰⵍ ⵉⵎⴰⵢⵏⵓⵜⴻⵏ.</translation>
     </message>
     <message>
         <source>Click here if you find errors in a translation and would like to help fix it.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴽⵏⴻⴷ ⴷⴰⴳⵉ ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⵓⴼⵉⴹ ⵜⵓⵛⵛⴹⵉⵡⵉⵏ ⴷⴻⴳ ⵜⵙⵓⵇⵉⵍⵜ ⵢⴻⵔⵏⴰ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⵄⵉⵡⵏⴻⴹ ⴰⴷ ⵜⵜⵜⴻⵙⵙⵉⵣⴻⴷⴳⴻⴹ.</translation>
     </message>
     <message>
         <source>Help translate</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵄⵉⵡⴻⵏ ⴰⵙⵓⵇⴻⵍ</translation>
     </message>
     <message>
         <source> min</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished"> ⵎⵉⵏ</translation>
     </message>
 </context>
@@ -1522,72 +1282,58 @@ instead of closing entirely.</source>
     <name>GenericChatForm</name>
     <message>
         <source>Send message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵣⴻⵏ ⵉⵣⴻⵏ</translation>
     </message>
     <message>
         <source>Smileys</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵉⵙⵎⵉⵍⵉⵢⵉⵏ</translation>
+        <translation type="unfinished">ⵉⵛⵎⵓⵎⵉⵢⴻⵏ</translation>
     </message>
     <message>
         <source>Send file(s)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵣⴻⵏ ⴰⴼⴰⵢⵍⵓ (ⵏ)</translation>
     </message>
     <message>
         <source>Send a screenshot</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵣⴻⵏⴷ ⵜⵓⴳⵏⴰ ⵏ ⵓⵙⴽⵔⵉⵏ</translation>
+        <translation type="unfinished">ⴰⵣⵏⴷ ⵜⵓⴳⵏⴰ ⵏ ⵓⴳⴷⵉⵍ</translation>
     </message>
     <message>
         <source>Save chat log</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵃⵔⴻⵣ ⴰⵖⵎⵉⵙ ⵏ ⵓⵎⴻⵙⵍⴰⵢ</translation>
+        <translation type="unfinished">ⵃⵔⴻⵣ ⴰⵖⵎⵉⵙ ⵏ ⵓⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Clear displayed messages</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴼⴻⴹ ⵉⵣⴻⵏ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴳⵏⴻⵏ</translation>
     </message>
     <message>
         <source>Quote selected text</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍ ⵏ ⵓⴹⵔⵉⵙ ⵢⴻⵜⵜⵡⴰⴼⴻⵔⵏⴻⵏ</translation>
     </message>
     <message>
         <source>Copy link address</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⵜⴰⵏⵙⴰ ⵏ ⵓⵙⴻⵏⵇⴻⴷ</translation>
+        <translation type="unfinished">ⵏⵖⵍ ⵜⴰⵏⵙⴰ ⵏ ⵓⵙⴻⵏⵇⴻⴷ</translation>
     </message>
     <message>
         <source>Confirmation</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵖⵜⵉ</translation>
+        <translation type="unfinished">ⴰⵙⴷⴷⵉⴷ</translation>
     </message>
     <message>
         <source>Search in text</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵏⴰⴷⵉ ⴷⴻⴳ ⵓⴹⵔⵉⵙ</translation>
+        <translation type="unfinished">ⵔⵣⵓ ⴳ ⵓⴹⵔⵉⵙ</translation>
     </message>
     <message>
         <source>Go to current date</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵔⵓⵃ ⵖⴻⵔ ⵡⴰⵙⵙⴰ</translation>
     </message>
     <message>
         <source>Load chat history...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⴰⵢⵜ...</translation>
+        <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⴰⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ...</translation>
     </message>
     <message>
         <source>Export to file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⵓⴼⴻⵖ ⵖⴻⵔ ⵓⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Are you sure that you want to clear all displayed messages?</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴻⵜⵜⵡⴰⵍⵉⴹ ⴱⴻⵍⵍⵉ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⵙⴼⴻⴹ ⴰⴽⴽ ⵉⵣⴻⵏ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴳⵏⴻⵏ?</translation>
     </message>
 </context>
@@ -1595,180 +1341,147 @@ instead of closing entirely.</source>
     <name>IdentitySettings</name>
     <message>
         <source>Public Information</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴰⵍⵍⴻⵏ ⵉⵏⴰⴳⴷⵓⴷⴻⵏ</translation>
     </message>
     <message>
         <source>Tox ID</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵎⴰⴳⵉⵜ ⵏ Tuks</translation>
+        <translation type="unfinished">ⵜⴰⴳⵉⵍⴰⵍⵉⵜ ⵏ Tox</translation>
     </message>
     <message>
         <source>Your Tox ID (click to copy)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Tox IDik (ⴽⵏⴻⴷ ⵉⵡⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵏⵓⵍⴼⵓⴹ)</translation>
+        <translation type="unfinished">Tox IDik (ⴽⵏⴻⴷ ⵉⵡⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵏⵖⵍⴷ)</translation>
     </message>
     <message>
         <source>Profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵍⴻⴳⴷⵉⵙ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Rename profile.</source>
         <comment>tooltip for renaming profile button</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵎ ⵏ ⵓⴼⴻⵔⴷⵉⵙ.</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⵉⵙⴻⵎ ⵏ ⵓⴳⵉⵍⴰⵍ.</translation>
     </message>
     <message>
         <source>Go back to the login screen</source>
         <comment>tooltip for logout button</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵖⴰⵍ ⵖⴻⵔ ⵓⵙⴻⴽⴽⵉⵍ ⵏ ⵜⵓⴽⴽⵙⴰ</translation>
+        <translation type="unfinished">ⵓⵖⴰⵍ ⵖⴻⵔ ⵓⴳⴷⵉⵍ ⵏ ⵓⵏⴻⴽⵛⵓⵎ</translation>
     </message>
     <message>
         <source>Logout</source>
         <comment>import profile button</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵓⴼⴼⵖⴰ</translation>
     </message>
     <message>
         <source>Remove password</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Change password</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>This QR code contains your Tox ID. You may share this with your friends as well.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴽⴰⵔⴰⵎⴰ ⵏ QR ⵢⴻⵙⵄⴰ IDik ⵏ Tox. ⵜⵣⴻⵎⵔⴻⴹ ⴰⴷ ⵜⴱⴻⴹⵏⴻⴹ ⴰⵢⴰ ⵓⵍⴰ ⴷ ⵉⵎⴷⵓⴽⴰⵍⵉⴽ.</translation>
     </message>
     <message>
         <source>Save image</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵃⵔⴻⵣ ⵜⵓⴳⵏⴰ</translation>
     </message>
     <message>
         <source>Copy image</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⵜⵓⴳⵏⴰ</translation>
+        <translation type="unfinished">ⵏⵖⵍ ⵜⵓⴳⵏⴰ</translation>
     </message>
     <message>
         <source>Rename</source>
         <comment>rename profile button</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵎ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⵉⵙⴻⵎ</translation>
     </message>
     <message>
         <source>Delete profile.</source>
         <comment>delete profile button tooltip</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⴼⴻⵔⴷⵉⵙ.</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⴳⵉⵍⴰⵍ.</translation>
     </message>
     <message>
         <source>Allows you to export your Tox profile to a file.
 Profile does not contain your history.</source>
         <comment>tooltip for profile exporting button</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵜⵜⴰⴵⴵⴰⴽ ⴰⴷ ⵜⴻⵙⵙⴻⴽⵛⴻⵎⴹ ⴰⴼⴻⵔⴷⵉⵙⵉⴽ ⵏ Tox ⵙ ⴰⴼⴰⵢⵍⵓ.
-ⴰⴼⴰⵢⵍⵓ ⵓⵔ ⵢⴻⵙⵄⵉ ⴰⵔⴰ ⴰⵎⴻⵣⵔⵓⵢⵉⴽ.</translation>
+        <translation type="unfinished">ⵢⴻⵜⵜⴰⴵⴵⴰⴽ ⴰⴷ ⵜⴻⵙⵙⵓⴼⵖⴻⴹ ⴰⴳⵉⵍⴰⵍⵉⴽ ⵏ Tox ⵙ ⴰⴼⴰⵢⵍⵓ.
+ⴰⴳⵉⵍⴰⵍ ⵓⵔ ⵢⴻⵙⵄⵉ ⴰⵔⴰ ⴰⵎⴻⵣⵔⵓⵢⵉⴽ.</translation>
     </message>
     <message>
         <source>Export</source>
         <comment>export profile button</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵙⵉⴼⵉⴹⴻⵏ</translation>
+        <translation type="unfinished">ⴰⵙⵓⴼⴻⵖ</translation>
     </message>
     <message>
         <source>Delete</source>
         <comment>delete profile button</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⵓⴽⴽⴻⵙ</translation>
+        <translation type="unfinished">ⴽⴽⵙ</translation>
     </message>
     <message>
         <source>Remove your password and encryption from your profile.</source>
         <comment>Tooltip for the `Remove password` button.</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔⵉⴽ ⴷ ⵓⵙⵎⴻⵍⵉⴽ ⵙⴻⴳ ⵓⴼⴻⵔⴷⵉⵙⵉⴽ.</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔⵉⴽ ⴷ ⵓⵙⵎⴻⵍⵉⴽ ⵙⴻⴳ ⵓⴳⵉⵍⴰⵍⵉⴽ.</translation>
     </message>
     <message>
         <source>Name input</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵢⵉⵙⴻⵎ</translation>
     </message>
     <message>
         <source>Name visible to contacts</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴻⵎ ⵢⴻⵜⵜⴱⴰⵏ ⵉ ⵢⵉⵎⴻⵙⵍⴰⵢⴻⵏ</translation>
     </message>
     <message>
         <source>Status message input</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵢⵉⵣⴻⵏ ⵏ ⵜⴻⴳⵏⵉⵜ</translation>
     </message>
     <message>
         <source>Your Tox ID</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵎⴰⴳⵉⵜⵉⴽ ⵏ Tox</translation>
+        <translation type="unfinished">Tox ID ⵉⵏⴽ</translation>
     </message>
     <message>
         <source>Save QR image as file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵃⵔⴻⵣ ⵜⵓⴳⵏⴰ ⵏ QR ⴰⵎ ⵓⴼⴰⵢⵍⵓ</translation>
+        <translation type="unfinished">ⵃⵔⵣ ⵜⴰⵡⵍⴰⴼⵜ ⵏ QR ⴰⵎ ⵓⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Copy QR image to clipboard</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⵜⵓⴳⵏⴰ ⵏ QR ⵖⴻⵔ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵙⴻⴽⵍⴻⵙ</translation>
+        <translation type="unfinished">ⵏⵖⵍ ⵜⴰⵡⵍⴰⴼⵜ ⵏ QR ⵖⵔ ⵜⴼⵍⵡⵉⵜ ⵏ ⵓⵙⵏⵖⵍ</translation>
     </message>
     <message>
         <source>Rename profile.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵎ ⵏ ⵓⴼⴻⵔⴷⵉⵙ.</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⵉⵙⴻⵎ ⵏ ⵓⴳⵉⵍⴰⵍ.</translation>
     </message>
     <message>
         <source>Delete profile.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⴼⴻⵔⴷⵉⵙ.</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⴳⵉⵍⴰⵍ.</translation>
     </message>
     <message>
         <source>Export profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵓⴼⴻⵖ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⵙⵙⵉⴼⴹ ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Remove password from profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵙⴻⴳ ⵓⴽⴰⵔⴰⵎ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵙⴳ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Change profile password</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>My name:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵉⵏⵓ:</translation>
+        <translation type="unfinished">ⵉⵙⵎ ⵉⵏⵓ:</translation>
     </message>
     <message>
         <source>My status:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴷⴷⵓⴷ ⵉⵏⵓ:</translation>
+        <translation type="unfinished">ⴰⴷⴷⴰⴷ ⵉⵏⵓ:</translation>
     </message>
     <message>
         <source>My profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴱⵜⴻⵔⵉⵡ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵉⵏⵓ</translation>
     </message>
     <message>
         <source>This ID allows other Tox users to add and contact you.
 Share it with your friends to begin chatting.</source>
         <comment>Tox ID tooltip</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">IDagi ⵢⴻⵜⵜⴰⴵⴵⴰ ⵉⵙⴻⵇⴷⴰⵛⴻⵏ ⵏⵏⵉⴹⴻⵏ ⵏ Tox ⴰⴷ ⵔⵏⵓⵏ ⵢⴻⵔⵏⴰ ⴰⴷ ⴽⵉⴷⵙⵙⵉⵡⴹⴻⵏ.
 ⴱⴹⵓⵜ ⴷ ⵉⵎⴷⵓⴽⴰⵍⵉⴽ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴱⴷⵓⴹ ⴰⵎⴻⵙⵍⴰⵢ.</translation>
     </message>
@@ -1781,185 +1494,150 @@ Share it with your friends to begin chatting.</source>
     <name>LoadHistoryDialog</name>
     <message>
         <source>Load history dialog</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⴰⴷⵉⵡⴻⵏⵏⵉ ⵏ ⵓⵎⴻⵣⵔⵓⵢ</translation>
+        <translation type="unfinished">ⴰⴷⵉⵡⵏⵏⵉ ⵏ ⵓⵙⵙⴰⵍⵉ ⵏ ⵓⵎⵣⵔⵓⵢ</translation>
     </message>
     <message>
         <source>Load history from:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵃⴻⴱⴱⴻⵙ ⴰⵎⴻⵣⵔⵓⵢ ⵙⴻⴳ:</translation>
+        <translation type="unfinished">ⵙⵙⴰⵍⵉ ⴰⵎⵣⵔⵓⵢ ⵙⴳ:</translation>
     </message>
 </context>
 <context>
     <name>LoginScreen</name>
     <message>
         <source>Username:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵏ ⵓⵙⴻⵇⴷⴰⵛ:</translation>
+        <translation type="unfinished">ⵉⵙⵎ ⵏ ⵓⵎⵙⵙⵎⵔⵙ:</translation>
     </message>
     <message>
         <source>Password:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵡⴰⵍ ⵏ ⵓⴼⴼⵉⵔ:</translation>
+        <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ:</translation>
     </message>
     <message>
         <source>Confirm:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⴻⴽⵏⴻⵖⵜ:</translation>
+        <translation type="unfinished">ⵙⴷⴷⵉⴷ:</translation>
     </message>
     <message>
         <source>Password strength: %p%</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵣⵎⴻⵔⵜ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ: %p%</translation>
     </message>
     <message>
         <source>Create Profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ Amyag</translation>
+        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓ ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>If the profile does not have a password, qTox can skip the login screen</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⴰⴼⴻⵔⴷⵉⵙ ⵓⵔ ⵢⴻⵙⵄⵉ ⴰⵔⴰ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ, qTox ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵣⴳⴻⵔ ⴰⴹⵔⵉⵙ ⵏ ⵜⵓⴽⴽⵙⴰ .</translation>
+        <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⴰⴳⵉⵍⴰⵍ ⵓⵔ ⵢⴻⵙⵄⵉ ⴰⵔⴰ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ, qTox ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵣⴳⴻⵔ ⴰⴳⴷⵉⵍ ⵏ ⵓⵏⴻⴽⵛⵓⵎ .</translation>
     </message>
     <message>
         <source>Load automatically</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
+        <translation type="unfinished">ⵙⵙⴰⵍⵉ ⵙ ⵡⵓⴷⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
     </message>
     <message>
         <source>Load</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵄⴻⴱⴱⴰ</translation>
+        <translation type="unfinished">ⵙⵙⴰⵍⵉ</translation>
     </message>
     <message>
         <source>Load Profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⴰⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⵙⵙⴰⵍⵉ ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>New Profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⴰⵎⴰⵢⵏⵓⵜ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Couldn&apos;t create a new profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵙⵏⵓⵍⴼⵓ ⴰⴳⴱⵓⵔ ⴰⵎⴰⵢⵏⵓⵜ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵙⵏⵓⵍⴼⵓ ⴰⴳⵉⵍⴰⵍ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>The username must not be empty.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴻⵎ ⵏ ⵓⵙⴻⵇⴷⴰⵛ ⵓⵔ ⵉⵍⴰⵇ ⴰⵔⴰ ⴰⴷ ⵢⵉⵍⵉ ⴷ ⴰⵍⴻⵎⵎⴰⵙ.</translation>
     </message>
     <message>
         <source>The password must be at least 6 characters long.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵢⴻⵙⵙⴻⴼⴽ ⴰⴷ ⵢⵉⵍⵉ ⵎⴰ ⵓⵍⴰⵛ 6 ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ.</translation>
     </message>
     <message>
         <source>A profile with this name already exists.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴻⵔⴷⵉⵙ ⵙ ⵢⵉⵙⴻⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴰⴽⴰⵏ.</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵙ ⵢⵉⵙⴻⵎⴰ ⵢⵍⵍⴰ ⵢⴰⴽⴰⵏ.</translation>
     </message>
     <message>
         <source>Password protected profiles can&apos;t be automatically loaded.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⴼⴻⵔⴷⵉⵙⴻⵏ ⵢⴻⵜⵜⵡⴰⵃⴻⵔⵣⴻⵏ ⵙ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⵜⵜⵡⴰⴹⴻⴳⴳⵔⴻⵏ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ.</translation>
+        <translation type="unfinished">ⵉⵎⴰⴳⵏ ⵢⴻⵜⵜⵡⴰⵃⴻⵔⵣⴻⵏ ⵙ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⵜⵜⵡⴰⴹⴻⴳⴳⵔⴻⵏ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ.</translation>
     </message>
     <message>
         <source>There is no selected profile.
 
 You may want to create one.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵍⵍⵉ ⴰⵔⴰ ⵓⴼⴻⵔⴷⵉⵙ ⵢⴻⵜⵜⵡⴰⴼⴻⵔⵏⴻⵏ.
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵍⵍⵉ ⴰⵔⴰ ⵓⴳⵉⵍⴰⵍ ⵢⴻⵜⵜⵡⴰⴼⴻⵔⵏⴻⵏ.
 
 ⴰⴷ ⵜⴻⴱⵖⵓⴹ ⴰⴷ ⴷⵜⴻⵙⵏⵓⵍⴼⵓⴹ ⵢⵉⵡⴻⵏ.</translation>
     </message>
     <message>
         <source>Couldn&apos;t load this profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⴼⴻⴷ ⴰⴳⴰⴼⴰ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⴼⴻⴷ ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>This profile is already in use.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴻⵔⴷⵉⵙⴰ ⵢⴻⵍⵍⴰ ⵢⴰⴽⴰⵏ ⴷⴻⴳ ⵓⵙⴻⵇⴷⴻⵛ.</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍⴰ ⵢⵍⵍⴰ ⵢⴰⴽⴰⵏ ⴷⴻⴳ ⵓⵙⴻⵇⴷⴻⵛ.</translation>
     </message>
     <message>
         <source>Wrong password.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵓⵔ ⵉⵚⴻⵃⵃⴰ ⴰⵔⴰ.</translation>
     </message>
     <message>
         <source>Import</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⵜⴻⵔ</translation>
+        <translation type="unfinished">ⵙⴽⵛⵎ</translation>
     </message>
     <message>
         <source>Username input field</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⴳⵔ ⵏ ⵓⵙⴻⴽⵛⴻⵎ ⵏ ⵢⵉⵙⴻⵎ ⵏ ⵓⵙⴻⵇⴷⴰⵛ</translation>
     </message>
     <message>
         <source>Password input field, you can leave it empty (no password), or type at least 6 characters</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵃⵔⵉⵛ ⵏ ⵓⵙⴻⴽⵛⴻⵎ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ, ⵜⵣⴻⵎⵔⴻⴹ ⴰⴷ ⵜⵜⴻⴵⴵⴻⴹ ⴷ ⵉⵍⴻⵎ (ⵓⵍⴰⵛ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ), ⵏⴻⵖ ⴰⴷ ⵜⴰⵔⵓⴹ ⵎⴰ ⵓⵍⴰⵛ 6 ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ</translation>
     </message>
     <message>
         <source>Password confirmation field</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⴳⵔ ⵏ ⵓⵙⴻⵖⵜⵉ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Create a new profile button</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⵜⴰⵖⴻⵛⵜ ⵏ ⵓⴼⴰⵢⵍⵓ ⴰⵎⴰⵢⵏⵓⵜ</translation>
+        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⵜⴰⵖⴻⵛⵜ ⵏ ⵓⴳⵉⵍⴰⵍ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Profile list</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵎⵓⵖ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
+        <translation type="unfinished">ⵓⵎⵓⵖ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>List of profiles</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵎⵓⵖ ⵏ ⵡⵓⴷⵎⴰⵡⴻⵏ</translation>
+        <translation type="unfinished">ⵓⵎⵓⵖ ⵏ ⵉⵎⴰⴳⵏ</translation>
     </message>
     <message>
         <source>Password input</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Load automatically checkbox</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⵜⴰⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵙⴻⴽⵍⴻⵙ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
     </message>
     <message>
         <source>Import profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⴰⵙⴽⵛⵎ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Load selected profile button</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⵜⴰⵙⴼⵉⴼⵜ ⵏ ⵓⴳⴱⵓⵔ ⵢⴻⵜⵜⵡⴰⴼⴻⵔⵏⴻⵏ</translation>
+        <translation type="unfinished">ⵛⴻⴱⴱⴻⵃ ⵜⴰⵙⴼⵉⴼⵜ ⵏ ⵓⴳⵉⵍⴰⵍ ⵢⴻⵜⵜⵡⴰⴼⴻⵔⵏⴻⵏ</translation>
     </message>
     <message>
         <source>New profile creation page</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴱⵜⴻⵔ ⵏ ⵓⵙⵏⵓⵍⴼⵓ ⵏ ⵓⴳⴱⵓⵔ ⴰⵎⴰⵢⵏⵓⵜ</translation>
+        <translation type="unfinished">ⴰⵙⴻⴱⵜⴻⵔ ⵏ ⵓⵙⵏⵓⵍⴼⵓ ⵏ ⵓⴳⵉⵍⴰⵍ ⴰⵎⴰⵢⵏⵓⵜ</translation>
     </message>
     <message>
         <source>Loading existing profile page</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵓⵙⴻⴱⵜⴻⵔ ⵏ ⵓⴳⴱⵓⵔ ⵢⴻⵍⵍⴰⵏ ⵢⴰⴽⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵙⴰⵍⵉ ⵏ ⵓⵙⴻⴱⵜⴻⵔ ⵏ ⵓⴳⵉⵍⴰⵍ ⵢⴻⵍⵍⴰⵏ ⵢⴰⴽⴰⵏ</translation>
     </message>
     <message>
         <source>The passwords you&apos;ve entered are different.
 Please make sure to enter the same password twice.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍⴻⵏ ⵓⴼⴼⵉⵔⴻⵏ ⵉ ⵜⴻⵙⵙⴻⴽⵛⴻⵎⴹ ⵎⵅⴰⵍⵍⴰⴼⴻⵏ.
 ⵜⵜⵅⵉⵍ ⴹⴻⵎⵏⴻⴹ ⴰⴷ ⵜⴻⵙⵙⴻⴽⵛⴻⵎⴹ ⵢⵉⵡⴻⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵙⵏⴰⵜ ⵏ ⵜⵉⴽⴽⴰⵍ.</translation>
     </message>
@@ -1967,15 +1645,13 @@ Please make sure to enter the same password twice.</source>
         <source>This optional password is used to encrypt local message data and your profile.
 If you lose this password, there is no way to recover it.
 Press Shift+F1 for more information.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔⴰⴳⵉ ⵏ ⵜⴼⴻⵔⴽⵉⵜ ⵢⴻⵜⵜⵡⴰⵙⴻⵇⴷⴻⵛ ⵉ ⵓⵙⴻⴽⵍⴻⵙ ⵏ ⵢⵉⵙⴻⴼⴽⴰ ⵏ ⵢⵉⵣⴻⵏ ⴰⴷⵉⴳⴰⵏ ⴷ ⵓⴼⴻⵔⴷⵉⵙⵉⴽ.
 ⵎⴰ ⵜⴻⵙⵄⴻⴷⴷⴰⴹ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔⴰⴳⵉ, ⵓⵍⴰⵛ ⴰⵎⴻⴽ ⴰⵔⴰ ⵜⵉⴷⵜⴻⵔⵔⴻⴹ.
 ⵜⵜⴹⴻⴳⴳⵉⵔ Shift+F1 ⵉ ⵓⴳⴰⵔ ⵏ ⵢⵉⵙⴰⵍⵍⴻⵏ.</translation>
     </message>
     <message>
         <source>The password you enter here is optional and encrypts message data and your Tox secret key. It does not encrypt files received. Your profile data is never sent to any servers. This is not a remote login, it&apos;s local to your computer only. qTox developers won&apos;t be able to recover your password if lost.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵔⴰ ⵜⴻⵙⵙⴻⴽⵛⴻⵎⴹ ⴷⴰⴳⵉ ⴷ ⴰⴼⴻⵔⴷⵉⵙ ⵢⴻⵔⵏⴰ ⵢⴻⵜⵜⵚⴻⵔⵔⵉⴼ ⵉⵙⴻⴼⴽⴰ ⵏ ⵢⵉⵣⴻⵏ ⴷ ⵜⵎⴻⵥⴷⵉⵜⵉⴽ ⵏ ⵜⵓⴼⴼⵔⴰ ⵏ Tox. ⵓⵔ ⵢⴻⵜⵜⵛⴻⴳⴳⵉⵄ ⴰⵔⴰ ⵉⴼⵓⵢⵍⴰ ⵉ ⴷⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⵏ. ⵉⵙⴻⴼⴽⴰ ⵏ ⵓⴼⴻⵔⴷⵉⵙⵉⴽ ⵓⵔ ⵜⵜⵡⴰⵣⴻⵏ ⴰⵔⴰ ⵖⴻⵔ ⴽⵔⴰ ⵏ ⵢⵉⵇⴻⴷⴷⴰⵛⴻⵏ. ⵡⴰⴳⵉ ⵎⴰⵞⵞⵉ ⴷ ⴰⵙⴻⴽⵛⴻⵎ ⵙ ⵜⵖⴻⵔⵖⴻⵔⵜ, ⴷ ⴰⴷⵉⴳⴰⵏ ⵉ ⵓⵙⴻⵍⴽⵉⵎⵉⴽ ⴽⴰⵏ. ⵉⵎⵙⵓⴷⴷⵙⴻⵏ ⵏ qTox ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⴷⵙⴼⴰⵢⴷⵉⵏ ⵙⴻⴳ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔⵉⴽ ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵖⵍⵉ.</translation>
+        <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵔⴰ ⵜⴻⵙⵙⴻⴽⵛⴻⵎⴹ ⴷⴰⴳⵉ ⴷ ⴰⴳⵉⵍⴰⵍ ⵢⴻⵔⵏⴰ ⵢⴻⵜⵜⵚⴻⵔⵔⵉⴼ ⵉⵙⴻⴼⴽⴰ ⵏ ⵢⵉⵣⴻⵏ ⴷ ⵜⵎⴻⵥⴷⵉⵜⵉⴽ ⵏ ⵜⵓⴼⴼⵔⴰ ⵏ Tox. ⵓⵔ ⵢⴻⵜⵜⵛⴻⴳⴳⵉⵄ ⴰⵔⴰ ⵉⴼⵓⵢⵍⴰ ⵉ ⴷⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⵏ. ⵉⵙⴻⴼⴽⴰ ⵏ ⵓⴼⴻⵔⴷⵉⵙⵉⴽ ⵓⵔ ⵜⵜⵡⴰⵣⴻⵏ ⴰⵔⴰ ⵖⴻⵔ ⴽⵔⴰ ⵏ ⵢⵉⵇⴻⴷⴷⴰⵛⴻⵏ. ⵡⴰⴳⵉ ⵎⴰⵞⵞⵉ ⴷ ⴰⵙⴻⴽⵛⴻⵎ ⵙ ⵜⵖⴻⵔⵖⴻⵔⵜ, ⴷ ⴰⴷⵉⴳⴰⵏ ⵉ ⵓⵙⴻⵍⴽⵉⵎⵉⴽ ⴽⴰⵏ. ⵉⵎⵙⵓⴷⴷⵙⴻⵏ ⵏ qTox ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⴷⵙⴼⴰⵢⴷⵉⵏ ⵙⴻⴳ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔⵉⴽ ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵖⵍⵉ.</translation>
     </message>
     <message>
         <source>Password input field, minimum 6 characters long</source>
@@ -1986,136 +1662,111 @@ Press Shift+F1 for more information.</source>
     <name>MainWindow</name>
     <message>
         <source>Your name</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴻⵎ ⵏⵏⴽ</translation>
     </message>
     <message>
         <source>Your status</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴷⴷⵓⴷⵉⴽ</translation>
     </message>
     <message>
         <source>Create a conference</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⴰⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>View completed file transfers</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵡⴰⵍⵉ ⴰⵙⵉⵡⴻⴹ ⵏ ⵓⴼⴰⵢⵍⵓ ⵢⴻⵜⵜⵡⴰⴽⴻⵎⵍⴻⵏ</translation>
+        <translation type="unfinished">ⵥⵔ ⵉⵙⵉⵡⴹⵏ ⵏ ⵉⴼⵓⵢⵍⴰ ⵉⵎⴷⵏ</translation>
     </message>
     <message>
         <source>Change your settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵖⵡⴰⵏⵉⴽ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⵉⵙⵖⵡⴰⵕⵏ ⵉⵏⴽ</translation>
     </message>
     <message>
         <source>Close</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵖⵍⴻⵇ</translation>
+        <translation type="unfinished">ⵎⴷⵍ</translation>
     </message>
     <message>
         <source>Open profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Open profile page when clicked</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴻⴱⵜⴻⵔ ⵏ ⵓⴼⴻⵔⴷⵉⵙ ⵎⵉ ⴰⵔⴰ ⵜⵜⴽⴻⵛⵎⴻⴹ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴱⵜⵔ ⵏ ⵓⴳⵉⵍⴰⵍ ⵎⵉ ⴰⵔⴰ ⵜⴽⵍⵉⴽⵉⴷ</translation>
     </message>
     <message>
         <source>Status message input</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵢⵉⵣⴻⵏ ⵏ ⵜⴻⴳⵏⵉⵜ</translation>
     </message>
     <message>
         <source>Set your status message that will be shown to others</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴱⴻⴷⴷ ⵉⵣⴻⵏ ⵏ ⵜⴻⴳⵏⵉⵜⵉⴽ ⴰⵔⴰ ⴷⵢⴻⵜⵜⵡⴰⵙⴱⴻⴳⵏⴻⵏ ⵉ ⵡⵉⵢⴰⴹ</translation>
     </message>
     <message>
         <source>Status</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵍⵖⴰ</translation>
+        <translation type="unfinished">ⴰⴷⴷⴰⴷ</translation>
     </message>
     <message>
         <source>Set availability status</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴱⴻⴷⴷ ⴰⴷⴻⴳ ⵏ ⵜⵉⵍⵉⵏ</translation>
+        <translation type="unfinished">ⵙⴱⴻⴷⴷ ⴰⴷⴷⴰⴷ ⵏ ⵜⵉⵍⵉⵏ</translation>
     </message>
     <message>
         <source>Contact search</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵏⴰⴷⵉ ⵏ ⵓⵙⵉⵡⴻⴹ</translation>
+        <translation type="unfinished">ⴰⵔⵣⵣⵓ ⵖⴼ ⵓⵏⴻⵔⵎⵉⵙ</translation>
     </message>
     <message>
         <source>Contact search input for known friends</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵓⵏⴰⴷⵉ ⵖⴻⴼ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ ⵢⴻⵜⵜⵡⴰⵙⵏⴻⵏ</translation>
+        <translation type="unfinished">ⴰⴽⵛⴰⵎ ⵏ ⵓⵔⵣⵣⵓ ⵖⴼ ⵉⵎⴷⴷⵓⴽⴽⴰⵍ ⵉⵜⵜⵡⴰⵙⵙⵏⵏ</translation>
     </message>
     <message>
         <source>Sorting and visibility</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⵔⴰⵏ ⴷ ⵜⵎⵓⵖⵍⵉ</translation>
+        <translation type="unfinished">ⴰⵙⵎⵉⵍ ⴷ ⵜⵎⵓⵖⵍⵉ</translation>
     </message>
     <message>
         <source>Set friends sorting and visibility</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴱⴻⴷⴷ ⵉⵎⴷⵓⴽⴰⵍ ⴰⴼⵔⴰⵏ ⴷ ⵜⵎⵓⵖⵍⵉ</translation>
+        <translation type="unfinished">ⵙⴱⴷⴷ ⴰⵙⵎⵉⵍ ⴷ ⵜⵎⵓⵖⵍⵉ ⵏ ⵉⵎⴷⴷⵓⴽⴽⴰⵍ</translation>
     </message>
     <message>
         <source>Open Add friends page</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴻⴱⵜⴻⵔ Rnu ⵉⵎⴷⵓⴽⴰⵍ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴱⵜⵔ ⵏ ⵜⵎⵔⵏⵉⵡⵜ ⵏ ⵉⵎⴷⴷⵓⴽⴽⴰⵍ</translation>
     </message>
     <message>
         <source>Conference</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>Open conference management page</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴻⴱⵜⴻⵔ ⵏ ⵓⵙⴻⵍⵃⵓ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴱⵜⵔ ⵏ ⵓⵙⵡⵓⴷⴷⵓ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>File transfers history</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵓⵙⵉⵡⴻⴹ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
+        <translation type="unfinished">ⴰⵎⵣⵔⵓⵢ ⵏ ⵉⵙⵉⵡⴹⵏ ⵏ ⵉⴼⵓⵢⵍⴰ</translation>
     </message>
     <message>
         <source>Open File transfers history</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵓⵙⵉⵡⴻⴹ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵎⵣⵔⵓⵢ ⵏ ⵉⵙⵉⵡⴹⵏ ⵏ ⵉⴼⵓⵢⵍⴰ</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵖⵥⴰⵏ</translation>
+        <translation type="unfinished">ⵉⵙⵖⵡⴰⵕⵏ</translation>
     </message>
     <message>
         <source>Open Settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⵉⵙⴻⵖⵡⴰⵏ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⵉⵙⵖⵡⴰⵕⵏ</translation>
     </message>
     <message>
         <source>Open internal debugging tools</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⴰⵍⵍⴰⵍⴻⵏ ⵏ ⵓⵙⴻⴳⴳⴻⵎ ⵏ ⴷⴰⵅⴻⵍ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵍⵍⴰⵍⵏ ⵏ ⵜⵙⵖⵉⵢⵜ ⵜⴰⴳⵏⵙⴰⵏⵜ</translation>
     </message>
     <message>
         <source>Debug</source>
-        <translation type="unfinished">ⴷⴻⴱⵓⴳ</translation>
+        <translation type="unfinished">ⵜⴰⵙⵖⵉⵢⵜ</translation>
     </message>
     <message>
         <source>Open Debugger</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ Asenqed</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵎⵙⵖⴰⵢ</translation>
     </message>
     <message>
         <source>Add friend</source>
-        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ</translation>
+        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴷⴷⴰⴽⴽⵍ</translation>
     </message>
 </context>
 <context>
@@ -2135,15 +1786,15 @@ Press Shift+F1 for more information.</source>
     <name>NetCamView</name>
     <message>
         <source>Tox video</source>
-        <translation type="unfinished">vidyu ⵏ Tux</translation>
+        <translation type="unfinished">ⴰⴼⵉⴷⵢⵓ ⵏ Tox</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation type="unfinished">ⴰⵙⴻⴽⴽⵉⵍ ⴰⴽⴻⵎⵎⴰⵍⵉ</translation>
+        <translation type="unfinished">ⴰⴳⴷⵉⵍ ⴰⴽⵎⵎⴰⵍ</translation>
     </message>
     <message>
         <source>Toggle video preview</source>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⴰⵙⴻⴽⵍⴻⵙ ⵏ vidyu</translation>
+        <translation type="unfinished">ⴰⵙⴽⵏ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Mute audio</source>
@@ -2151,24 +1802,22 @@ Press Shift+F1 for more information.</source>
     </message>
     <message>
         <source>Mute microphone</source>
-        <translation type="unfinished">ⵙⵙⵓⵙⵎ ⴰⵎⵉⴽⵔⵓⴼⵓⵏ</translation>
+        <translation type="unfinished">ⵙⵙⵓⵙⵎ ⴰⵙⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>End video call</source>
-        <translation type="unfinished">ⴽⴻⵎⵎⴻⵍ ⴰⵙⵉⵡⴻⵍ ⵙ vidyu</translation>
+        <translation type="unfinished">ⴼⴽⴽ ⴰⵙⵉⵡⵍ ⵏ ⵓⴼⵉⴷⵢⵓ</translation>
     </message>
     <message>
         <source>Exit full screen</source>
-        <translation type="unfinished">ⵜⵓⴼⴼⵖⴰ ⵏ ⵓⵙⴻⴽⴽⵉⵍ ⴰⴽⴽ</translation>
+        <translation type="unfinished">ⴼⴼⵖ ⵙⴳ ⵓⵙⴽⴽⵉⵍ ⴰⴽⴽ</translation>
     </message>
     <message>
         <source>Hide messages</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴼⴼⴻⵔ ⵉⵣⴻⵏ</translation>
     </message>
     <message>
         <source>Show messages</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴽⴻⵏⴷ ⵉⵣⴻⵏ</translation>
     </message>
 </context>
@@ -2177,46 +1826,39 @@ Press Shift+F1 for more information.</source>
     <message>
         <source>View</source>
         <comment>macOS Menu bar</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵏⵏⴰⵢⵜ</translation>
     </message>
     <message>
         <source>Window</source>
         <comment>macOS Menu bar</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵟⵟⴰⵇ</translation>
     </message>
     <message>
         <source>Minimize</source>
         <comment>macOS Menu bar</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵏⴻⵇⵙ</translation>
     </message>
     <message>
         <source>Bring All to Front</source>
         <comment>macOS Menu bar</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⵉⴷ ⴰⴽⴽ ⵖⴻⵔ ⵣⴷⴰⵜ</translation>
     </message>
     <message>
         <source>Exit Full Screen</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵓⴼⴼⵖⴰ ⵙⴻⴳ ⵓⵙⴻⴽⴽⵉⵍ ⴰⴽⴽ</translation>
+        <translation type="unfinished">ⴼⴼⵖ ⵙⴳ ⵓⴳⴷⵉⵍ ⴰⴽⵎⵎⴰⵍ</translation>
     </message>
     <message>
         <source>Enter Full Screen</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⵛⴻⵎ ⴰⵙⴻⴽⴽⵉⵍ ⴰⴽⴽ</translation>
+        <translation type="unfinished">ⴽⵛⵎ ⵖⵔ ⵓⴳⴷⵉⵍ ⴰⴽⵎⵎⴰⵍ</translation>
     </message>
 </context>
 <context>
     <name>NotificationEdgeWidget</name>
     <message numerus="yes">
         <source>Unread message(s)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">
-            <numerusform>ⵉⵣⴻⵏ (ⵏ) ⵓⵔ ⵢⴻⵜⵜⵡⴰⵖⵔⴻⵏ ⴰⵔⴰ</numerusform>
-            <numerusform></numerusform>
+            <numerusform>%n ⵢⵉⵣⴻⵏ ⵓⵔ ⵢⴻⵜⵜⵡⴰⵖⵔⴻⵏ ⴰⵔⴰ</numerusform>
+            <numerusform>%n ⵢⵉⵣⵏⴰⵏ ⵓⵔ ⵢⴻⵜⵜⵡⴰⵖⵔⴻⵏ ⴰⵔⴰ</numerusform>
         </translation>
     </message>
 </context>
@@ -2237,30 +1879,26 @@ Press Shift+F1 for more information.</source>
     <message>
         <source>%1 - file transfer</source>
         <extracomment>e.g. Bob - file transfer</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 - ⴰⵙⵉⵡⴻⴹ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Conference invite received</source>
-        <translation type="unfinished">ⵢⴻⵡⵡⴻⴹⴷ ⵓⵏⴻⵄⵔⴻⴹ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
+        <translation type="unfinished">ⵜⴰⵏⴱⴳⵉⵡⵜ ⵏ ⵓⵙⴰⵔⴰⴳ ⵜⴻⵡⵡⴻⴹⴷ</translation>
     </message>
     <message>
         <source>%1 invites you to join a conference.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 ⵢⴻⵜⵜⵛⴻⴳⴳⵉⵄⵉⴽ ⴰⴷ ⵜⴽⴻⵛⵎⴻⴹ ⴷⴻⴳ ⵓⵙⴰⵔⴰⴳ.</translation>
+        <translation type="unfinished">%1 ⵢⴻⵜⵜⵙⵏⵓⴱⴳⵓⴽ ⴰⴷ ⵜⴽⴻⵛⵎⴻⴹ ⴷⴻⴳ ⵓⵙⴰⵔⴰⴳ.</translation>
     </message>
     <message>
         <source>Friend request received</source>
-        <translation type="unfinished">ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ ⵢⴻⵡⵡⴻⴹⴷ</translation>
+        <translation type="unfinished">ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵢⴻⵡⵡⴻⴹⴷ</translation>
     </message>
     <message>
         <source>Friend request received from %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ ⵢⴻⵡⵡⴻⴹⴷ ⵙⴻⴳ %1.</translation>
+        <translation type="unfinished">ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵢⴻⵡⵡⴻⴹⴷ ⵙⴻⴳ %1.</translation>
     </message>
     <message>
         <source>Incoming call</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵉⵖⵔⵉ ⵉⴷ ⵉⴽⴻⵞⵞⵎⴻⵏ</translation>
     </message>
 </context>
@@ -2268,7 +1906,6 @@ Press Shift+F1 for more information.</source>
     <name>PasswordEdit</name>
     <message>
         <source>Caps-lock enabled</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵉⵎⴻⵇⵇⵔⴰⵏⴻⵏ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ</translation>
     </message>
 </context>
@@ -2276,18 +1913,15 @@ Press Shift+F1 for more information.</source>
     <name>PrivacyForm</name>
     <message>
         <source>Privacy</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⴱⴰⴷⵏⵉⵜ</translation>
     </message>
     <message>
         <source>Confirmation</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵖⵜⵉ</translation>
+        <translation type="unfinished">ⴰⵙⴷⴷⵉⴷ</translation>
     </message>
     <message>
         <source>Do you want to permanently delete all chat history?</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⵙⴼⴻⴹ ⴰⴽⴽ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵉ ⵍⴻⴱⴷⴰ?</translation>
+        <translation type="unfinished">ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⵙⴼⴻⴹ ⴰⴽⴽ ⴰⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ ⵉ ⵍⴻⴱⴷⴰ?</translation>
     </message>
 </context>
 <context>
@@ -2295,67 +1929,56 @@ Press Shift+F1 for more information.</source>
     <message>
         <source>Your friends will be able to see when you are typing.</source>
         <comment>tooltip for typing notifications setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴷ ⵣⴻⵎⵔⴻⵏ ⵉⵎⴷⴷⵓⴽⴽⴰⵍ ⵏⵏⴻⴽ ⴰⴷ ⵡⴰⵍⵉⵏ ⵎⵉ ⴰⵔⴰ ⵜⵜⴰⵔⵓⴹ.</translation>
     </message>
     <message>
         <source>Send typing notifications</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵣⴻⵏ ⵉⵙⴻⴱⵜⴰⵔ ⵏ ⵜⵉⵔⴰ</translation>
+        <translation type="unfinished">ⴰⵣⵏ ⵜⵉⵏⴱⴱⴰⴹⵉⵏ ⵏ ⵜⵉⵔⴰ</translation>
     </message>
     <message>
         <source>Keep chat history</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵃⵔⴻⵣ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ</translation>
+        <translation type="unfinished">ⵃⵔⵣ ⴰⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>NoSpam is part of your Tox ID.
 If you are being spammed with friend requests, you should change your NoSpam.
 People will be unable to add you with your old ID, but you will keep your current friends.</source>
         <comment>toolTip for nospam</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">NoSpam ⴷ ⴰⵃⵔⵉⵛ ⵙⴻⴳ Tox IDik.
-ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⵜⵡⴰⵛⴻⴳⴳⵄⴻⴹ ⵙ ⵢⵉⵙⵓⵜⴰⵔ ⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ, ⵢⴻⵙⵙⴻⴼⴽ ⴰⴷ ⵜⴱⴻⴷⴷⴻⵍⴻⴹ NoSpamik.
+ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⵜⵡⴰⵛⴻⴳⴳⵄⴻⴹ ⵙ ⵢⵉⵙⵓⵜⴰⵔ ⵏ ⵢⵉⵎⴷⴷⵓⴽⴽⴰⵍ, ⵢⴻⵙⵙⴻⴼⴽ ⴰⴷ ⵜⵙⵏⴼⵍⴷ NoSpamik.
 ⵉⵎⴷⴰⵏⴻⵏ ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⴽⵔⵏⵓⵏ ⵙ ⵜⵎⴰⴳⵉⵜⵉⴽ ⵜⴰⵇⴱⵓⵔⵜ, ⵎⴰⵛⴰ ⴰⴷ ⵜⴻⵟⵟⴼⴻⴹ ⵉⵎⴷⵓⴽⴰⵍⵉⴽ ⵏ ⵜⵓⵔⴰ.</translation>
     </message>
     <message>
         <source>NoSpam</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵍⴰⵛ Aspam</translation>
+        <translation type="unfinished">NoSpam</translation>
     </message>
     <message>
         <source>NoSpam is a part of your ID that can be changed at will.
 If you are getting spammed with friend requests, change the NoSpam.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">NoSpam ⴷ ⴰⵃⵔⵉⵛ ⵙⴻⴳ IDik ⵉⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵢⴻⵜⵜⵡⴰⴱⴻⴷⴷⴻⵍ ⵙ ⵍⴻⴱⵖⵉⴽ.
-ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⴹ ⵙ spam ⵙ ⵢⵉⵙⵓⵜⴰⵔ ⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ, ⴱⴻⴷⴷⴻⵍ NoSpam.</translation>
+        <translation type="unfinished">NoSpam ⴷ ⴰⵃⵔⵉⵛ ⵙⴻⴳ IDik ⵉⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵢⴻⵜⵜⵡⴰⵙⵏⴼⵍ ⵙ ⵍⴻⴱⵖⵉⴽ.
+ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⴹ ⵙ spam ⵙ ⵢⵉⵙⵓⵜⴰⵔ ⵏ ⵢⵉⵎⴷⴷⵓⴽⴽⴰⵍ, ⵙⵏⴼⵍ NoSpam.</translation>
     </message>
     <message>
         <source>Generate random NoSpam</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓ NoSpam ⵙ ⵓⴼⵓⵙ</translation>
+        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓ NoSpam ⴰⴳⴰⵛⵓⵔ</translation>
     </message>
     <message>
         <source>Chat history keeping is still in development.
 Save format changes are possible, which may result in data loss.</source>
         <comment>toolTip for Keep History setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵃⵔⴰⵣ ⵏ ⵓⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵎⴰⵣⴰⵍⵉⵜ ⴷⴻⴳ ⵓⵙⵏⴻⵔⵏⵉ.
-ⵉⴱⴻⴷⴷⴰⵍⴻⵏ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵙⴻⵍⴽⴻⵎ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⴷⵉⵍⵉⵏ, ⴰⵢⴰ ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⴷⵢⴻⴳⵍⵓ ⵙ ⵜⵎⴻⵜⵜⴰⵏⵜ ⵏ ⵢⵉⵙⴻⴼⴽⴰ.</translation>
+        <translation type="unfinished">ⴰⵃⵔⴰⵣ ⵏ ⵓⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ ⵎⴰⵣⴰⵍⵉⵜ ⴷⴻⴳ ⵓⵙⵏⴻⵔⵏⵉ.
+ⵉⴱⴻⴷⴷⴰⵍⴻⵏ ⵏ ⵜⴰⵍⵖⴰ ⵏ ⵓⵃⵔⴰⵣ ⵣⴻⵎⵔⴻⵏ ⴰⴷ ⴷⵉⵍⵉⵏ, ⴰⵢⴰ ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⴷⵢⴻⴳⵍⵓ ⵙ ⵜⵎⴻⵜⵜⴰⵏⵜ ⵏ ⵢⵉⵙⴻⴼⴽⴰ.</translation>
     </message>
     <message>
         <source>Privacy</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⴱⴰⴷⵏⵉⵜ</translation>
     </message>
     <message>
         <source>Conference block list</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵎⵓⵖ ⵏ ⵓⵃⵔⵉⵛ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
+        <translation type="unfinished">ⵜⴰⵍⴳⴰⵎⵜ ⵏ ⵉⵙⴰⵔⴰⴳⵏ ⵉⵜⵜⵡⴰⴳⴷⵍⵏ</translation>
     </message>
     <message>
         <source>Filter out conference messages by conference members&apos; public keys. Put public keys here, one per line.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴼⵉⵍⵜⴻⵔ ⵉⵣⴻⵏ ⵏ ⵓⵙⴰⵔⴰⴳ ⵙ ⵢⵉⵙⴰⵔⵓⵜⴻⵏ ⵉⵏⴰⴳⴷⵓⴷⴻⵏ ⵏ ⵢⵉⵄⴻⴳⴳⴰⵍⴻⵏ ⵏ ⵓⵙⴰⵔⴰⴳ. ⵙⵙⴻⵔⵙ ⵜⵉⵙⴰⵔⵓⵜⵉⵏ ⵜⵉⵏⴰⴳⴷⵓⴷⵉⵏ ⴷⴰⴳⵉ, ⵢⵉⵡⴻⵜ ⵉ ⵢⴰⵍ ⴰⴹⵔⵉⵙ.</translation>
     </message>
 </context>
@@ -2363,236 +1986,194 @@ Save format changes are possible, which may result in data loss.</source>
     <name>Profile</name>
     <message>
         <source>Failed to derive key from password, the profile won&apos;t use the new password.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⴷⵢⴻⵙⵙⵓⴼⴼⴻⵖ ⵜⴰⵙⴰⵔⵓⵜ ⵙⴻⴳ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ, ⴰⴼⴻⵔⴷⵉⵙ ⵓⵔ ⵢⴻⵙⵙⴻⵇⴷⴰⵛ ⴰⵔⴰ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵎⴰⵢⵏⵓⵜ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⴷⵢⴻⵙⵙⵓⴼⴼⴻⵖ ⵜⴰⵙⴰⵔⵓⵜ ⵙⴻⴳ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ, ⴰⴳⵉⵍⴰⵍ ⵓⵔ ⵢⴻⵙⵙⴻⵇⴷⴰⵛ ⴰⵔⴰ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵎⴰⵢⵏⵓⵜ.</translation>
     </message>
     <message>
         <source>Toxing on qTox</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵓⴽⵙⵉⵏⴳ ⵖⴻⴼ qTox</translation>
     </message>
     <message>
         <source>Couldn&apos;t change database password, it may be corrupted or use the old password.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⴱⴻⴷⴷⴻⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵜⴱⴰⴹⵏⵉⵜ, ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⵉⵍⵉ ⵢⴻⵖⵍⵉ ⵏⴻⵖ ⵢⴻⵙⵙⴻⵇⴷⴻⵛ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵇⴱⵓⵔ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⵙⵏⴼⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵜⴱⴰⴹⵏⵉⵜ, ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⵉⵍⵉ ⵢⴻⵖⵍⵉ ⵏⴻⵖ ⵢⴻⵙⵙⴻⵇⴷⴻⵛ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵇⴱⵓⵔ.</translation>
     </message>
 </context>
 <context>
     <name>ProfileForm</name>
     <message>
         <source>Choose a profile picture</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴼⵔⴻⵏ ⵜⵓⴳⵏⴰ ⵏ ⵓⴼⴻⵔⴷⵉⵙ</translation>
+        <translation type="unfinished">ⴼⵔⵏ ⵜⴰⵡⵍⴰⴼⵜ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Error</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵓⵛⵛⴹⴰ</translation>
     </message>
     <message>
         <source>Rename &quot;%1&quot;</source>
         <comment>renaming a profile</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵎ ⵏ &quot;%1&quot;</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⵉⵙⴻⵎ ⵏ &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Unable to open this file.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ ⴰⴼⴰⵢⵍⵓⴰ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵉⵣⵎⵉⵔ ⴰⴷ ⵉⵍⴷⵉ ⴰⴼⴰⵢⵍⵓ ⴰ.</translation>
     </message>
     <message>
         <source>Current profile: </source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵏ ⵜⵓⵔⴰ:</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵏ ⵜⵓⵔⴰ: </translation>
     </message>
     <message>
         <source>Remove</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ</translation>
+        <translation type="unfinished">ⴽⴽⵙ</translation>
     </message>
     <message>
         <source>Unable to read this image.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵖⵔⴻⴹ ⵜⵓⴳⵏⴰⴰ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵉⵣⵎⵉⵔ ⴰⴷ ⵉⵖⵔ ⵜⴰⵡⵍⴰⴼⵜ ⴰ.</translation>
     </message>
     <message>
         <source>The supplied image is too large.
 Please use another image.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵓⴳⵏⴰ ⵉ ⴷⵢⴻⵜⵜⵓⵏⴻⴼⴽⴻⵏ ⵎⴻⵇⵇⴻⵔ ⴰⵟⴰⵙ.
-ⵜⵜⵅⵉⵍⴽ ⵙⵙⴻⵇⴷⴻⵛ ⵜⵓⴳⵏⴰ ⵏⵏⵉⴹⴻⵏ.</translation>
+        <translation type="unfinished">ⵜⴰⵡⵍⴰⴼⵜ ⵉ ⴷ-ⵉⵜⵜⵓⴼⴽⴰⵏ ⵎⵇⵇⵔ ⴱⴰⵀⵔⴰ.
+ⵜⵜⵅⵉⵍⴽ ⵙⵙⵎⵔⵙ ⵜⴰⵡⵍⴰⴼⵜ ⵏⵉⴹⵏ.</translation>
     </message>
     <message>
         <source>Couldn&apos;t rename the profile to &quot;%1&quot;</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵎ ⵏ ⵓⴼⴰⵢⵍⵓ ⵖⴻⵔ &quot;%1&quot;.</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⵙⵏⴼⵍ ⵉⵙⴻⵎ ⵏ ⵓⴳⵉⵍⴰⵍ ⵖⴻⵔ &quot;%1&quot;.</translation>
     </message>
     <message>
         <source>Nothing to remove</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵍⴰⵛ ⴷ ⴰⵛⵓ ⴰⵔⴰ ⵏⴻⴽⴽⴻⵙ</translation>
+        <translation type="unfinished">ⵓⵍⴰⵛ ⵎⴰ ⴰⴷ ⵉⵜⵜⵡⴰⴽⴽⵙ</translation>
     </message>
     <message>
         <source>Your profile does not have a password!</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴻⵔⴷⵉⵙⵉⴽ ⵓⵔ ⵢⴻⵙⵄⵉ ⴰⵔⴰ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ!</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵉⵏⴽ ⵓⵔ ⵢⵙⵄⵉ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ!</translation>
     </message>
     <message>
         <source>Please enter a new password.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵜⵅⵉⵍⴽ ⵙⴻⴽⵛⴻⵎ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵎⴰⵢⵏⵓⵜ.</translation>
+        <translation type="unfinished">ⵜⵜⵅⵉⵍⴽ ⵙⵙⴽⵛⵎ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵜⴰⵎⴰⵢⵏⵓⵜ.</translation>
     </message>
     <message>
         <source>Are you sure you want to delete this profile?</source>
         <comment>deletion confirmation text</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵃⴻⵇⵇⴻⴷ ⴱⴻⵍⵍⵉ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⴽⴽⵙⴻⴹ ⴰⴽⴰⵔⴰⵎⴰ?</translation>
+        <translation type="unfinished">ⵉⵙ ⵜⵙⵙⵉⴷⵜⴷ ⵉⵙ ⵜⴱⵖⵉⴷ ⴰⴷ ⵜⴽⴽⵙⴷ ⴰⴳⵉⵍⴰⵍ ⴰ?</translation>
     </message>
     <message>
         <source>Save</source>
         <comment>save qr image</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵍⴽⴻⵜ</translation>
+        <translation type="unfinished">ⵃⵔⵣ</translation>
     </message>
     <message>
         <source>Save QrCode (*.png)</source>
         <comment>save dialog filter</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵃⵔⴻⵣ ⴰⴽⴰⵔⴰⵎ Qr (*.png)</translation>
+        <translation type="unfinished">ⵃⵔⵣ QrCode (*.png)</translation>
     </message>
     <message>
         <source>Files could not be deleted!</source>
         <comment>deletion failed title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⵜⵜⵡⴰⴽⴽⵙⴻⵏ ⵉⴼⵓⵢⵍⴰ!</translation>
+        <translation type="unfinished">ⵉⴼⵓⵢⵍⴰ ⵓⵔ ⵣⵎⵉⵔⵏ ⴰⴷ ⵜⵜⵡⴰⴽⴽⵙⵏ!</translation>
     </message>
     <message>
         <source>Change password</source>
         <comment>button text</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Set profile password</source>
         <comment>button text</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴱⴻⴷⴷ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⵙⴱⴷⴷ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Current profile location: %1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⴷⵖⴰⵔ ⵏ ⵓⴼⴰⵢⵍⵓ ⵏ ⵜⵓⵔⴰ: %1.</translation>
+        <translation type="unfinished">ⴰⴷⵖⴰⵔ ⵏ ⵓⴳⵉⵍⴰⵍ ⵏ ⵜⵓⵔⴰ: %1</translation>
     </message>
     <message>
         <source>Couldn&apos;t change password</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⴱⴻⴷⴷⴻⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
+        <translation type="unfinished">ⵓⵔ ⵉⵣⵎⵉⵔ ⴰⴷ ⵉⵙⵏⴼⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Empty path is unavailable</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴱⵔⵉⴷ ⵉⵍⴻⵎ ⵓⵔ ⵢⴻⵍⵍⵉ ⴰⵔⴰ</translation>
+        <translation type="unfinished">ⴰⴱⵔⵉⴷ ⵉⵍⵎ ⵓⵔ ⵢⵍⵍⵉ</translation>
     </message>
     <message>
         <source>Failed to rename</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵎ</translation>
+        <translation type="unfinished">ⴰⵔⵎⵎⵓⵙ ⵏ ⵓⵙⵏⴼⵍ ⵏ ⵢⵉⵙⵎ</translation>
     </message>
     <message>
         <source>Profile already exists</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴳⴱⵓⵔ ⵢⴻⵍⵍⴰ ⵢⴰⴽⴰⵏ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵢⵍⵍⴰ ⵢⴰⴽⴰⵏ</translation>
     </message>
     <message>
         <source>A profile named &quot;%1&quot; already exists.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴻⵔⴷⵉⵙ ⵙ ⵢⵉⵙⴻⵎ &quot;%1&quot; ⵢⴻⵍⵍⴰ ⵢⴰⴽⴰⵏ.</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵉⵙⵎ ⵏⵏⵙ &quot;%1&quot; ⵢⵍⵍⴰ ⵢⴰⴽⴰⵏ.</translation>
     </message>
     <message>
         <source>Empty name</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵉⵍⴻⵎ</translation>
+        <translation type="unfinished">ⵉⵙⵎ ⵉⵍⵎ</translation>
     </message>
     <message>
         <source>Empty name is unavailable</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴻⵎ ⵉⵍⴻⵎ ⵓⵔ ⵢⴻⵍⵍⵉ ⴰⵔⴰ</translation>
+        <translation type="unfinished">ⵉⵙⵎ ⵉⵍⵎ ⵓⵔ ⵢⵍⵍⵉ</translation>
     </message>
     <message>
         <source>Empty path</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴱⵔⵉⴷ ⴷ ⵉⵍⴻⵎ</translation>
+        <translation type="unfinished">ⴰⴱⵔⵉⴷ ⵉⵍⵎ</translation>
     </message>
     <message>
         <source>Export profile</source>
         <extracomment>save dialog title</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵓⴼⴻⵖ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⴰⵙⵓⴼⴻⵖ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Tox save file (*.tox)</source>
         <extracomment>save dialog filter</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵏ ⵓⵙⴻⵍⴽⴻⵎ ⵏ Tuks (*.tuks)</translation>
+        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵏ ⵓⵃⵔⴰⵣ ⵏ Tox (*.tox)</translation>
     </message>
     <message>
         <source>The following files could not be deleted:</source>
         <extracomment>deletion failed text part 1</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⴼⵓⵢⵍⴰⴰ ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⵜⵜⵡⴰⴽⴽⵙⴻⵏ:</translation>
     </message>
     <message>
         <source>Please manually remove them.</source>
         <extracomment>deletion failed text part 2</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵜⵅⵉⵍⴽ ⴽⴽⵙⴻⵜⵜⴻⵏ ⵙ ⵓⴼⵓⵙ.</translation>
     </message>
     <message>
         <source>Images (%1)</source>
         <comment>filetype filter</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵓⴳⵏⵉⵡⵉⵏ (%1)</translation>
     </message>
     <message>
         <source>Failed to save file</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵃⵔⴻⵣ ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>The file you chose could not be saved.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵉ ⵜⴼⴻⵔⵏⴻⴹ ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵜⵜⵡⴰⵃⵔⴻⵣ.</translation>
     </message>
     <message>
         <source>Empty path is unavailable.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴱⵔⵉⴷ ⵉⵍⴻⵎ ⵓⵔ ⵢⴻⵍⵍⵉ ⴰⵔⴰ.</translation>
     </message>
     <message>
         <source>Couldn&apos;t change database password, it may be corrupted or use the old password.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⴱⴻⴷⴷⴻⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵜⴱⴰⴹⵏⵉⵜ, ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⵉⵍⵉ ⵢⴻⵖⵍⵉ ⵏⴻⵖ ⵢⴻⵙⵙⴻⵇⴷⴻⵛ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵇⴱⵓⵔ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵉⵙⵏⴼⵍ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵜⴱⴰⴹⵏⵉⵜ, ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⵉⵍⵉ ⵢⴻⵖⵍⵉ ⵏⴻⵖ ⵢⴻⵙⵙⴻⵇⴷⴻⵛ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴰⵇⴱⵓⵔ.</translation>
     </message>
     <message>
         <source>Tox user names cannot exceed %1 characters.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⵎⴰⵡⴻⵏ ⵏ ⵢⵉⵙⴻⵇⴷⴰⵛⴻⵏ ⵏ Tox ⵓⵔ ⵣⵎⵉⵔⴻⵏ ⴰⵔⴰ ⴰⴷ ⵙⵙⵉⵡⴹⴻⵏ %1 ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ.</translation>
     </message>
     <message>
         <source>Delete profile</source>
         <comment>deletion confirmation title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Remove password</source>
         <comment>deletion confirmation title</comment>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Are you sure you want to remove your password?</source>
         <extracomment>deletion confirmation text</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴻⵜⵜⵡⴰⵍⵉⴹ ⴱⴻⵍⵍⵉ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⴽⴽⵙⴻⴹ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔⵉⴽ?</translation>
     </message>
     <message>
@@ -2600,7 +2181,6 @@ Please use another image.</source>
 Share it with your friends to begin chatting.
 
 This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">IDagi ⵢⴻⵜⵜⴰⴵⴵⴰ ⵉⵙⴻⵇⴷⴰⵛⴻⵏ ⵏⵏⵉⴹⴻⵏ ⵏ Tox ⴰⴷ ⵔⵏⵓⵏ ⵢⴻⵔⵏⴰ ⴰⴷ ⴽⵉⴷⵙⵙⵉⵡⴹⴻⵏ.
 ⴱⴹⵓⵜ ⴷ ⵉⵎⴷⵓⴽⴰⵍⵉⴽ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴱⴷⵓⴹ ⴰⵎⴻⵙⵍⴰⵢ.
 
@@ -2612,86 +2192,72 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     <message>
         <source>Import profile</source>
         <comment>import dialog title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⴰⵙⴽⵛⵎ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Tox save file (*.tox)</source>
         <comment>import dialog filter</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵏ ⵓⵙⴻⵍⴽⴻⵎ ⵏ Tuks (*.tuks)</translation>
+        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵏ ⵓⵃⵔⴰⵣ ⵏ Tox (*.tox)</translation>
     </message>
     <message>
         <source>Ignoring non-Tox file</source>
         <comment>popup title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵜⵜⵃⴻⵇⵔⵉⴹ ⴰⵔⴰ ⴰⴼⴰⵢⵍⵓ ⵓⵔ ⵏⴻⵍⵍⵉ ⴰⵔⴰ ⴷ Tox</translation>
+        <translation type="unfinished">ⴰⵏⵣⴳⵉ ⵏ ⵓⴼⴰⵢⵍⵓ ⵓⵔ ⵏⴳⵉ ⴰⵔⴰ ⵏ Tox</translation>
     </message>
     <message>
         <source>Warning: You have chosen a file that is not a Tox save file; ignoring.</source>
         <comment>popup text</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵄⴻⵢⵢⴻⵏ: ⵜⴼⴻⵔⵏⴻⴹ ⴰⴼⴰⵢⵍⵓ ⵓⵔ ⵏⴻⵍⵍⵉ ⴰⵔⴰ ⴷ ⴰⴼⴰⵢⵍⵓ ⵏ ⵓⵙⴻⵍⴽⴻⵎ ⵏ Tox; ⵓⵔ ⵢⴻⵜⵜⵃⴻⵇⵔⵉ ⴰⵔⴰ.</translation>
+        <translation type="unfinished">ⴰⵄⴻⵢⵢⴻⵏ: ⵜⴼⴻⵔⵏⴻⴹ ⴰⴼⴰⵢⵍⵓ ⵓⵔ ⵏⴻⵍⵍⵉ ⴰⵔⴰ ⴷ ⴰⴼⴰⵢⵍⵓ ⵏ ⵓⵃⵔⴰⵣ ⵏ Tox; ⵓⵔ ⵢⴻⵜⵜⵃⴻⵇⵔⵉ ⴰⵔⴰ.</translation>
     </message>
     <message>
         <source>Profile already exists</source>
         <comment>import confirm title</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴳⴱⵓⵔ ⵢⴻⵍⵍⴰ ⵢⴰⴽⴰⵏ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵢⵍⵍⴰ ⵢⴰⴽⴰⵏ</translation>
     </message>
     <message>
         <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
         <comment>import confirm text</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴻⵔⴷⵉⵙ ⵙ ⵢⵉⵙⴻⵎ &quot;%1&quot; ⵢⴻⵍⵍⴰ ⵢⴰⴽⴰⵏ. ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⵜⴻⵎⵖⴻⴹ?</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵙ ⵢⵉⵙⴻⵎ &quot;%1&quot; ⵢⵍⵍⴰ ⵢⴰⴽⴰⵏ. ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴽⴽⵙⴷ?</translation>
     </message>
     <message>
         <source>File doesn&apos;t exist</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵓⵔ ⵢⴻⵍⵍⵉ ⴰⵔⴰ</translation>
+        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ ⵓⵔ ⵢⵍⵍⵉ</translation>
     </message>
     <message>
         <source>Profile doesn&apos;t exist</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴳⴱⵓⵔ ⵓⵔ ⵢⴻⵍⵍⵉ ⴰⵔⴰ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵓⵔ ⵢⵍⵍⵉ</translation>
     </message>
     <message>
         <source>Profile imported</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵉⵜⵜⵡⴰⵙⴽⵛⵎ</translation>
     </message>
     <message>
         <source>%1.tox was successfully imported</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1.tox ⵢⴻⵜⵜⵡⴰⵙⴻⴽⵛⴻⵎ ⵙ ⵔⵔⴱⴻⵃ</translation>
+        <translation type="unfinished">%1.tox ⵉⵜⵜⵡⴰⵙⴽⵛⵎ ⵙ ⵓⵎⵓⵔⵙ</translation>
     </message>
 </context>
 <context>
     <name>QApplication</name>
     <message>
         <source>Ok</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵔⴱⴰⵃ</translation>
+        <translation type="unfinished">ⵡⴰⵅⵅⴰ</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⴽⴽⴻⵙ</translation>
+        <translation type="unfinished">ⴱⵟⴻⵍ</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵀ</translation>
     </message>
     <message>
         <source>No</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵍⴰ</translation>
     </message>
     <message>
         <source>LTR</source>
         <comment>DO NOT TRANSLATE. Instead, set this string to &apos;RTL&apos; in right-to-left languages (for example Hebrew and Arabic) to get proper widget layout. This string should only ever be &apos;LTR&apos; or &apos;RTL&apos;.</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">LTR</translation>
     </message>
 </context>
 <context>
@@ -2699,147 +2265,122 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     <message>
         <source>Choose an auto-accept directory</source>
         <comment>popup title</comment>
-        <translation type="unfinished">ⴼⵔⴻⵏ ⴰⴹⵔⵉⵙ ⵏ ⵓⵇⴱⴰⵍ ⵙ ⵡⵓⴷⴻⵎ ⴰⵡⵓⵔⵎⴰⵏ</translation>
+        <translation type="unfinished">ⴼⵔⵏ ⴰⴽⴰⵔⴰⵎ ⵏ ⵓⵇⴱⴰⵍ ⴰⵡⵓⵔⵎⴰⵏ</translation>
     </message>
 </context>
 <context>
     <name>QMessageBox</name>
     <message>
         <source>Couldn&apos;t add friend</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵣⵎⵉⵔⴻⵖ ⴰⵔⴰ ⴰⴷ ⵔⵏⵓⵖ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵣⵎⵉⵔⴻⵖ ⴰⵔⴰ ⴰⴷ ⵔⵏⵓⵖ ⴰⵎⴷⴷⴰⴽⴽⵍ.</translation>
     </message>
     <message>
         <source>You can&apos;t add yourself as a friend!</source>
         <comment>When trying to add your own Tox ID as friend</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵜⴻⵣⵎⵉⵔⴻⴹ ⴰⵔⴰ ⴰⴷ ⵜⴻⵔⵏⵓⴹ ⵉⵎⴰⵏⵉⴽ ⴷ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ!</translation>
+        <translation type="unfinished">ⵓⵔ ⵜⴻⵣⵎⵉⵔⴻⴹ ⴰⵔⴰ ⴰⴷ ⵜⴻⵔⵏⵓⴹ ⵉⵎⴰⵏⵉⴽ ⴷ ⴰⵎⴷⴷⴰⴽⴽⵍ!</translation>
     </message>
     <message>
         <source>%1 is not a valid Tox address.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 ⵎⴰⵞⵞⵉ ⴷ ⵜⴰⵏⵙⴰ ⵏ Tox ⵉⵡⴰⵜⴰⵏ.</translation>
+        <translation type="unfinished">%1 ⵓⵔ ⵉⴳⵉ ⵜⴰⵏⵙⴰ ⵏ Tox ⵜⴰⵎⵖⴱⵓⵍⵜ.</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>Default</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵎⴽⴰⵏ ⵓⵔ ⵏⴻⵜⵜⵡⴰⵙⵙⴻⵏ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍⵏⵓ</translation>
     </message>
     <message>
         <source>Blue</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵣⴻⴳⵣⴰⵡ</translation>
+        <translation type="unfinished">ⴰⵥⵕⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Olive</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵣⵣⵉⵜ</translation>
     </message>
     <message>
         <source>Red</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵣⴳⴳⴰⵖ</translation>
+        <translation type="unfinished">ⴰⵣⴳⴳⵯⴰⵖ</translation>
     </message>
     <message>
         <source>Violet</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⴱⵕⵓⵃⵉⵜ</translation>
+        <translation type="unfinished">ⴰⵎⴽⵥⴰⵢ</translation>
     </message>
     <message>
         <source>Incoming call...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵉⵖⵔⵉ ⵉ ⴷⵉⴽⴻⵞⵞⵎⴻⵏ...</translation>
     </message>
     <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">%1 ⴷⴰⴳⵉ! Tox ⵎⴻ ⴰⵀⴰⵜ?</translation>
     </message>
     <message>
         <source>None</source>
         <comment>No camera device set</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵍⴰⵛ</translation>
     </message>
     <message>
         <source>Desktop</source>
         <comment>Desktop as a camera input for screen sharing</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴰⵔⵓ</translation>
+        <translation type="unfinished">ⵜⴰⵏⴰⵔⴰ</translation>
     </message>
     <message>
         <source>Error</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵓⵛⵛⴹⴰ</translation>
     </message>
     <message>
         <source>qTox couldn&apos;t open your chat logs, they will be disabled.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">qTox ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ ⵉⵖⵎⵉⵙⴻⵏⵉⴽ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ, ⴰⴷ ⵜⵜⵡⴰⵇⵏⴻⵏ.</translation>
+        <translation type="unfinished">qTox ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵍⴷⵉ ⵉⵖⵎⵉⵙⴻⵏⵉⴽ ⵏ ⵓⵎⵙⴰⵡⴰⵍ, ⴰⴷ ⵜⵜⵡⴰⵇⵏⴻⵏ.</translation>
     </message>
     <message>
         <source>Dark</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴱⴻⵔⴽⴰⵏ</translation>
+        <translation type="unfinished">ⴰⴱⵔⴽⴰⵏ</translation>
     </message>
     <message>
         <source>Dark blue</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵣⴻⴳⵣⴰⵡ ⴰⵇⴻⵙⵃⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵥⵕⵡⴰⵍ ⴰⴱⵔⴽⴰⵏ</translation>
     </message>
     <message>
         <source>Dark olive</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵣⵉⵜⵓⵏ ⴰⵇⴻⵙⵃⴰⵏ</translation>
+        <translation type="unfinished">ⵣⵣⵉⵜ ⴰⴱⵔⴽⴰⵏ</translation>
     </message>
     <message>
         <source>Dark red</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵣⴻⴳⴳⴰⵖ ⴰⵇⴻⵙⵃⴰⵏ</translation>
+        <translation type="unfinished">ⴰⵣⴳⴳⵯⴰⵖ ⴰⴱⵔⴽⴰⵏ</translation>
     </message>
     <message>
         <source>Dark violet</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵥⴻⴳⵡⴰ ⵜⴰⵣⴻⴳⵣⴰⵡⵜ</translation>
+        <translation type="unfinished">ⴰⵎⴽⵥⴰⵢ ⴰⴱⵔⴽⴰⵏ</translation>
     </message>
     <message>
         <source>online</source>
         <comment>contact status</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">oⵏⵍⴰⵢⵏ</translation>
+        <translation type="unfinished">ⵢⵍⵍⴰ</translation>
     </message>
     <message>
         <source>away</source>
         <comment>contact status</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⴱⵄⴻⴷ</translation>
+        <translation type="unfinished">ⵉⴱⵄⴷ</translation>
     </message>
     <message>
         <source>busy</source>
         <comment>contact status</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵄⵎⴻⵔ</translation>
+        <translation type="unfinished">ⵢⵛⵖⵍ</translation>
     </message>
     <message>
         <source>offline</source>
         <comment>contact status</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⵕⵕⴰ ⵉ ⵍⴰⵏⵜⵉⵔⵏⴰⵜ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵍⵍⵉ</translation>
     </message>
     <message>
         <source>blocked</source>
         <comment>contact status</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵜⵜⵡⴰⵃⴱⴻⵙ</translation>
+        <translation type="unfinished">ⵉⵜⵜⵡⴰⴳⴷⵍ</translation>
     </message>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵄⵉⵡⴻⴷ ⵏ ⵓⵙⴻⵖⵣⴻⴼ ⵏ ⵓⴹⵔⵉⵙ...</translation>
     </message>
     <message>
@@ -2893,52 +2434,42 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     </message>
     <message>
         <source>You have joined the conference</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴽⴻⵛⵎⴻⴹ ⵖⴻⵔ ⵓⵙⴰⵔⴰⴳ</translation>
+        <translation type="unfinished">ⵜⴽⵛⵎⴷ ⵖⵔ ⵓⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>You have left the conference</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴻⴵⴵⵉⴹ ⴰⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>%1 went offline during the call attempt</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">%1 ⴼⴼⵖⵏ ⴱⵕⵕⴰ ⴳ ⵓⵣⵎⵣ ⵏ ⵓⵔⵣⵣⵓ ⵏ ⵜⵖⵓⵔⵉ</translation>
+        <translation type="unfinished">%1 ⵓⵔ ⵢⴻⵍⵍⵉ ⴷⴳ ⵓⵣⵎⵣ ⵏ ⵓⵔⵣⵣⵓ ⵏ ⵜⵖⵓⵔⵉ</translation>
     </message>
     <message>
         <source>Failed to load chat history</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⵥⴻⵎ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⵥⴻⵎ ⴰⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Database version (%1) is newer than we currently support (%2). Please upgrade qTox.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵍⵇⴻⵎ ⵏ ⵜⴱⴰⴹⵏⵉⵜ (%1) ⴷ ⴰⵎⴰⵢⵏⵓⵜ ⵓⴳⴰⵔ ⵏ ⵡⵉⵏ ⵉ ⵏⴻⵙⵙⴻⵎⵔⴰⵙ ⵜⵓⵔⴰ (%2). ⵜⵜⵅⵉⵍⴽ ⵙⵏⴻⵔⵏⵉ qTox.</translation>
     </message>
     <message>
         <source>Initializing</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴱⴷⴰⴷ</translation>
     </message>
     <message>
         <source>Transmitting</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⵉⵡⴻⴹ</translation>
     </message>
     <message>
         <source>Finished</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⴼⵓⴽ</translation>
     </message>
     <message>
         <source>Broken</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⴻⵥⴻⵏ</translation>
     </message>
     <message>
         <source>Canceled</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⵜⵜⵡⴰⴱⵟⴻⵍ</translation>
     </message>
     <message>
@@ -2947,41 +2478,34 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     </message>
     <message>
         <source>Remote paused</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵍⴽⵉⵎ ⵢⴻⵃⴱⴻⵙ</translation>
+        <translation type="unfinished">ⵢⴻⵃⴱⴻⵙ ⵙⵖⵓⵔ ⵓⵏⴻⵔⵎⵉⵙ</translation>
     </message>
     <message>
         <source>File Name</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴻⵎ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Contact</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵏⴻⵔⵎⴻⵙ</translation>
+        <translation type="unfinished">ⴰⵏⴻⵔⵎⵉⵙ</translation>
     </message>
     <message>
         <source>Progress</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵏⴻⵔⵏⵉ</translation>
+        <translation type="unfinished">ⴰⵙⵎⴰⴷ</translation>
     </message>
     <message>
         <source>Size</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵛⵃⴰⵍ ⴰⵢ ⵜⴻⵜⵜⵍⵓⵙⵓⴹ</translation>
+        <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ</translation>
     </message>
     <message>
         <source>Speed</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵍⴻⵎⵖⴰⵡⵍⴰ</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished">ⵜⴰⵍⵖⴰ</translation>
+        <translation type="unfinished">ⴰⴷⴷⴰⴷ</translation>
     </message>
     <message>
         <source>Control</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵃⴻⴽⵎ</translation>
     </message>
 </context>
@@ -2989,23 +2513,23 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     <name>RemoveChatDialog</name>
     <message>
         <source>Remove friend</source>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ</translation>
+        <translation type="unfinished">ⴽⴽⵙ ⴰⵎⴷⴷⴰⴽⴽⵍ</translation>
     </message>
     <message>
         <source>Remove all chat history with the friend if set</source>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⴽⴽ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⴷ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ</translation>
+        <translation type="unfinished">ⴽⴽⴻⵙ ⴰⴽⴽ ⴰⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ ⴷ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ</translation>
     </message>
     <message>
         <source>Also remove chat history</source>
-        <translation type="unfinished">ⴽⴽⴻⵙ ⴷⴰⵖⴻⵏ ⴰⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ</translation>
+        <translation type="unfinished">ⴽⴽⴻⵙ ⴷⴰⵖⴻⵏ ⴰⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Are you sure you want to remove %1 from your contacts list?</source>
-        <translation type="unfinished">ⵎⴰ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⴽⴽⵙⴻⴹ %1 ⵙⴻⴳ ⵜⴻⴼⵢⵉⵔⵜ ⵏ ⵢⵉⵏⵎⴰⵖⴻⵏⵉⴽ?</translation>
+        <translation type="unfinished">ⵎⴰ ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⴽⴽⵙⴻⴹ %1 ⵙⴻⴳ ⵜⴻⴼⵢⵉⵔⵜ ⵏ ⵢⵉⵏⴻⵔⵎⵉⵙⴻⵏⵉⴽ?</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished">ⴽⴽⴻⵙ</translation>
+        <translation type="unfinished">ⴽⴽⵙ</translation>
     </message>
 </context>
 <context>
@@ -3013,31 +2537,26 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     <message>
         <source>Click and drag to select a region. Press %1 to hide/show qTox window, or %2 to cancel.</source>
         <comment>Help text shown when no region has been selected yet</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴽⵏⴻⴷ ⵓ ⵊⴱⴻⴷⴷ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⵔⴻⵏⴹ ⵜⴰⵎⵏⴰⴹⵜ. ⵜⵜⴱⴻⵄ %1 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⴼⵔⴻⴹ/ⴰⴷ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ qTox, ⵏⴻⵖ %2 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴱⴻⴹⴹⴻⴹ.</translation>
+        <translation type="unfinished">ⴽⵏⴻⴷ ⵓ ⵊⴱⴻⴷⴷ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⵔⴻⵏⴹ ⵜⴰⵎⵏⴰⴹⵜ. ⵜⵜⴱⴻⵄ %1 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⴼⵔⴻⴹ/ⴰⴷ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⴰⵙⴼⴰⵢⵍⵓ ⵏ qTox, ⵏⴻⵖ %2 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴱⴻⴹⴹⴻⴹ.</translation>
     </message>
     <message>
         <source>Space</source>
         <comment>[Space] key on the keyboard</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵍⵉⵜⵙⴻⵄ</translation>
     </message>
     <message>
         <source>Escape</source>
         <comment>[Escape] key on the keyboard</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵔⵡⵍⴰ</translation>
     </message>
     <message>
         <source>Press %1 to send a screenshot of the selection, %2 to hide/show qTox window, or %3 to cancel.</source>
         <comment>Help text shown when a region has been selected</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⵜⴹⴻⴳⴳⵉⵔ %1 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⵉⵡⴹⴻⴹ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ ⵏ ⵓⴼⵔⴰⵏ, %2 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⴼⵔⴻⴹ/ⴰⴷ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ ⵏ qTox, ⵏⴻⵖ %3 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴱⴻⴹⴹⴻⴹ.</translation>
+        <translation type="unfinished">ⵜⵜⴹⴻⴳⴳⵉⵔ %1 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⵉⵡⴹⴻⴹ ⵜⵓⴳⵏⴰ ⵏ ⵓⴼⵔⴰⵏ, %2 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⴼⵔⴻⴹ/ⴰⴷ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⴰⵙⴼⴰⵢⵍⵓ ⵏ qTox, ⵏⴻⵖ %3 ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⴱⴻⴹⴹⴻⴹ.</translation>
     </message>
     <message>
         <source>Enter</source>
         <comment>[Enter] key on the keyboard</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴽⴻⵛⵎⴻⵜ</translation>
     </message>
 </context>
@@ -3045,12 +2564,10 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     <name>SearchForm</name>
     <message>
         <source>The text could not be found.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵔ ⵢⴻⵜⵜⵡⴰⴼ ⴰⵔⴰ ⵓⴹⵔⵉⵙ.</translation>
     </message>
     <message>
         <source>Start</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴱⴷⵓ</translation>
     </message>
 </context>
@@ -3058,42 +2575,34 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     <name>SearchSettingsForm</name>
     <message>
         <source>Start search:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴱⴷⵓ ⴰⵏⴰⴷⵉ:</translation>
     </message>
     <message>
         <source>from the end</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⴳ ⵜⴰⴳⴳⴰⵔⴰ</translation>
     </message>
     <message>
         <source>from the beginning</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⴳ ⵜⴰⵣⵡⴰⵔⴰ</translation>
     </message>
     <message>
         <source>after date</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵏⴷ ⴰⵣⴻⵎⵣ</translation>
+        <translation type="unfinished">ⴷⴼⴼⵉⵔ ⵓⵣⴻⵎⵣ</translation>
     </message>
     <message>
         <source>before date</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⵏⴷ ⵏ ⵡⴰⵙⵙ</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵢⴻⵜⵜⵃⵓⵍⴼⵓ ⵙ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵉⵎⴻⵇⵇⵔⴰⵏⴻⵏ</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍⴻⵏ ⵙ ⵍⴻⴽⵎⴰⵍⵏⵙⴻⵏ ⴽⴰⵏ</translation>
     </message>
     <message>
         <source>Use regular expressions</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵉⵎⴻⵙⵍⴰⵢⴻⵏ ⵓⵙⵍⵉⴳⴻⵏ</translation>
     </message>
     <message>
@@ -3109,141 +2618,118 @@ IDa ⵢⴻⵙⵄⴰ ⴰⴽⴰⵔⴰⵎ ⵏ NoSpam (ⵙ ⵜⴼⴻⵍⵡⵉⵜ), �
     <name>SetPasswordDialog</name>
     <message>
         <source>Confirm:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⴻⴽⵏⴻⵖⵜ:</translation>
+        <translation type="unfinished">ⵙⴷⴷⵉⴷ:</translation>
     </message>
     <message>
         <source>Password:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵡⴰⵍ ⵏ ⵓⴼⴼⵉⵔ:</translation>
+        <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ:</translation>
     </message>
     <message>
         <source>Password strength: %p%</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵣⵎⴻⵔⵜ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ: %p%</translation>
     </message>
     <message>
         <source>The password doesn&apos;t match.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵓⵔ ⵢⴻⵜⵜⴻⵎⵛⴰⴱⵉ ⴰⵔⴰ.</translation>
     </message>
     <message>
         <source>Confirm password</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⴻⴽⵏⴻⴹ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Confirm password input</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⴻⴽⵏⴻⴹ ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Password input</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ</translation>
     </message>
     <message>
         <source>Password input field, minimum 6 characters long</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵃⵔⵉⵛ ⵏ ⵓⵙⴻⴽⵛⴻⵎ ⵏ ⵡⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ, ⵙ ⵜⴻⵖⵣⵉ ⵏ 6 ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ</translation>
     </message>
     <message>
         <source>The password is too short.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⴷ ⴰⵡⴻⵣⵍⴰⵏ ⴰⵟⴰⵙ.</translation>
     </message>
     <message>
         <source>Set profile password</source>
-        <translation type="unfinished">ⵙⴱⴻⴷⴷ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵓⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⵙⴱⴷⴷ ⴰⵡⴰⵍ ⵓⴼⴼⵉⵔ ⵏ ⵓⴳⵉⵍⴰⵍ</translation>
     </message>
 </context>
 <context>
     <name>Settings</name>
     <message>
         <source>Circle #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵖⴻⵛⵜ #%1.</translation>
+        <translation type="unfinished">ⵜⴰⵔⴱⴰⵄⵜ #%1</translation>
     </message>
     <message>
         <source>Failed to load global settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⵥⴻⵎ ⵉⵙⴻⵖⵡⴰⵏ ⵉⵎⴰⴹⵍⴰⵏⴻⵏ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⵥⴻⵎ ⵉⵙⵖⵡⴰⵕⵏ ⵉⵎⴰⴹⵍⴰⵏⴻⵏ</translation>
     </message>
     <message>
         <source>Unable to upgrade settings from version %1 to version %2. Cannot start qTox.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵙⵏⴻⵔⵏⵉ ⵉⵙⴻⵖⵡⴰⵏ ⵙⴻⴳ ⵓⵍⵇⴻⵎ %1 ⵖⴻⵔ ⵓⵍⵇⴻⵎ %2. ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴱⴷⵓ qTox.</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵙⵏⴻⵔⵏⵉ ⵉⵙⵖⵡⴰⵕⵏ ⵙⴻⴳ ⵓⵍⵇⴻⵎ %1 ⵖⴻⵔ ⵓⵍⵇⴻⵎ %2. ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴱⴷⵓ qTox.</translation>
     </message>
     <message>
         <source>Failed to load personal settings</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⵔ ⵉⵙⴻⵖⵡⴰⵏ ⵓⵙⵍⵉⴳⴻⵏ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⵔⵔ ⵉⵙⵖⵡⴰⵕⵏ ⵓⵙⵍⵉⴳⴻⵏ</translation>
     </message>
 </context>
 <context>
     <name>ToxURIDialog</name>
     <message>
         <source>Do you want to add %1 as a friend?</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⵔⵏⵓⴹ %1 ⴷ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ?</translation>
+        <translation type="unfinished">ⵜⴻⴱⵖⵉⴹ ⴰⴷ ⵜⴻⵔⵏⵓⴹ %1 ⴷ ⴰⵎⴷⴷⴰⴽⴽⵍ?</translation>
     </message>
     <message>
         <source>User ID:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵎⴰⴳⵉⵜ ⵏ ⵓⵙⴻⵇⴷⴰⵛ:</translation>
+        <translation type="unfinished">ⴰⵙⵏⴰⵎ ⵏ ⵓⵎⵙⵙⵎⵔⵙ:</translation>
     </message>
     <message>
         <source>Friend request message:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵣⴻⵏ ⵏ ⵓⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ:</translation>
+        <translation type="unfinished">ⵉⵣⵏ ⵏ ⵜⵓⵜⵔⴰ ⵏ ⵜⴷⴷⵓⴽⴽⵍⴰ:</translation>
     </message>
     <message>
         <source>Send</source>
         <comment>Send a friend request</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵛⴻⴳⴳⴻⵄ</translation>
+        <translation type="unfinished">ⴰⵣⵏ</translation>
     </message>
     <message>
         <source>Cancel</source>
         <comment>Don&apos;t send a friend request</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⴽⴽⴻⵙ</translation>
+        <translation type="unfinished">ⴱⵟⴻⵍ</translation>
     </message>
     <message>
         <source>Add friend</source>
         <comment>Title of the window to add a friend through Tox URI</comment>
-        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ</translation>
+        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴷⴷⴰⴽⴽⵍ</translation>
     </message>
 </context>
 <context>
     <name>UserInterfaceForm</name>
     <message>
         <source>None</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵓⵍⴰⵛ</translation>
     </message>
     <message>
         <source>User Interface</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵏⴻⴳⴳⴰⵔⵓ ⵏ ⵓⵙⴻⵇⴷⴰⵛ</translation>
+        <translation type="unfinished">ⴰⵎⵢⴰⴳⵔ ⵏ ⵓⵎⵙⵙⵎⵔⵙ</translation>
     </message>
 </context>
 <context>
     <name>UserInterfaceSettings</name>
     <message>
         <source>Chat</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵜⵇⴻⵚⵚⵉⵔ</translation>
+        <translation type="unfinished">ⴰⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Base font:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵉⵔⴰ ⵏ ⵍⵍⵙⴰⵙ:</translation>
     </message>
     <message>
         <source>Size: </source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵛⵃⴰⵍ ⴰⵢ ⵜⴻⵜⵜⵍⵓⵙⵓⴹ:</translation>
+        <translation type="unfinished">ⵜⵉⴷⴷⵉ: </translation>
     </message>
     <message>
         <source>New text styling preference may not load on chat history until qTox restarts.
@@ -3258,310 +2744,254 @@ Show formatting characters:
 Hide formatting characters:
     Apply formatting and don&apos;t show characters.
     E.g. &quot;**text**&quot; will show as &quot;text&quot;, bold.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵏⴼⴰⵔ ⴰⵎⴰⵢⵏⵓⵜ ⵏ ⵓⵙⵏⵓⵍⴼⵓ ⵏ ⵓⴹⵔⵉⵙ ⵢⴻⵣⵎⴻⵔ ⵓⵔ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ ⴰⵔⴰ ⴷⴻⴳ ⵓⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⴰⵍⴰⵎⵎⴰ ⵢⴻⵇⵇⴻⵍ qTox.
+        <translation type="unfinished">ⴰⵙⴻⵏⴼⴰⵔ ⴰⵎⴰⵢⵏⵓⵜ ⵏ ⵓⵙⵏⵓⵍⴼⵓ ⵏ ⵓⴹⵔⵉⵙ ⵢⴻⵣⵎⴻⵔ ⵓⵔ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ ⴰⵔⴰ ⴷⴻⴳ ⵓⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ ⴰⵍⴰⵎⵎⴰ ⵢⴻⵇⵇⴻⵍ qTox.
 ⴰⴷ ⵉⵃⴰⵣ ⵉⵣⴻⵏ ⵉⵎⴰⵢⵏⵓⵜⴻⵏ ⵉⵎⵉⵔⴻⵏ ⴽⴰⵏ.
 
 ⴰⴹⵔⵉⵙ ⴰⴼⵔⴰⵔⴰⵢ:
     ⵓⵔ ⵙⵙⴻⵇⴷⴰⵛ ⴰⵔⴰ ⴽⵔⴰ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵉ ⵢⵉⵣⴻⵏ.
     ⴰⵎ. &quot;**ⴰⴹⵔⵉⵙ**&quot; ⴰⴷ ⴷⵢⴻⴼⴼⴻⵖ ⴰⵎ &quot;**ⴰⴹⵔⵉⵙ**&quot;, ⵎⴰⵞⵞⵉ ⴷ ⴰⵥⴰⵢⴰⵏ.
 ⵙⴽⴻⵏ ⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵏ ⵓⵙⵏⵉⵍⴻⵙ:
-    ⵙⵙⴻⵇⴷⴻⵛ ⴰⵙⴻⵎⵔⴻⵙ ⴷ ⵓⵙⴻⴽⵍⴻⵙ ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ.
+    ⵙⵙⵇⴷⴻⵛ ⴰⵙⴻⵎⵔⴻⵙ ⴷ ⵓⵙⴻⴽⵍⴻⵙ ⵏ ⵢⵉⵙⴻⴽⴽⵉⵍⴻⵏ.
     ⴰⵎ. &quot;**ⴰⴹⵔⵉⵙ**&quot; ⴰⴷ ⴷⵢⴻⴼⴼⴻⵖ ⴰⵎ &quot;**ⴰⴹⵔⵉⵙ**&quot;, ⴷ ⴰⵥⴰⵢⴰⵏ.
 ⴼⴼⴻⵔ ⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵏ ⵓⵙⵏⵉⵍⴻⵙ:
     ⵙⵙⴻⵇⴷⴻⵛ ⴰⵙⴻⵎⵔⴻⵙ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵢⴻⵔⵏⴰ ⵓⵔ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⴰⵔⴰ ⵉⵙⴻⴽⴽⵉⵍⴻⵏ.
-    ⴰⵎ. &quot;**ⴰⴹⵔⵉⵙ**&quot; ⴰⴷ ⴷⵢⴻⴼⴼⴻⵖ ⴰⵎ &quot;ⴰⴹⵔⵉⵙ&quot;, ⴷ ⴰⵥⵉⴹⴰⵏ.</translation>
+    ⴰⵎ. &quot;**ⴰⴹⵔⵉⵙ**&quot; ⴰⴷ ⴷⵢⴻⴼⴼⴻⵖ ⴰⵎ &quot;ⴰⴹⵔⵉⵙ&quot;, ⴷ ⴰⵥⴰⵢⴰⵏ.</translation>
     </message>
     <message>
         <source>Text styling:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⵏⵓⵍⴼⵓ ⵏ ⵓⴹⵔⵉⵙ:</translation>
     </message>
     <message>
         <source>Select text styling preference.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴼⵔⴻⵏ ⴰⵙⴻⴼⵔⵓ ⵏ ⵓⵙⵏⵉⵍⴻⵙ ⵏ ⵓⴹⵔⵉⵙ.</translation>
+        <translation type="unfinished">ⴼⵔⵏ ⴰⵙⵎⵏⵢⴰⴼ ⵏ ⵓⵙⵜⴰⵢ ⵏ ⵓⴹⵔⵉⵙ.</translation>
     </message>
     <message>
         <source>Plaintext</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴹⵔⵉⵙ ⴰⴼⵔⴰⵔⴰⵢ</translation>
+        <translation type="unfinished">ⴰⴹⵔⵉⵙ ⴰⴼⵔⴰⵔ</translation>
     </message>
     <message>
         <source>Show formatting characters</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴽⴻⵏ ⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵏ ⵓⵙⵏⵉⵍⴻⵙ</translation>
+        <translation type="unfinished">ⵙⴽⵏ ⵉⵙⴽⴽⵉⵍⵏ ⵏ ⵓⵙⵯⵍⵓ</translation>
     </message>
     <message>
         <source>Hide formatting characters</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴼⴼⴻⵔ ⵉⵙⴻⴽⴽⵉⵍⴻⵏ ⵏ ⵜⴰⵍⵖⴰ</translation>
+        <translation type="unfinished">ⴼⴼⵔ ⵉⵙⴽⴽⵉⵍⵏ ⵏ ⵓⵙⵯⵍⵓ</translation>
     </message>
     <message>
         <source>New message</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓ</translation>
     </message>
     <message>
         <source>Open qTox&apos;s window when you receive a new message and no window is open yet.</source>
         <comment>tooltip for Show window setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵍⴷⵉ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ ⵏ qTox ⵎⵉ ⴰⵔⴰ ⴷⵜⴰⵡⴻⴹ ⵢⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓⵜ ⵢⴻⵔⵏⴰ ⵓⵍⴰⵛ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ ⵢⴻⵍⴷⵉⵏ ⴰⵔ ⴰⵙⵙⴰ.</translation>
     </message>
     <message>
         <source>Open window</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴰⵙⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Contact list</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵎⵓⵖ ⵏ ⵓⵙⵉⵡⴻⵍ</translation>
+        <translation type="unfinished">ⵜⴰⵍⴳⴰⵎⵜ ⵏ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ</translation>
     </message>
     <message>
         <source>If checked, conferences will be placed at the top of the friends list, otherwise, they&apos;ll be placed below online friends.</source>
         <comment>toolTip for conference positioning</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⵜⵡⴰⵙⴻⴽⵏⴻⵏ, ⵉⵙⴰⵔⴰⴳⴻⵏ ⴰⴷ ⵜⵜⵡⴰⵙⴻⵔⵙⴻⵏ ⴷⴻⴳ ⵜⵇⴰⵛⵓⵛⵜ ⵏ ⵍⵉⵙⵜⵉ ⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ, ⵎⴰ ⵓⵍⴰⵛ, ⴰⴷ ⵜⵜⵡⴰⵙⴻⵔⵙⴻⵏ ⴷⴷⴰⵡ ⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ ⵏ ⵓⵙⵎⴻⵍ.</translation>
+        <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⵜⵡⴰⵙⴻⴽⵏⴻⵏ, ⵉⵙⴰⵔⴰⴳⴻⵏ ⴰⴷ ⵜⵜⵡⴰⵙⴻⵔⵙⴻⵏ ⴷⴻⴳ ⵜⵇⴰⵛⵓⵛⵜ ⵏ ⵜⵍⴳⴰⵎⵜ ⵏ ⵢⵉⵎⴷⴷⵓⴽⴽⴰⵍ, ⵎⴰ ⵓⵍⴰⵛ, ⴰⴷ ⵜⵜⵡⴰⵙⴻⵔⵙⴻⵏ ⴷⴷⴰⵡ ⵏ ⵢⵉⵎⴷⴷⵓⴽⴽⴰⵍ ⵏ ⵓⵙⵎⴻⵍ.</translation>
     </message>
     <message>
         <source>Place conferences at top of friend list</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵙⴻⵔⵙ ⵉⵙⴰⵔⴰⴳⴻⵏ ⴷⴻⴳ ⵜⵇⴰⵛⵓⵛⵜ ⵏ ⵓⵎⵓⵖ ⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ</translation>
+        <translation type="unfinished">ⵙⵔⵙ ⵉⵙⴰⵔⴰⴳⵏ ⴳ ⵜⵇⴰⵛⵓⵛⵜ ⵏ ⵜⵍⴳⴰⵎⵜ ⵏ ⵉⵎⴷⴷⵓⴽⴽⴰⵍ</translation>
     </message>
     <message>
         <source>Your contact list will be shown in compact mode (small avatars, tabular view).</source>
         <comment>toolTip for compact layout setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴷ ⴷⵜⴱⴰⵏ ⵓⴹⵔⵉⵙⵉⴽ ⵏ ⵓⵙⵎⴻⵍ ⴷⴻⴳ ⵜⴻⴳⵏⵉⵜ ⵏ ⵜⵎⴻⵥⴷⵉⵜ (avatars ⵉⵎⴻⵥⵢⴰⵏⴻⵏ, ⵜⴰⵎⵓⵖⵍⵉ ⵏ ⵜⴼⴻⵍⵡⵉⵜ).</translation>
+        <translation type="unfinished">ⴰⴷ ⴷⵜⴱⴰⵏ ⵜⵍⴳⴰⵎⵜ ⵏ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ ⵉⵏⴽ ⴷⴻⴳ ⵜⴻⴳⵏⵉⵜ ⵏ ⵜⵎⴻⵥⴷⵉⵜ (avatars ⵉⵎⴻⵥⵢⴰⵏⴻⵏ, ⵜⴰⵎⵓⵖⵍⵉ ⵏ ⵜⴼⴻⵍⵡⵉⵜ).</translation>
     </message>
     <message>
         <source>Compact contact list</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵎⵓⵖ ⵏ ⵓⵙⵉⵡⴻⵍ ⴰⵎⴻⵙⴱⴰⵟⵍⵉ</translation>
+        <translation type="unfinished">ⵜⴰⵍⴳⴰⵎⵜ ⵏ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ ⵉⵎⵣⵎⵥⵉⵏ</translation>
     </message>
     <message>
         <source>Multiple windows mode</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴹⵔⵉⵙ ⵏ ⵡⴰⵟⴰⵙ ⵏ ⵟⵟⴰⵇ</translation>
+        <translation type="unfinished">ⴰⵙⴽⴰⵏ ⵏ ⵡⴰⵟⵟⴰⵙ ⵏ ⵉⵙⴼⵓⵢⵍⴰ</translation>
     </message>
     <message>
         <source>Open each chat in an individual window</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵍⴷⵉ ⵢⴰⵍ ⴰⵎⴻⵙⵍⴰⵢ ⴷⴻⴳ ⵢⵉⵡⴻⵏ ⵏ ⵟⵟⴰⵇ</translation>
+        <translation type="unfinished">ⵍⴷⵉ ⴽⵓ ⴰⵎⵙⴰⵡⴰⵍ ⴳ ⵓⵙⴼⴰⵢⵍⵓ ⵉⵎⴰⵏ ⵏⵏⵙ</translation>
     </message>
     <message>
         <source>Emoticons</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵎⵓⴽⴰⵏ</translation>
+        <translation type="unfinished">ⵉⵛⵎⵓⵎⵉⵢⴻⵏ</translation>
     </message>
     <message>
         <source>Use emoticons</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵉⵙⴻⴽⴽⵉⵍⴻⵏ</translation>
+        <translation type="unfinished">ⵙⵙⵎⵔⵙ ⵉⵛⵎⵓⵎⵉⵢⴻⵏ</translation>
     </message>
     <message>
         <source>Emoticon size:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ ⵏ ⵓⵙⵎⴻⴽⵜⵉ:</translation>
     </message>
     <message>
         <source> px</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished"> px</translation>
     </message>
     <message>
         <source>Theme</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵏⵜⴻⵍ</translation>
+        <translation type="unfinished">ⴰⵙⵏⵜⵍ</translation>
     </message>
     <message>
         <source>Style:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵖⴰⵏⵉⴱ:</translation>
     </message>
     <message>
         <source>Theme color:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵏⵉ ⵏ ⵓⵙⴻⵏⵜⴻⵍ:</translation>
+        <translation type="unfinished">ⵉⵏⵉ ⵏ ⵓⵙⵏⵜⵍ:</translation>
     </message>
     <message>
         <source>Timestamp format:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵍⵖⴰ ⵏ ⵓⵣⴰⵍ ⵏ ⵡⴰⴽⵓⴷ:</translation>
+        <translation type="unfinished">ⴰⵎⴰⵍⴰⵢ ⵏ ⵓⵣⵎⵣ ⵏ ⵡⴰⴽⵓⴷ:</translation>
     </message>
     <message>
         <source>Date format:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵍⵖⴰ ⵏ ⵓⵣⴻⵎⵣ:</translation>
+        <translation type="unfinished">ⴰⵎⴰⵍⴰⵢ ⵏ ⵓⵣⵎⵣ:</translation>
     </message>
     <message>
         <source>Use identicons instead of empty avatars</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵉⵙⴻⵎⵍⴻⵏ ⴷⴻⴳ ⵓⵎⴹⵉⵇ ⵏ ⵢⵉⵙⵓⵔⴰ ⵉⵍⴻⵎ</translation>
+        <translation type="unfinished">ⵙⵙⵎⵔⵙ ⵜⵉⵡⵍⴰⴼⵉⵏ ⵏ ⵓⵙⵏⴰⵎ ⴷⴳ ⵓⵎⴹⵉⵇ ⵏ ⵉⴼⵔⴷⵉⵙⵏ ⵉⵍⵎⴰⵡⵏ</translation>
     </message>
     <message>
         <source>Show a notification when you receive a new message, call, or friend request and the window is not selected.</source>
         <comment>tooltip for Notify setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴽⴻⵏⴷ ⴰⵖⵜⴰⵙ ⵎⵉ ⴰⵔⴰ ⴷⵜⴰⵡⴻⴹ ⵢⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓⵜ, ⴰⵙⵉⵡⴻⵍ, ⵏⴻⵖ ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ ⵢⴻⵔⵏⴰ ⵓⵔ ⵢⴻⵜⵜⵡⴰⴼⵔⴻⵏ ⴰⵔⴰ ⵓⴹⵔⵉⵙ.</translation>
+        <translation type="unfinished">ⵙⴽⴻⵏⴷ ⴰⵖⵜⴰⵙ ⵎⵉ ⴰⵔⴰ ⴷⵜⴰⵡⴻⴹ ⵢⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓⵜ, ⴰⵙⵉⵡⴻⵍ, ⵏⴻⵖ ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵢⴻⵔⵏⴰ ⵓⵔ ⵢⴻⵜⵜⵡⴰⴼⵔⴻⵏ ⴰⵔⴰ ⵓⴹⵔⵉⵙ.</translation>
     </message>
     <message>
         <source>Notify</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴱⴻⵔⵔⴻⵃ</translation>
+        <translation type="unfinished">ⵙⵙⵉⵡⴹ ⴰⵏⵖⵎⵉⵙ</translation>
     </message>
     <message>
         <source>Conferences only notify when mentioned</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵙⴰⵔⴰⴳⴻⵏ ⵜⵜⴱⴻⵛⵛⵉⵔⴻⵏⴷ ⴽⴰⵏ ⵎⴰ ⵜⵜⵡⴰⴱⴷⴻⵔⴷ</translation>
+        <translation type="unfinished">ⵉⵙⴰⵔⴰⴳⵏ ⴰⴷ ⵙⵙⵉⵡⴹⵏ ⴰⵏⵖⵎⵉⵙ ⵖⴰⵙ ⵎⴰ ⵜⵜⵡⴰⴱⴷⴰⵔⵏ</translation>
     </message>
     <message>
         <source>Play sound</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔⴰⵔ ⵙ ⵚⵚⵓⵜ</translation>
+        <translation type="unfinished">ⵖⵔ ⵉⵎⵙⵍⵉ</translation>
     </message>
     <message>
         <source>Play sound while Busy</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔⴰⵔ ⵙ ⵚⵚⵓⵜ ⴷⴻⴳ ⵡⴰⴽⵓⴷ ⵉⴷⴻⴳ ⵜⵃⴻⵎⵎⵍⴻⴹ</translation>
+        <translation type="unfinished">ⵖⵔ ⵉⵎⵙⵍⵉ ⵖⴰⵙ ⵎⴰ ⵜⵛⵖⵍⴷ</translation>
     </message>
     <message>
         <source>Notify via desktop notifications</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⴱⴻⵔⵔⴻⵃ ⵙ ⵓⴱⴻⴳⴳⴻⵏ ⵏ ⵓⵙⴻⵍⴽⵉⵎ</translation>
+        <translation type="unfinished">ⵙⵙⵉⵡⴹ ⴰⵏⵖⵎⵉⵙ ⵙ ⵜⵏⴱⴱⴰⴹⵉⵏ ⵏ ⵜⵏⴰⵔⴰ</translation>
     </message>
     <message>
         <source>Hide message sender and contents</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴼⴼⴻⵔ ⴰⵎⵛⴻⴳⴳⴻⵄ ⵏ ⵢⵉⵣⴻⵏ ⴷ ⵡⴰⵢⴻⵏ ⵢⴻⵍⵍⴰⵏ ⴷⴻⴳⵙ</translation>
+        <translation type="unfinished">ⴼⴼⵔ ⴰⵎⵙⴰⵣⵏ ⵏ ⵉⵣⵏ ⴷ ⵓⴳⴱⵓⵔ</translation>
     </message>
     <message>
         <source>Use colored nicknames in conferences</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵉⵙⵎⴰⵡⴻⵏ ⵏ ⵢⵉⵏⵉ ⴷⴻⴳ ⵢⵉⵙⴰⵔⴰⴳⴻⵏ</translation>
+        <translation type="unfinished">ⵙⵙⵎⵔⵙ ⵉⵙⵎⴰⵡⵏ ⵏ ⵓⵙⵏⵓⴱⴳ ⵙ ⵢⵉⵏⵉ ⴳ ⵉⵙⴰⵔⴰⴳⵏ</translation>
     </message>
     <message>
         <source>Only notify about new messages in conferences when your nickname is mentioned.</source>
         <comment>toolTip for Conferences only notify when mentioned</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⴻⵅⴷⴻⵎ ⴽⴰⵏ ⵉⵣⴻⵏ ⵉⵎⴰⵢⵏⵓⵜⴻⵏ ⴷⴻⴳ ⵢⵉⵙⴰⵔⴰⴳⴻⵏ ⵎⵉ ⴰⵔⴰ ⴷⵢⴻⵜⵜⵡⴰⴱⴷⴻⵔ ⵢⵉⵙⴻⵎⵉⴽ ⵏ ⵜⵎⴻⵥⴷⵉⵜ.</translation>
     </message>
     <message>
         <source>If disabled, mute notification sounds when status is Busy (but still show a notification)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴼⴻⴹ, ⵙⵙⵓⵙⵎ ⴰⵙⴻⵍⴽⵉⵏ ⵎⵉ ⴰⵔⴰ ⵢⵉⵍⵉ ⵍⵃⴰⵍ ⵢⴻⵜⵜⵡⴰⵅⴷⴻⵎ (ⵎⴰⵛⴰ ⵎⴰⵣⴰⵍ ⵢⴻⵙⵙⴽⴰⵏⴰⵢⴷ ⴰⵙⴻⵍⴽⵉⵏ)</translation>
     </message>
     <message>
         <source>Use desktop notifications, e.g. in a notification center or at the system tray. Without this, the notification will only be visible as a flashing tray icon.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵉⵙⴰⵍⴰⵏ ⵏ ⵓⵙⴻⵍⴽⵉⵎ, ⴰⵎⴻⴷⵢⴰ. ⴷⴻⴳ ⵢⵉⵡⴻⵏ ⵏ ⵡⴰⵎⵎⴰⵙ ⵏ ⵓⵙⵎⴻⵍ ⵏⴻⵖ ⴷⴻⴳ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵏⴰⴳⵔⴰⵡ. ⵎⴻⴱⵍⴰ ⴰⵢⴰ, ⴰⵖⵎⵉⵙ ⴰⴷ ⵢⴻⵜⵜⵡⴰⵥⴻⵔ ⴽⴰⵏ ⴰⵎ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵢⴻⵜⵜⴼⴻⴳⴳⵉⴹⴻⵏ.</translation>
     </message>
     <message>
         <source>If disabled, use basic system tray notifications. Otherwise, try to use the notification backend of your desktop environment. Disable this if you observe issues with desktop notifications.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴼⴻⴹ, ⵙⵙⴻⵇⴷⴻⵛ ⵉⵙⴰⵍⴰⵏ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵏ ⵓⵏⴰⴳⵔⴰⵡ ⵏ ⵍⵍⵙⴰⵙ. ⵎⴰ ⵓⵍⴰⵛ, ⵄⵔⴻⴹ ⴰⴷ ⵜⴻⵙⵇⴻⴷⵛⴻⴹ ⴰⴹⵔⵉⵙ ⵏ ⵓⵙⵎⴻⵍ ⵏ ⵜⵡⴻⵏⵏⴰⴹⵜ ⵏ ⵓⵙⴻⵍⴽⵉⵎⵉⴽ. ⵙⵙⴻⵅⴷⴻⵎ ⴰⵢⴰ ⵎⴰ ⵜⵎⵓⵇⵍⴻⴹ ⵓⴳⵓⵔⴻⵏ ⵙ ⵜⵖⴻⵎⵎⴰⵔ ⵏ ⵓⴹⵔⵉⵙ.</translation>
     </message>
     <message>
         <source>Use system-specific notification backend if available</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵇⴷⴻⵛ ⵜⴰⵖⴻⵛⵜ ⵏ ⵓⵙⵎⴻⵍ ⵏ ⵓⵏⴰⴳⵔⴰⵡ ⵎⴰ ⵢⴻⵍⵍⴰ ⵜⴻⵍⵍⴰ</translation>
+        <translation type="unfinished">ⵙⵙⵎⵔⵙ ⴰⵏⴳⵔⴰⵡ ⵏ ⵜⵏⴱⴱⴰⴹⵉⵏ ⵏ ⵓⵏⴳⵔⴰⵡ ⵎⴰ ⵢⵍⵍⴰ</translation>
     </message>
     <message>
         <source>Only show &quot;new message&quot; without showing potentially secret information in desktop notifications.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⴻⴽⵏⴻⴹ ⴽⴰⵏ &quot;ⵉⵣⴻⵏ ⴰⵎⴰⵢⵏⵓⵜ&quot; ⵡⴰⵔ ⵎⴰ ⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵉⵙⴰⵍⴰⵏ ⵉⵣⴻⵎⵔⴻⵏ ⴰⴷ ⵉⵍⵉⵏ ⴷ ⵓⴼⵓⵔⴻⵏ ⴷⴻⴳ ⵢⵉⵙⴰⵍⴰⵏ ⵏ ⵓⵙⴻⵍⴽⵉⵎ.</translation>
     </message>
     <message>
         <source>Split friend list and chat window into separately moveable windows.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴹⵓ ⵍⵉⵙⵜⵉ ⵏ ⵢⵉⵎⴻⴷⴷⵓⴽⴰⵍ ⴷ ⵟⵟⴰⵇ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵖⴻⴼ ⵟⵟⴰⵇ ⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⵏ ⵙ ⵜⴼⴻⵔⴽⵉⵜ ⵢⴻⵎⴳⴰⵔⴰⴷⴻⵏ.</translation>
+        <translation type="unfinished">ⴱⴹⵓ ⵜⴰⵍⴳⴰⵎⵜ ⵏ ⵢⵉⵎⴷⴷⵓⴽⴽⴰⵍ ⴷ ⵟⵟⴰⵇ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵖⴻⴼ ⵟⵟⴰⵇ ⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⵏ ⵙ ⵜⴼⴻⵔⴽⵉⵜ ⵢⴻⵎⴳⴰⵔⴰⴷⴻⵏ.</translation>
     </message>
     <message>
         <source>If enabled, every contact without an avatar will have a generated icon based on their Tox ID instead of the default picture. Requires restart to apply.</source>
         <comment>toolTip for show identicons</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵎⴰ ⵢⴻⵍⵍⴰ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷ, ⵢⴰⵍ ⴰⵙⴻⵏⵇⴻⴷ ⵡⴰⵔ avatar ⴰⴷ ⵢⴻⵙⵄⵓ ⵜⴰⵙⴻⴽⴽⵉⵔⵜ ⵢⴻⵜⵜⵡⴰⵙⵏⵓⵍⴼⴰⵏ ⵙ ⵍⵙⴰⵙ ⵏ Tox IDnsen ⴷⴻⴳ ⵓⵎⴹⵉⵇ ⵏ ⵜⵓⴳⵏⴰ ⵏ ⵓⵙⵎⴻⵍ. ⵢⴻⵃⵡⴰⴵ ⴰⵄⵉⵡⴻⴷ ⵏ ⵓⵙⴱⴰⴷⵓ ⴰⴽⴽⴻⵏ ⴰⴷ ⵢⴻⵜⵜⵡⴰⵙⵇⴻⴷⵛⴻⴹ.</translation>
     </message>
     <message>
         <source>Display textual emojis as colorful pictures instead of text or black/white font-rendered emojis.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵙⴻⴽⵏⴻⴹ ⵉⵎⵓⴹⴰⵏ ⵏ ⵓⴹⵔⵉⵙ ⴰⵎ ⵜⵓⴳⵏⵉⵡⵉⵏ ⵏ ⵢⵉⵏⵉ ⴷⴻⴳ ⵓⵎⴹⵉⵇ ⵏ ⵓⴹⵔⵉⵙ ⵏⴻⵖ ⵉⵎⵓⴹⴰⵏ ⵏ ⵜⴼⴻⵍⵡⵉⵜ ⵢⴻⵜⵜⵡⴰⵙⴱⴻⴷⴷⴻⵏ ⵙ ⵜⴼⴻⵍⵡⵉⵜ ⵜⴰⴱⴻⵔⴽⴰⵏⵜ/ⵜⴰⵎⴻⵍⵍⴰⵍⵜ.</translation>
     </message>
     <message>
         <source>Select which set of pictures to use when rendering emojis.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴼⵔⴻⵏ ⴰⵏⵡⴰ ⵜⴰⴳⴳⵔⵓⵎⴰ ⵏ ⵜⵓⴳⵏⵉⵡⵉⵏ ⴰⵔⴰ ⵜⴻⵙⵇⴻⴷⵛⴻⴹ ⵎⵉ ⴰⵔⴰ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ emojis.</translation>
     </message>
     <message>
         <source>Smiley pack:</source>
         <extracomment>Text on smiley pack label</extracomment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵇⴱⵓⵛⵜ ⵏ Smiley:</translation>
+        <translation type="unfinished">ⵜⴰⴳⵔⵓⵎⵎⴰ ⵏ ⵉⵙⵎⴰⵢⵍⵉⵢⵏ:</translation>
     </message>
     <message>
         <source>Size in pixels of an emoji picture. Select something similar to your base font size.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⴳⵎⵓⴹⵜ ⴷⴻⴳ yipiksel ⵏ ⵜⵓⴳⵏⴰ ⵏ emoji. ⴼⵔⴻⵏ ⴽⵔⴰ ⵢⴻⵛⴱⴰⵏ ⴰⴹⵔⵉⵙ ⵏ ⵜⴼⴻⵍⵡⵉⵜⵉⴽ ⵏ ⵍⵍⵙⴰⵙ.</translation>
+        <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ ⵙ ⵉⴱⵉⴽⵙⵉⵍⵏ ⵏ ⵜⵡⵍⴰⴼⵜ ⵏ ⵉⵎⵓⵊⵉ. ⴼⵔⵏ ⴰⵢⵏ ⵉⵔⵡⴰⵙⵏ ⵜⴰⵊⵓⵎⵎⴰ ⵏ ⵜⵉⵔⴰ ⵏⵏⴽ.</translation>
     </message>
     <message>
         <source>Base style to use for the UI. Fusion is recommended as it works best with qTox theming.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙⵜⵢⵍⴻ ⵏ ⵍⵍⵙⴰⵙ ⴰⵔⴰ ⵜⴻⵙⵇⴻⴷⵛⴻⴹ ⵉ UI. Fusion ⵢⴻⵜⵜⵡⴰⵙⵙⵓⵎⵎⴻⵍ ⵉⵎⵉ ⵉⵅⴻⴷⴷⴻⵎ ⵎⵍⵉⵃ ⵙ qTox ⵜⵀⴻⵎⵉⵏⴳ.</translation>
     </message>
     <message>
         <source>UI color theme. Use this to select dark mode.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴻⵏⵜⴻⵍ ⵏ ⵢⵉⵏⵉ ⵏ UI. ⵙⴻⵇⴷⴻⵛ ⴰⵢⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⴼⵔⴻⵏⴹ ⴰⴹⵔⵉⵙ ⵏ ⵜⵍⴻⵎⵎⴰⵙⵜ.</translation>
     </message>
     <message>
         <source>Show previews for sent and received images in chats. Hover over the inline preview to display a larger preview.</source>
         <comment>tooltip for Image preview setting</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴽⴻⵏⴷ ⵜⵉⵡⵡⵓⵔⴰ ⵏ ⵜⵓⴳⵏⵉⵡⵉⵏ ⵢⴻⵜⵜⵡⴰⵣⴻⵏ ⴷ ⵜⵉⴷ ⵢⴻⵜⵜⵡⴰⵇⴱⴰⵍ ⴷⴻⴳ ⵜⵎⴻⵙⵍⴰⵢⵉⵏ. ⵃⴰⴷⴻⵔ ⴰⴼⵓⵙⵉⴽ ⵖⴻⴼ ⵜⵎⵓⵖⵍⵉ ⵏ ⵓⵙⵎⴻⵍ ⴰⴽⴽⴻⵏ ⴰⴷ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵜⴰⵎⵓⵖⵍⵉ ⵜⴰⵎⴻⵇⵔⴰⵏⵜ.</translation>
+        <translation type="unfinished">ⵙⴽⴻⵏⴷ ⵜⵉⵡⵡⵓⵔⴰ ⵏ ⵜⵓⴳⵏⵉⵡⵉⵏ ⵢⴻⵜⵜⵡⴰⵣⴻⵏ ⴷ ⵜⵉⴷ ⵢⴻⵜⵜⵡⴰⵇⴱⴰⵍ ⴷⴻⴳ ⵢⵉⵎⵙⴰⵡⴰⵍⴻⵏ. ⵃⴰⴷⴻⵔ ⴰⴼⵓⵙⵉⴽ ⵖⴻⴼ ⵜⵎⵓⵖⵍⵉ ⵏ ⵓⵙⵎⴻⵍ ⴰⴽⴽⴻⵏ ⴰⴷ ⴷⵜⴻⵙⵙⴻⴽⵏⴻⴹ ⵜⴰⵎⵓⵖⵍⵉ ⵜⴰⵎⴻⵇⵔⴰⵏⵜ.</translation>
     </message>
     <message>
         <source>Image preview</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴽⵛⴻⵎ ⵏ ⵜⵓⴳⵏⴰ</translation>
+        <translation type="unfinished">ⵜⴰⵎⵓⵖⵍⵉ ⵏ ⵜⵡⵍⴰⴼⵜ</translation>
     </message>
     <message>
         <source>Maximum number of messages (per conversation) loaded from chat history.
 Decrease this to improve performance. A too low number here may cause the
 scroll bar to disappear.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵎⴹⴰⵏ ⴰⵄⵍⴰⵢⴰⵏ ⵏ ⵢⵉⵣⴻⵏ (ⵉ ⵢⴰⵍ ⴰⵎⵙⴰⵡⴰⵍ) ⵢⴻⵜⵜⵡⴰⵛⴰⵔⴳⴻⵏ ⵙⴻⴳ ⵓⵎⴻⵣⵔⵓⵢ ⵏ
-ⵜⵎⴻⵙⵍⵉⵡⵜ. ⵙⵏⴻⵇⵙ ⴰⵢⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⵍⵀⵓⴹ ⴰⵅⴻⴷⴷⵉⵎ. ⴰⵎⴹⴰⵏ ⴷ ⴰⵎⴻⵥⵢⴰⵏ ⴰⵟⴰⵙ ⴷⴰⴳⵉ
+        <translation type="unfinished">ⴰⵎⴹⴰⵏ ⴰⵄⵍⴰⵢⴰⵏ ⵏ ⵢⵉⵣⴻⵏ (ⵉ ⵢⴰⵍ ⴰⵎⵙⴰⵡⴰⵍ) ⵢⴻⵜⵜⵡⴰⵛⴰⵔⴳⴻⵏ ⵙⴻⴳ ⵓⵎⵣⵔⵓⵢ ⵏ
+ⵓⵎⵙⴰⵡⴰⵍ. ⵙⵏⴻⵇⵙ ⴰⵢⴰ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵙⵙⴻⵍⵀⵓⴹ ⴰⵅⴻⴷⴷⵉⵎ. ⴰⵎⴹⴰⵏ ⴷ ⴰⵎⴻⵥⵢⴰⵏ ⴰⵟⴰⵙ ⴷⴰⴳⵉ
 ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵙⵙⵉⵡⴻⴹ ⴰⴷ ⵢⴻⴼⴼⴻⵖ ⵓⴹⵔⵉⵙ ⵏ ⵓⵙⵎⴻⵍ.</translation>
     </message>
     <message>
         <source>Maximum chat log view size</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ ⵜⴰⵎⴻⵇⵇⵔⴰⵏⵜ ⵏ ⵓⵎⵓⵖ
-ⵏ ⵓⵖⵎⵉⵙ ⵏ ⵓⵎⴻⵙⵍⴰⵢ</translation>
+ⵏ ⵓⵖⵎⵉⵙ ⵏ ⵓⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Number of messages to load from the chat history when scrolling. A too low
 number here may cause the scroll bar to disappear.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵎⴹⴰⵏ ⵏ ⵢⵉⵣⴻⵏ ⴰⵔⴰ ⵜⵉⴷⵜⴻⵙⵙⵓⴼⵖⴻⴹ ⵙⴻⴳ ⵓⵎⴻⵣⵔⵓⵢ ⵏ ⵜⵎⴻⵙⵍⵉⵡⵜ ⵎⵉ ⴰⵔⴰ ⵜⵉⴷⵜⴻⵙⵙⵓⴼⵖⴻⴹ.
+        <translation type="unfinished">ⴰⵎⴹⴰⵏ ⵏ ⵢⵉⵣⴻⵏ ⴰⵔⴰ ⵜⵉⴷⵜⴻⵙⵙⵓⴼⵖⴻⴹ ⵙⴻⴳ ⵓⵎⵣⵔⵓⵢ ⵏ ⵓⵎⵙⴰⵡⴰⵍ ⵎⵉ ⴰⵔⴰ ⵜⵉⴷⵜⴻⵙⵙⵓⴼⵖⴻⴹ.
 ⴰⵎⴹⴰⵏ ⴷ ⴰⵎⴻⵥⵢⴰⵏ ⴰⵟⴰⵙ ⴷⴰⴳⵉ ⵢⴻⵣⵎⴻⵔ ⴰⴷ ⵢⴻⵙⵙⵉⵡⴻⴹ ⴰⴷ ⵢⴻⴼⴼⴻⵖ ⵓⴹⵔⵉⵙ ⵏ ⵓⵙⵎⴻⵍ.</translation>
     </message>
     <message>
         <source>Chat log chunk size</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⵊⵓⵎⵎⴰ ⵏ ⵓⵃⵔⵉⵛ ⵏ
-ⵓⵖⵎⵉⵙ ⵏ ⵓⵎⴻⵙⵍⴰⵢ</translation>
+ⵓⵖⵎⵉⵙ ⵏ ⵓⵎⵙⴰⵡⴰⵍ</translation>
     </message>
     <message>
         <source>Chat log:</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵖⵎⵉⵙ ⵏ
-ⵓⵎⴻⵙⵍⴰⵢ:</translation>
+ⵓⵎⵙⴰⵡⴰⵍ:</translation>
     </message>
     <message>
         <source>Hide suffix after NULL symbol</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴼⴼⵔⵏ ⴷⴼⴼⵉⵔ ⵏ ⵓⵣⴰⵎⵓⵍ ⵏ NULL</translation>
     </message>
 </context>
@@ -3570,183 +3000,151 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Online</source>
         <comment>Button to set your status to &apos;Online&apos;</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Oⵏⵍⴰⵢⵏ</translation>
+        <translation type="unfinished">ⵢⵍⵍⴰ</translation>
     </message>
     <message>
         <source>Away</source>
         <comment>Button to set your status to &apos;Away&apos;</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⴱⵄⴻⴷ</translation>
+        <translation type="unfinished">ⵉⴱⵄⴷ</translation>
     </message>
     <message>
         <source>Busy</source>
         <comment>Button to set your status to &apos;Busy&apos;</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵄⵎⴻⵔ</translation>
+        <translation type="unfinished">ⵢⵛⵖⵍ</translation>
     </message>
     <message>
         <source>File</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⴻⵏⵜⵓ</translation>
+        <translation type="unfinished">ⴰⴼⴰⵢⵍⵓ</translation>
     </message>
     <message>
         <source>Edit</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵥⵔⴻⴳ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ</translation>
     </message>
     <message>
         <source>Logout</source>
         <comment>Tray action menu to logout user</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⵓⴼⴼⵖⴰ</translation>
     </message>
     <message>
         <source>Filter...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵜⴰⴼⵉⵍⵜ...</translation>
     </message>
     <message>
         <source>Contacts</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵉⵎⴻⵙⵍⴰⵢⴻⵏ</translation>
+        <translation type="unfinished">ⵉⵏⴻⵔⵎⵉⵙⴻⵏ</translation>
     </message>
     <message>
         <source>Status</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵜⴰⵍⵖⴰ</translation>
+        <translation type="unfinished">ⴰⴷⴷⴰⴷ</translation>
     </message>
     <message>
         <source>Your name</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴻⵎ ⵏⵏⴽ</translation>
     </message>
     <message>
         <source>Create new conference...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓⴷ ⴰⵙⴰⵔⴰⴳ ⴰⵎⴰⵢⵏⵓⵜ...</translation>
+        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓ ⴰⵙⴰⵔⴰⴳ ⴰⵎⴰⵢⵏⵓⵜ...</translation>
     </message>
     <message>
         <source>Create new circle...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵔⵏⵓ ⵜⴰⵖⴻⵛⵜ ⵜⴰⵎⴰⵢⵏⵓⵜ...</translation>
+        <translation type="unfinished">ⵙⵏⵓⵍⴼⵓ ⵜⴰⵔⴱⴰⵄⵜ ⵜⴰⵎⴰⵢⵏⵓⵜ...</translation>
     </message>
     <message>
         <source>By Name</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵙ ⵢⵉⵙⴻⵎ</translation>
     </message>
     <message>
         <source>By Activity</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵙ Tigawt</translation>
+        <translation type="unfinished">ⵙ ⵜⵉⴳⴰⵡⵜ</translation>
     </message>
     <message>
         <source>All</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⴽⴽ</translation>
     </message>
     <message>
         <source>Online</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Oⵏⵍⴰⵢⵏ</translation>
+        <translation type="unfinished">ⵢⵍⵍⴰ</translation>
     </message>
     <message>
         <source>Offline</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⵕⵕⴰ ⵉ ⵍⴰⵏⵜⵉⵔⵏⴰⵜ</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵍⵍⵉ</translation>
     </message>
     <message>
         <source>Friends</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵎⴷⵓⴽⴰⵍ</translation>
     </message>
     <message>
         <source>Conferences</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⵉⵙⴰⵔⴰⴳⴻⵏ</translation>
     </message>
     <message>
         <source>Search Contacts</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵏⴰⴷⵉ ⵖⴻⴼ ⵉⵎⴻⵙⵍⴰⵢⴻⵏ</translation>
+        <translation type="unfinished">ⵔⵣⵓ ⵅⴼ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ</translation>
     </message>
     <message>
         <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵙⴰⵔⴰⴳ #%1.</translation>
     </message>
     <message>
         <source>Show</source>
         <comment>Tray action menu to show qTox window</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵢⴻⵎⵍⴰⵯⵉⵢⵉⵯⴷ</translation>
+        <translation type="unfinished">ⵙⴽⵏ</translation>
     </message>
     <message>
         <source>Add friend</source>
         <comment>title of the window</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴻⴷⴷⴰⴽⴻⵍ</translation>
+        <translation type="unfinished">ⵔⵏⵓ ⴰⵎⴷⴷⴰⴽⴽⵍ</translation>
     </message>
     <message>
         <source>Conference invites</source>
         <comment>title of the window</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵄⵔⴰⴹ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
+        <translation type="unfinished">ⵜⵉⵏⴱⴳⵉⵡⵉⵏ ⵏ ⵓⵙⴰⵔⴰⴳ</translation>
     </message>
     <message>
         <source>File transfers</source>
         <comment>title of the window</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⵉⵡⴻⴹ ⵏ ⵓⴼⴰⵢⵍⵓ</translation>
+        <translation type="unfinished">ⵉⵙⵉⵡⴹⵏ ⵏ ⵉⴼⵓⵢⵍⴰ</translation>
     </message>
     <message>
         <source>Settings</source>
         <comment>title of the window</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⵖⵥⴰⵏ</translation>
+        <translation type="unfinished">ⵉⵙⵖⵡⴰⵕⵏ</translation>
     </message>
     <message>
         <source>My profile</source>
         <comment>title of the window</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴰⵙⴻⴱⵜⴻⵔⵉⵡ</translation>
+        <translation type="unfinished">ⴰⴳⵉⵍⴰⵍ ⵉⵏⵓ</translation>
     </message>
     <message>
         <source>Toxcore failed to start, the application will terminate after you close this message.</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Toxcore ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴱⴷⵓ, ⴰⵙⴻⵏⴼⴰⵔ ⴰⴷ ⵢⴻⴽⴼⵓ ⴷⴻⴼⴼⵉⵔ ⵎⴰ ⵜⵖⴻⵍⴹⴻⴹ ⵉⵣⴻⵏⴰ.</translation>
+        <translation type="unfinished">Toxcore ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴱⴷⵓ, ⴰⵙⵏⴰⵙ ⴰⴷ ⵢⴻⴽⴼⵓ ⴷⴻⴼⴼⵉⵔ ⵎⴰ ⵜⵖⴻⵍⴹⴻⴹ ⵉⵣⴻⵏⴰ.</translation>
     </message>
     <message>
         <source>Toxcore failed to start with your proxy settings. qTox cannot run; please modify your settings and restart.</source>
         <comment>popup text</comment>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Toxcore ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴱⴷⵓ ⵙ ⵜⵖⴰⵡⵙⵉⵡⵉⵏⵉⴽ ⵏ proxy. qTox ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴷⴷⵓ; ⵜⵜⵅⵉⵍⴽ ⴱⴻⴷⴷⴻⵍ ⵉⵙⴻⵖⵡⴰⵏⵉⴽ ⵓ ⵄⵉⵡⴻⴷ ⴱⴷⵓ.</translation>
+        <translation type="unfinished">Toxcore ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴱⴷⵓ ⵙ ⵜⵖⴰⵡⵙⵉⵡⵉⵏⵉⴽ ⵏ proxy. qTox ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴷⴷⵓ; ⵜⵜⵅⵉⵍⴽ ⵙⵏⴼⵍ ⵉⵙⵖⵡⴰⵕⵏⵉⴽ ⵓ ⵄⵉⵡⴻⴷ ⴱⴷⵓ.</translation>
     </message>
     <message>
         <source>Couldn&apos;t send friend request</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴰⵣⴻⵏ ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ.</translation>
+        <translation type="unfinished">ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴰⵣⴻⵏ ⴰⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ.</translation>
     </message>
     <message>
         <source>Debug</source>
         <comment>title of the window</comment>
-        <translation type="unfinished">ⴷⴻⴱⵓⴳ</translation>
+        <translation type="unfinished">ⵜⴰⵙⵖⵉⵢⵜ</translation>
     </message>
     <message numerus="yes">
         <source>%n new friend request(s)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">
-            <numerusform>%ⵏ ⴰⵙⵓⵜⴻⵔ (ⵏ) ⵏ ⵓⵎⴻⴷⴷⴰⴽⴻⵍ ⴰⵎⴰⵢⵏⵓⵜ</numerusform>
-            <numerusform></numerusform>
+            <numerusform>%n ⵓⵙⵓⵜⴻⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⴰⵎⴰⵢⵏⵓⵜ</numerusform>
+            <numerusform>%n ⵢⵉⵙⵓⵜⴰⵔ ⵏ ⵓⵎⴷⴷⴰⴽⴽⵍ ⵉⵎⴰⵢⵏⵓⵜⴻⵏ</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n new conference invite(s)</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">
-            <numerusform>%ⵏ ⴰⵄⵔⴰⴹ ⵏ ⵓⵙⴰⵔⴰⴳ ⴰⵎⴰⵢⵏⵓⵜ</numerusform>
-            <numerusform></numerusform>
+            <numerusform>%n ⵜⴰⵏⴱⴳⵉⵡⵜ ⵏ ⵓⵙⴰⵔⴰⴳ ⵜⴰⵎⴰⵢⵏⵓⵜ</numerusform>
+            <numerusform>%n ⵜⵉⵏⴱⴳⵉⵡⵉⵏ ⵏ ⵓⵙⴰⵔⴰⴳ ⵜⵉⵎⴰⵢⵏⵓⵜⵉⵏ</numerusform>
         </translation>
     </message>
     <message>
@@ -3756,13 +3154,11 @@ number here may cause the scroll bar to disappear.</source>
     </message>
     <message>
         <source>Change status</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⴰⴷⴻⴳ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⴰⴷⴷⴰⴷ</translation>
     </message>
     <message>
         <source>Edit profile</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⴱⴻⴷⴷⴻⵍ ⴰⴳⴱⵓⵔ</translation>
+        <translation type="unfinished">ⵙⵏⴼⵍ ⴰⴳⵉⵍⴰⵍ</translation>
     </message>
     <message>
         <source>Logout</source>
@@ -3770,17 +3166,14 @@ number here may cause the scroll bar to disappear.</source>
     </message>
     <message>
         <source>Add contact...</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ⵔⵏⵓ ⴰⵙⵙⴰⵖ...</translation>
+        <translation type="unfinished">ⵔⵏⵓ ⴰⵏⴻⵔⵎⵉⵙ...</translation>
     </message>
     <message>
         <source>Next conversation</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵎⵙⴰⵡⴰⵍ ⵉⴷ ⵉⵜⴻⴷⴷⵓⵏ</translation>
     </message>
     <message>
         <source>Previous conversation</source>
-        <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ⴰⵎⵙⴰⵡⴰⵍ ⵢⴻⵣⵔⵉⵏ</translation>
     </message>
 </context>


### PR DESCRIPTION
Make it a more natural and less literal translation.

Also:
- Get rid of "vidyu", which is an anglicism that feels out of place.
- Keeping LAN and other acronyms, though.
- Corrected a bunch of weird auto-translation errors like writing ".tox" as ".tuks" or "Tox" as "Tuks". That's a proper noun and doesn't need translation.
- Corrected weird auto-translations of things like "offline", which was translated to "ⴱⴻⵕⵕⴰ ⵉ ⵍⴰⵏⵜⵉⵔⵏⴰⵜ" (roughly: "outside of the internet") to something more succinct and common (ⵢⴼⴼⵖ = exited/offline).

Removed the automated translation comments, but kept the unfinished marker so someone more knowledgeable than me can verify my changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/642)
<!-- Reviewable:end -->
