### PR TITLE
fix(chatlog): Handle null document in Text item when right-clicking.

### DIFF
--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -38,6 +38,7 @@ set(TEST_RESOURCES test/resources/test_data.qrc ${${BINARY_NAME}_RESOURCES})
 # keep-sorted start
 auto_test(chatlog chatlinestorage "" "")
 auto_test(chatlog chatwidget "" "")
+auto_test(chatlog text "" "")
 auto_test(chatlog textformatter "" "")
 auto_test(core chatid "" "")
 auto_test(core core "${${BINARY_NAME}_RESOURCES}" "mock_library")

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -303,6 +303,10 @@ QString Text::getText() const
  */
 QString Text::getLinkAt(QPointF scenePos) const
 {
+    if (doc == nullptr) {
+        return {};
+    }
+
     QTextCursor cursor(doc);
     cursor.setPosition(cursorFromPos(scenePos));
     return cursor.charFormat().anchorHref();
@@ -437,6 +441,10 @@ QString Text::extractSanitizedText(int from, int to) const
 
 QString Text::extractImgTooltip(int pos) const
 {
+    if (doc == nullptr) {
+        return {};
+    }
+
     for (QTextBlock::Iterator itr = doc->firstBlock().begin(); itr != doc->firstBlock().end(); ++itr) {
         if (itr.fragment().contains(pos) && itr.fragment().charFormat().isImageFormat()) {
             const QTextImageFormat imgFmt = itr.fragment().charFormat().toImageFormat();

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -92,9 +92,28 @@ UI_TESTS = ["loginscreen_test"]
         "persistence/dbschema_test.cpp",
         "platform/stacktrace_test.cpp",
         "video/videoframe_test.cpp",
+        "chatlog/text_test.cpp",
         "**/*_fuzz_test.cpp",
     ],
 )]
+
+qt_test(
+    name = "text_test",
+    size = "small",
+    src = "chatlog/text_test.cpp",
+    copts = COPTS,
+    mocopts = ["-Iqtox"],
+    deps = [
+        ":dbutility",
+        ":mock",
+        "//qtox:res_lib",
+        "//qtox/src",
+        "//qtox/util",
+        "@qt//:qt_core",
+        "@qt//:qt_gui",
+        "@qt//:qt_widgets",
+    ],
+)
 
 qt_test(
     name = "videoframe_test",

--- a/test/chatlog/text_test.cpp
+++ b/test/chatlog/text_test.cpp
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2026 The TokTok team.
+ */
+
+#include "src/chatlog/content/text.h"
+
+#include "src/chatlog/documentcache.h"
+#include "src/persistence/settings.h"
+#include "src/persistence/smileypack.h"
+#include "src/widget/style.h"
+#include "src/widget/tool/imessageboxmanager.h"
+
+#include <QApplication>
+#include <QObject>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+class MockMessageBoxManager : public IMessageBoxManager
+{
+public:
+    ~MockMessageBoxManager() override;
+    void showInfo(const QString& title, const QString& msg) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+    }
+    void showWarning(const QString& title, const QString& msg) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+    }
+    void showError(const QString& title, const QString& msg) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+    }
+    bool askQuestion(const QString& title, const QString& msg, bool defaultAns = false,
+                     bool warning = true, bool yesno = true) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+        std::ignore = warning;
+        std::ignore = yesno;
+        return defaultAns;
+    }
+    bool askQuestion(const QString& title, const QString& msg, const QString& button1,
+                     const QString& button2, bool defaultAns = false, bool warning = true) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+        std::ignore = button1;
+        std::ignore = button2;
+        std::ignore = warning;
+        return defaultAns;
+    }
+    void confirmExecutableOpen(const QFileInfo& file) override
+    {
+        std::ignore = file;
+    }
+};
+
+MockMessageBoxManager::~MockMessageBoxManager() = default;
+
+class TestText : public QObject
+{
+    Q_OBJECT
+private slots:
+    void init();
+    void cleanup();
+    void testGetLinkAtNullDoc();
+
+private:
+    std::unique_ptr<QTemporaryDir> tempHome;
+    std::unique_ptr<MockMessageBoxManager> messageBoxManager;
+    std::unique_ptr<Settings> settings;
+    std::unique_ptr<Style> style;
+    std::unique_ptr<SmileyPack> smileyPack;
+    std::unique_ptr<DocumentCache> documentCache;
+};
+
+void TestText::init()
+{
+    tempHome = std::make_unique<QTemporaryDir>();
+    qputenv("HOME", tempHome->path().toUtf8());
+    qputenv("XDG_CONFIG_HOME", tempHome->path().toUtf8());
+
+    messageBoxManager = std::make_unique<MockMessageBoxManager>();
+    settings = std::make_unique<Settings>(*messageBoxManager);
+    style = std::make_unique<Style>();
+    smileyPack = std::make_unique<SmileyPack>(*settings);
+    documentCache = std::make_unique<DocumentCache>(*smileyPack, *settings);
+}
+
+void TestText::cleanup()
+{
+    documentCache.reset();
+    smileyPack.reset();
+    style.reset();
+    settings.reset();
+    messageBoxManager.reset();
+    tempHome.reset();
+}
+
+void TestText::testGetLinkAtNullDoc()
+{
+    Text text(*documentCache, *settings, *style, QStringLiteral("some text"));
+
+    // Ensure document is not in memory
+    text.visibilityChanged(false);
+
+    // This should not crash
+    const QString link = text.getLinkAt(QPointF(0, 0));
+    QVERIFY(link.isEmpty());
+}
+
+QTEST_MAIN(TestText)
+#include "text_test.moc"


### PR DESCRIPTION
To save memory, Text items unload their document when off-screen. If a right-click hit test returns an unloaded item, calling `getLinkAt()` or `extractImgTooltip()` crashed on a null doc pointer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/653)
<!-- Reviewable:end -->
