### PR TITLE
fix(video): Handle empty frame dimensions when screen grabs are denied.

### DIFF
--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -63,6 +63,7 @@ if("EmojiOne" IN_LIST SMILEY_PACKS)
   auto_test(persistence smileypack "${SMILEY_RESOURCES}" "") # needs emojione
 endif()
 auto_test(video videomode "" "")
+auto_test(video videoframe "" "${LIBAVUTIL_LIBRARIES}")
 auto_test(widget filesform "" "")
 auto_test(widget/form/settings generalform "" "")
 auto_test(widget/tool identicon "" "")

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -91,9 +91,23 @@ UI_TESTS = ["loginscreen_test"]
         "model/exiftransform_test.cpp",
         "persistence/dbschema_test.cpp",
         "platform/stacktrace_test.cpp",
+        "video/videoframe_test.cpp",
         "**/*_fuzz_test.cpp",
     ],
 )]
+
+qt_test(
+    name = "videoframe_test",
+    size = "small",
+    src = "video/videoframe_test.cpp",
+    copts = COPTS,
+    mocopts = ["-Iqtox"],
+    deps = [
+        "//qtox/src",
+        "@ffmpeg",
+        "@qt//:qt_core",
+    ],
+)
 
 cc_fuzz_test(
     name = "serialize_fuzz_test",

--- a/test/chatlog/chatwidget_test.cpp
+++ b/test/chatlog/chatwidget_test.cpp
@@ -4,9 +4,7 @@
 
 #include "src/chatlog/chatwidget.h"
 
-#include "src/chatlog/chatlinestorage.h"
 #include "src/chatlog/documentcache.h"
-#include "src/chatlog/pixmapcache.h"
 #include "src/core/icoreidhandler.h"
 #include "src/model/ichatlog.h"
 #include "src/persistence/settings.h"

--- a/test/net/updateversion_test.cpp
+++ b/test/net/updateversion_test.cpp
@@ -30,10 +30,10 @@ void TestUpdateVersion::testTagToVersion()
 
 void TestUpdateVersion::testIsUpdateAvailable()
 {
-    Version v123{1, 2, 3};
-    Version v124{1, 2, 4};
-    Version v130{1, 3, 0};
-    Version v200{2, 0, 0};
+    const Version v123{1, 2, 3};
+    const Version v124{1, 2, 4};
+    const Version v130{1, 3, 0};
+    const Version v200{2, 0, 0};
 
     QVERIFY(isUpdateAvailable(v123, v124));
     QVERIFY(isUpdateAvailable(v123, v130));

--- a/test/video/videoframe_test.cpp
+++ b/test/video/videoframe_test.cpp
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2026 The TokTok team.
+ */
+
+#include "src/video/videoframe.h"
+
+#include <QObject>
+#include <QtTest/QtTest>
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavutil/imgutils.h>
+}
+
+class TestVideoFrame : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testToQImageEmptySize();
+    void testToQImageEmptySource();
+    void testToToxYUVFrameEmptySource();
+};
+
+void TestVideoFrame::testToQImageEmptySize()
+{
+    AVFrame* frame = av_frame_alloc();
+    frame->width = 100;
+    frame->height = 100;
+    frame->format = AV_PIX_FMT_YUV420P;
+    av_image_alloc(frame->data, frame->linesize, 100, 100, AV_PIX_FMT_YUV420P, 1);
+
+    // VideoFrame takes ownership and will free the frame if we pass true
+    auto videoFrame = VideoFrame::fromAVFrameUntracked(1, frame, true);
+
+    // This should not crash. Since QSize(0,0) is empty, it should fall back to source size (100x100)
+    const QImage img = videoFrame->toQImage(QSize(0, 0));
+    QCOMPARE(img.size(), QSize(100, 100));
+}
+
+void TestVideoFrame::testToQImageEmptySource()
+{
+    AVFrame* frame = av_frame_alloc();
+    frame->width = 0;
+    frame->height = 0;
+    frame->format = AV_PIX_FMT_YUV420P;
+
+    auto videoFrame = VideoFrame::fromAVFrameUntracked(1, frame, true);
+
+    // Both requested size and source size are empty, should return null image
+    const QImage img = videoFrame->toQImage(QSize(0, 0));
+    QVERIFY(img.isNull());
+}
+
+void TestVideoFrame::testToToxYUVFrameEmptySource()
+{
+    AVFrame* frame = av_frame_alloc();
+    frame->width = 0;
+    frame->height = 0;
+    frame->format = AV_PIX_FMT_YUV420P;
+
+    auto videoFrame = VideoFrame::fromAVFrameUntracked(1, frame, true);
+
+    auto [toxFrame, locker] = videoFrame->toToxYUVFrame();
+    QVERIFY(!toxFrame.isValid());
+}
+
+QTEST_GUILESS_MAIN(TestVideoFrame)
+#include "videoframe_test.moc"

--- a/test/widget/loginscreen_test.cpp
+++ b/test/widget/loginscreen_test.cpp
@@ -53,15 +53,14 @@ private:
 
 void TestLoginScreen::testLoginScreen()
 {
-    // NOLINTNEXTLINE(misc-const-correctness)
-    LoginScreen loginScreen(paths, style, themeColor, profileName);
+    LoginScreen loginScreen(paths, style, themeColor, profileName); // NOLINT(misc-const-correctness)
 
     COMPARE_GRAB(&loginScreen, "loginscreen_empty.png");
 }
 
 void TestLoginScreen::testCreateProfile()
 {
-    LoginScreen loginScreen(paths, style, themeColor, profileName);
+    LoginScreen loginScreen(paths, style, themeColor, profileName); // NOLINT(misc-const-correctness)
 
     bool created = false;
     QObject::connect(&loginScreen, &LoginScreen::createNewProfile, this,
@@ -78,7 +77,7 @@ void TestLoginScreen::testCreateProfile()
 
 void TestLoginScreen::testCreateProfileBadPassword()
 {
-    LoginScreen loginScreen(paths, style, themeColor, profileName);
+    LoginScreen loginScreen(paths, style, themeColor, profileName); // NOLINT(misc-const-correctness)
 
     bool created = false;
     connect(&loginScreen, &LoginScreen::createNewProfile, this, [&created]() { created = true; });


### PR DESCRIPTION
If a video capture fails (e.g. gdigrab error), it may emit frames with 0x0 dimensions. `VideoFrame::toQImage` previously checked for `isValid()`, which incorrectly included 0x0 sizes, causing nullptr derefs. `isEmpty()` catches zero dimensions. Also, added nullptr checks in the internal frame storage logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/651)
<!-- Reviewable:end -->
