### PR TITLE
fix(Chat): Prevent file transfer widget from briefly reappearing when scrolling.

### DIFF
--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -36,6 +36,7 @@ add_subdirectory(test/dbutility)
 set(TEST_RESOURCES test/resources/test_data.qrc ${${BINARY_NAME}_RESOURCES})
 
 # keep-sorted start
+auto_test(chatlog chatlinecontentproxy "" "")
 auto_test(chatlog chatlinestorage "" "")
 auto_test(chatlog chatwidget "" "")
 auto_test(chatlog text "" "")

--- a/src/chatlog/chatlinecontentproxy.cpp
+++ b/src/chatlog/chatlinecontentproxy.cpp
@@ -42,8 +42,13 @@ QRectF ChatLineContentProxy::boundingRect() const
 void ChatLineContentProxy::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                                  QWidget* widget)
 {
-    painter->setClipRect(boundingRect());
-    proxy->paint(painter, option, widget);
+    // The proxy is a child item and paints automatically.
+    // Explicitly painting here forces it to draw out-of-bounds
+    // when ChatLineContentProxy's larger bounding rect intersects the viewport
+    // but the proxy's own bounding rect is outside the clip region.
+    std::ignore = painter;
+    std::ignore = option;
+    std::ignore = widget;
 }
 
 qreal ChatLineContentProxy::getAscent() const

--- a/test/chatlog/chatlinecontentproxy_test.cpp
+++ b/test/chatlog/chatlinecontentproxy_test.cpp
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2026 The TokTok team.
+ */
+
+#include "src/chatlog/chatlinecontentproxy.h"
+
+#include <QGraphicsScene>
+#include <QImage>
+#include <QPainter>
+#include <QStyleOptionGraphicsItem>
+#include <QWidget>
+#include <QtTest/QtTest>
+
+class TestChatLineContentProxy : public QObject
+{
+    Q_OBJECT
+private slots:
+    void testClippingOutOfBounds();
+};
+
+void TestChatLineContentProxy::testClippingOutOfBounds()
+{
+    auto* widget = new QWidget();
+    widget->setFixedSize(100, 100);
+    // Use a solid color background to reliably detect if the widget is drawn out of bounds.
+    QPalette pal = widget->palette();
+    pal.setColor(QPalette::Window, Qt::green);
+    widget->setAutoFillBackground(true);
+    widget->setPalette(pal);
+
+    auto* proxy = new ChatLineContentProxy(widget, 100, 1.0f);
+
+    QGraphicsScene scene;
+    scene.addItem(proxy);
+
+    QImage image(100, 100, QImage::Format_ARGB32);
+    image.fill(Qt::transparent);
+
+    QPainter painter(&image);
+
+    // Simulate a strict clip set by a parent container (e.g., QGraphicsView viewport scroll).
+    // Restrict drawing to only the bottom 50 pixels.
+    painter.setClipRect(QRect(0, 50, 100, 50));
+
+    // Call the proxy's paint method directly.
+    QStyleOptionGraphicsItem option;
+    option.exposedRect = QRectF(0, 0, 100, 105); // Expose the whole thing to force a draw
+    proxy->paint(&painter, &option, nullptr);
+    painter.end();
+
+    // Check a pixel outside the clip region (e.g., at (50, 25)).
+    // The proxy's painting behavior should not override the painter's clip region.
+    // Since this area is clipped out, it should remain entirely transparent.
+    const QColor pixelColor = image.pixelColor(50, 25);
+    QCOMPARE(pixelColor.alpha(), 0);
+}
+
+QTEST_MAIN(TestChatLineContentProxy)
+#include "chatlinecontentproxy_test.moc"


### PR DESCRIPTION
The file transfer widget would briefly reappear over the chat header due to an explicit call to `proxy->paint()` in `ChatLineContentProxy::paint()`. Since `ChatLineContentProxy` sets a bounding rect that is 5 pixels taller than its child `QGraphicsProxyWidget`, the proxy was being forced to paint when its area was outside the view's clip region, causing it to draw unclipped. Removing the explicit paint call allows the scene to paint the proxy correctly when it intersects the viewport.

See #236.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/679)
<!-- Reviewable:end -->
