### PR TITLE
fix(video): Prevent race condition when scaling video frames concurrently.

### DIFF
--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -178,8 +178,8 @@ private:
     static FrameBufferKey getFrameKey(const QSize& frameSize, int pixFmt, int linesize);
     static FrameBufferKey getFrameKey(const QSize& frameSize, int pixFmt, bool frameAligned);
 
-    AVFrame* retrieveAVFrame(const QSize& dimensions, int pixelFormat, bool requireAligned);
-    AVFrame* generateAVFrame(const QSize& dimensions, int pixelFormat, bool requireAligned);
+    AVFrame* retrieveAVFrame(const QSize& dimensions, int pixelFormat, bool requireAligned) const;
+    AVFrame* generateAVFrame(const QSize& dimensions, int pixelFormat, bool requireAligned) const;
     AVFrame* storeAVFrame(AVFrame* frame, const QSize& dimensions, int pixelFormat);
 
     void deleteFrameBuffer();

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -124,6 +124,7 @@ qt_test(
     deps = [
         "//qtox/src",
         "@ffmpeg",
+        "@qt//:qt_concurrent",
         "@qt//:qt_core",
     ],
 )


### PR DESCRIPTION
VideoFrame was using non-const map access while holding a Read Lock, causing internal corruption and returning null pointers when multiple threads requested scaling at once. Switched to `find()` and added explicit null checks to ensure thread safety.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/655)
<!-- Reviewable:end -->
