### PR TITLE
fix(Chat): Prevent chat messages from disappearing when switching chats.

### DIFF
--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -1355,11 +1355,18 @@ void ChatWidget::hideEvent(QHideEvent* event)
     // qTox, but that isn't a regression from previously released behavior.
 
     const std::size_t maxWindowSize = settings.getChatMaxWindowSize();
-    auto numLinesToRemove =
-        chatLineStorage->size() > maxWindowSize ? chatLineStorage->size() - maxWindowSize : 0;
 
-    if (numLinesToRemove > 0) {
-        removeLines(chatLineStorage->firstIdx(), chatLineStorage->firstIdx() + numLinesToRemove);
+    if (chatLineStorage->size() > maxWindowSize) {
+        while (chatLineStorage->size() > maxWindowSize) {
+            auto it = chatLineStorage->begin();
+            (*it)->removeFromScene();
+            chatLineStorage->erase(it);
+        }
+
+        if (chatLineStorage->hasIndexedMessage()) {
+            layout(0, chatLineStorage->size(), useableWidth());
+        }
+
         startResizeWorker();
     }
 }


### PR DESCRIPTION
When the chat window accumulated more lines than `maxWindowSize`, `hideEvent` incorrectly calculated the `ChatLogIdx` to remove. It added the number of lines to remove to the first index, which resulted in a nonexistent ID due to non-contiguous IDs (e.g., from date lines or file transfers). This caused `ChatLineStorage::erase` to clear all remaining messages. Removing the old messages by iterating and erasing directly fixes the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/681)
<!-- Reviewable:end -->
