### PR TITLE
fix(Chat): Keep file transfer widget bounds within chat history.

### DIFF
--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -67,6 +67,7 @@ endif()
 auto_test(video videomode "" "")
 auto_test(video videoframe "" "${LIBAVUTIL_LIBRARIES}")
 auto_test(widget filesform "" "")
+auto_test(widget filetransferwidget "" "")
 auto_test(widget/form/settings generalform "" "")
 auto_test(widget/tool identicon "" "")
 # keep-sorted end

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -190,7 +190,7 @@ void FileTransferWidget::paintEvent(QPaintEvent* event)
     // Draw the widget background:
     painter.setClipRect(QRect(0, 0, width(), height()));
     painter.setBrush(QBrush(backgroundColor));
-    painter.drawRoundedRect(geometry(), r * ratio, r, Qt::RelativeSize);
+    painter.drawRoundedRect(rect(), r * ratio, r, Qt::RelativeSize);
 
     if (drawButtonAreaNeeded()) {
         // Draw the button background:
@@ -222,7 +222,7 @@ void FileTransferWidget::paintEvent(QPaintEvent* event)
         // Draw the right button:
         painter.setBrush(QBrush(buttonColor));
         painter.setClipRect(QRect(width() - buttonFieldWidth, 0, buttonFieldWidth, buttonFieldWidth));
-        painter.drawRoundedRect(geometry(), r * ratio, r, Qt::RelativeSize);
+        painter.drawRoundedRect(rect(), r * ratio, r, Qt::RelativeSize);
     }
 }
 

--- a/src/core/corefile.h
+++ b/src/core/corefile.h
@@ -30,6 +30,7 @@ using CoreFilePtr = std::unique_ptr<CoreFile>;
 class CoreFile : public QObject
 {
     Q_OBJECT
+    friend class TestFileTransferWidget;
 
 public:
     void handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept, uint64_t filesize);

--- a/test/widget/filetransferwidget_test.cpp
+++ b/test/widget/filetransferwidget_test.cpp
@@ -1,0 +1,111 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2026 The TokTok team.
+ */
+
+#include "src/chatlog/content/filetransferwidget.h"
+
+#include "src/core/corefile.h"
+#include "src/core/toxfile.h"
+#include "src/persistence/settings.h"
+#include "src/widget/style.h"
+#include "src/widget/tool/imessageboxmanager.h"
+
+#include <QDebug>
+#include <QImage>
+#include <QObject>
+#include <QPixmap>
+#include <QtTest/QtTest>
+
+class MockMessageBoxManagerFT : public IMessageBoxManager
+{
+public:
+    MockMessageBoxManagerFT();
+    ~MockMessageBoxManagerFT() override;
+    void showInfo(const QString& title, const QString& msg) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+    }
+    void showWarning(const QString& title, const QString& msg) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+    }
+    void showError(const QString& title, const QString& msg) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+    }
+    bool askQuestion(const QString& title, const QString& msg, bool d = false, bool warning = true,
+                     bool yesno = true) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+        std::ignore = warning;
+        std::ignore = yesno;
+        return d;
+    }
+    bool askQuestion(const QString& title, const QString& msg, const QString& button1,
+                     const QString& button2, bool d = false, bool warning = true) override
+    {
+        std::ignore = title;
+        std::ignore = msg;
+        std::ignore = button1;
+        std::ignore = button2;
+        std::ignore = warning;
+        return d;
+    }
+    void confirmExecutableOpen(const QFileInfo& file) override
+    {
+        std::ignore = file;
+    }
+};
+
+MockMessageBoxManagerFT::MockMessageBoxManagerFT() = default;
+MockMessageBoxManagerFT::~MockMessageBoxManagerFT() = default;
+
+class TestFileTransferWidget : public QObject
+{
+    Q_OBJECT
+private slots:
+    void testRenderingBounds();
+};
+
+void TestFileTransferWidget::testRenderingBounds()
+{
+    MockMessageBoxManagerFT messageBoxManager;
+    Settings settings(messageBoxManager);
+    Style style;
+    QRecursiveMutex dummyMutex;
+    CoreFile coreFile(nullptr, dummyMutex);
+
+    // ToxFile(uint32_t fileNum_, uint32_t friendId_, QString fileName_, QString filePath_, uint64_t filesize, FileDirection direction)
+    ToxFile file(0, 0, "test.txt", "test.txt", 100, ToxFile::SENDING);
+    file.status = ToxFile::TRANSMITTING;
+
+    FileTransferWidget widget(nullptr, coreFile, file, settings, style, messageBoxManager);
+
+    // Set geometry with a non-zero origin. This ensures we test that the widget
+    // paints itself using its own local coordinate system (rect()) rather than
+    // its parent-relative coordinates (geometry()).
+    widget.setGeometry(50, 50, 200, 50);
+
+    // Force the widget to layout and be ready to paint
+    widget.show();
+
+    // Grab the rendered pixels of the widget into a QImage
+    const QImage image = widget.grab().toImage();
+
+    // Check a pixel near the top-left of the widget (10, 10).
+    // If the widget incorrectly uses geometry() instead of rect() to draw its
+    // background, it would draw the background starting at its parent-relative
+    // offset (50, 50), leaving the local (10, 10) pixel completely transparent.
+    // By verifying the pixel is opaque, we prove the background fills the widget
+    // area starting from its local origin (0, 0).
+    const QColor pixelColor = image.pixelColor(10, 10);
+
+    QCOMPARE(pixelColor.alpha(), 255);
+}
+
+QTEST_MAIN(TestFileTransferWidget)
+#include "filetransferwidget_test.moc"


### PR DESCRIPTION
The file transfer widget was incorrectly using `geometry()` instead of `rect()` when painting its background. `geometry()` returns coordinates relative to the parent widget, which caused the widget to offset its drawing context by its X/Y coordinates on the screen, bleeding over the chat log bounds. Using `rect()` ensures it draws from `0, 0` within its own local coordinate system.

Fixes #236.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/678)
<!-- Reviewable:end -->
