### PR TITLE
fix(Chat): Restore chat history visibility after hiding window.

### DIFF
--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -1015,7 +1015,7 @@ void ChatWidget::removeLines(ChatLogIdx begin, ChatLogIdx end)
     }
 
     begin = std::clamp<ChatLogIdx>(begin, chatLineStorage->firstIdx(), chatLineStorage->lastIdx());
-    end = std::clamp<ChatLogIdx>(end, chatLineStorage->firstIdx(), chatLineStorage->lastIdx()) + 1;
+    end = std::clamp<ChatLogIdx>(end, chatLineStorage->firstIdx(), chatLineStorage->lastIdx() + 1);
 
     // NOTE: Optimization potential if this find proves to be too expensive.
     // Batching all our erases into one call would be more efficient
@@ -1336,9 +1336,13 @@ void ChatWidget::handleMultiClickEvent()
 void ChatWidget::showEvent(QShowEvent* event)
 {
     std::ignore = event;
-    // Empty.
     // The default implementation calls centerOn - for some reason - causing
     // the scrollbar to move.
+
+    // When the widget was hidden, its layout might have been compressed to 0x0,
+    // which caused all lines to be marked invisible and purged from memory to save
+    // resources. We must explicitly check visibility when shown to restore them.
+    checkVisibility();
 }
 
 void ChatWidget::hideEvent(QHideEvent* event)


### PR DESCRIPTION
When the chat window is hidden (e.g. system tray or settings view), its layout can evaluate to 0x0, causing lines to be marked invisible and purged from memory. `checkVisibility` is now called on `showEvent` to explicitly re-evaluate visibility and redraw them.

Also: fix an off-by-one error in `ChatWidget::removeLines` that caused one extra message to be deleted whenever the history was pruned.

Fixes #572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/677)
<!-- Reviewable:end -->
