### PR TITLE
fix: Prevent multiple qTox instances when opening profile files.

### DIFF
--- a/src/persistence/toxsave.cpp
+++ b/src/persistence/toxsave.cpp
@@ -13,6 +13,7 @@
 
 #include <QCoreApplication>
 #include <QString>
+#include <QTimer>
 
 const QString ToxSave::eventHandlerKey = QStringLiteral("save");
 
@@ -36,7 +37,8 @@ bool ToxSave::toxSaveEventHandler(const QByteArray& eventData, void* userData)
         return false;
     }
 
-    toxSave->handleToxSave(QString::fromUtf8(eventData));
+    const QString path = QString::fromUtf8(eventData);
+    QTimer::singleShot(0, toxSave->parent, [toxSave, path]() { toxSave->handleToxSave(path); });
     return true;
 }
 

--- a/test/persistence/settings_test.cpp
+++ b/test/persistence/settings_test.cpp
@@ -85,7 +85,7 @@ void TestSettings::testAutoSaveGlobal()
     settings.setEnableDebug(true);
 
     // Wait for the event loop to process the QTimer event in Settings::setVal
-    QTest::qWait(100);
+    QTest::qWait(250);
 
     // Block until the background QThread finishes writing to disk
     settings.sync();
@@ -108,33 +108,33 @@ void TestSettings::testAutoSaveDebounce()
     settings.getPaths().setPortablePath(tempDir.path());
 
     // Use a small but measurable interval
-    settings.setSaveTimerInterval(100);
+    settings.setSaveTimerInterval(500);
 
     const QString filePath = settings.getPaths().getSettingsDirPath() + "qtox.ini";
     QFile::remove(filePath); // Ensure clean state
     QVERIFY(!QFile::exists(filePath));
 
-    // First change starts the timer (100ms)
+    // First change starts the timer (500ms)
     settings.setEnableDebug(true);
 
-    // Wait 60ms - timer shouldn't have fired yet
-    QTest::qWait(60);
+    // Wait 250ms - timer shouldn't have fired yet
+    QTest::qWait(250);
     settings.sync();                   // Wait for any *potential* I/O to finish
     QVERIFY(!QFile::exists(filePath)); // Verify no save happened yet
 
-    // Second change should reset the timer back to 100ms
+    // Second change should reset the timer back to 500ms
     settings.setEnableIPv6(false);
 
-    // Wait another 60ms - a total of 120ms since the first change,
-    // but only 60ms since the second change.
+    // Wait another 250ms - a total of 500ms since the first change,
+    // but only 250ms since the second change.
     // If it didn't reset, it would have fired by now.
-    QTest::qWait(60);
+    QTest::qWait(250);
     settings.sync();
     QVERIFY(!QFile::exists(filePath)); // Still shouldn't exist because it was reset
 
-    // Wait 60ms more - now it has been 120ms since the *second* change,
+    // Wait 300ms more - now it has been 550ms since the *second* change,
     // so the timer must have fired and saved the file.
-    QTest::qWait(60);
+    QTest::qWait(300);
     settings.sync();
     QVERIFY(QFile::exists(filePath));
 }


### PR DESCRIPTION
Opening a .tox profile export file while qTox was already running could incorrectly launch a second instance. This happened because the application was blocking while waiting for the user to confirm the import, causing the single-instance check to time out.

Fixes #661.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/669)
<!-- Reviewable:end -->
