### PR TITLE
fix: Undo performance regression change on chat visibility check.

### DIFF
--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -1336,13 +1336,9 @@ void ChatWidget::handleMultiClickEvent()
 void ChatWidget::showEvent(QShowEvent* event)
 {
     std::ignore = event;
+    // Empty.
     // The default implementation calls centerOn - for some reason - causing
     // the scrollbar to move.
-
-    // When the widget was hidden, its layout might have been compressed to 0x0,
-    // which caused all lines to be marked invisible and purged from memory to save
-    // resources. We must explicitly check visibility when shown to restore them.
-    checkVisibility();
 }
 
 void ChatWidget::hideEvent(QHideEvent* event)

--- a/test/chatlog/chatwidget_test.cpp
+++ b/test/chatlog/chatwidget_test.cpp
@@ -4,7 +4,6 @@
 
 #include "src/chatlog/chatwidget.h"
 
-#include "src/chatlog/chatlinestorage.h"
 #include "src/chatlog/documentcache.h"
 #include "src/core/icoreidhandler.h"
 #include "src/model/ichatlog.h"
@@ -270,7 +269,6 @@ private slots:
     void testScrollStress();
     void testResizeAndInterrupt();
     void testClearPreservesFileTransfers();
-    void testHideAndShowRestoresVisibility();
     void testHideWithManyUnindexedLinesDoesNotClearChat();
 
 private:
@@ -701,56 +699,6 @@ void TestChatWidget::testClearPreservesFileTransfers()
 
     // Now it should be empty
     QVERIFY(chatWidget->isEmpty());
-}
-
-void TestChatWidget::testHideAndShowRestoresVisibility()
-{
-    QSignalSpy spy(chatWidget.get(), &ChatWidget::renderFinished);
-    QSignalSpy visibilitySpy(chatWidget.get(), &ChatWidget::firstVisibleLineChanged);
-
-    // 1. Scroll up to fetch older messages, causing storage to exceed maxWindowSize (50)
-    QScrollBar* vScroll = chatWidget->verticalScrollBar();
-    vScroll->setValue(vScroll->minimum());
-    waitForRender(spy);
-
-    // Verify lines are rendered (implying the storage holds them)
-    QVERIFY(chatWidget->getRenderedEndIdx() > chatWidget->getRenderedStartIdx());
-    QVERIFY(visibilitySpy.count() > 0);
-    visibilitySpy.clear();
-
-    // Record the starting index before hiding.
-    // In our mock, chunk size is 20, max window size is 50.
-    // Scrolling up loaded 20 more messages, plus date lines.
-    // The off-by-one bug will cause it to prune 1 more message than intended.
-    const size_t oldStartIdx = chatWidget->getRenderedStartIdx().get();
-
-    // 2. Hide the widget (e.g. switching to Settings view or system tray)
-    // We do not resize it, as tab switching doesn't necessarily change the geometry width.
-    chatWidget->hide();
-
-    // Wait for the resize worker to finish its background job
-    waitForRender(spy);
-
-    // Calculate how many messages were pruned.
-    const size_t newStartIdx = chatWidget->getRenderedStartIdx().get();
-    const size_t prunedCount = newStartIdx - oldStartIdx;
-
-    // We expect exactly 5 messages to be pruned (55 total items - 50 maxWindowSize).
-    // The off-by-one bug would prune 6 messages.
-    QCOMPARE(prunedCount, 5);
-
-    // Because the view is hidden, the background worker's layout evaluation of getVisibleRect()
-    // results in no lines intersecting the viewport, effectively clearing visibleLines.
-    // We expect the subsequent show() to trigger a visibility restore via checkVisibility().
-    visibilitySpy.clear();
-
-    // 3. Show the widget again (e.g. switching back to Chat view)
-    chatWidget->show();
-    QTest::qWait(100);
-
-    // The messages should be restored to visibility and re-rendered,
-    // which triggers the firstVisibleLineChanged signal.
-    QVERIFY(visibilitySpy.count() > 0);
 }
 
 void TestChatWidget::testHideWithManyUnindexedLinesDoesNotClearChat()


### PR DESCRIPTION
This didn't fix the problem. A later commit did fix this problem. We don't need this change anymore.

Preserving the off by one fix from
79f7d14b53e9f07f2461a45e690ca33a55afe8cd still.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/685)
<!-- Reviewable:end -->
