### PR TITLE
refactor: Split libraries.

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -24,9 +24,7 @@ qt_moc(
         "chatlog/content/text.h",
         "chatlog/content/timestamp.h",
         "chatlog/customtextdocument.h",
-        "core/core.h",
         "core/coreav.h",
-        "core/corefile.h",
         "core/toxcall.h",
         "ipc.h",
         "model/about/aboutfriend.h",
@@ -215,15 +213,72 @@ cc_library(
     ],
 )
 
+qt_moc(
+    name = "core_moc",
+    srcs = [
+        "core/core.h",
+        "core/corefile.h",
+    ],
+    hdrs = glob(["core/**/*.h"]) + ["model/status.h"],
+    mocopts = [
+        "-Iqtox",
+        "-Iqtox/util/include",
+    ],
+    tags = ["qt"],
+    deps = [
+        "//qtox/util",
+        "@qt//:qt_widgets",
+    ],
+)
+
+cc_library(
+    name = "core",
+    srcs = [":core_moc"] + glob(
+        ["core/**/*.cpp"],
+        exclude = [
+            "core/coreav.cpp",
+            "core/toxcall.cpp",
+        ],
+    ) + [
+        "model/conferenceinvite.cpp",
+        "model/ibootstraplistgenerator.cpp",
+        "model/status.cpp",
+    ],
+    hdrs = glob(["core/**/*.h"]) + [
+        "model/conferenceinvite.h",
+        "model/ibootstraplistgenerator.h",
+        "model/status.h",
+        "model/toxclientstandards.h",
+    ],
+    copts = COPTS,
+    tags = ["qt"],
+    visibility = ["//qtox:__subpackages__"],
+    deps = [
+        "//c-toxcore",
+        "//qtox/audio",
+        "//qtox/util",
+        "@libsodium",
+        "@qt//:qt_core",
+        "@qt//:qt_gui",
+        "@qt//:qt_network",
+    ],
+)
+
 cc_library(
     name = "src",
     srcs = [":version"] + [
+        "core/coreav.cpp",
+        "core/toxcall.cpp",
         ":src_moc",
         ":src_ui",
     ] + glob(
         ["**/*.cpp"],
         exclude = [
+            "core/**",
+            "model/conferenceinvite.cpp",
             "model/exiftransform.cpp",
+            "model/ibootstraplistgenerator.cpp",
+            "model/status.cpp",
             "persistence/serialize.cpp",
             "main.cpp",
         ],
@@ -231,7 +286,12 @@ cc_library(
     hdrs = glob(
         ["**/*.h"],
         exclude = [
+            "core/**",
+            "model/conferenceinvite.h",
             "model/exiftransform.h",
+            "model/ibootstraplistgenerator.h",
+            "model/status.h",
+            "model/toxclientstandards.h",
             "persistence/serialize.h",
         ],
     ),
@@ -247,6 +307,7 @@ cc_library(
     tags = ["qt"],
     visibility = ["//qtox:__subpackages__"],
     deps = [
+        ":core",
         ":exiftransform",
         ":serialize",
         ":stacktrace",

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -16,7 +16,6 @@
 #include "src/model/conferenceinvite.h"
 #include "src/model/ibootstraplistgenerator.h"
 #include "src/model/status.h"
-#include "src/persistence/profile.h"
 #include "util/toxcoreerrorparser.h"
 
 #include <QCoreApplication>

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -28,6 +28,7 @@ qt_moc(
     tags = ["qt"],
     deps = [
         "//qtox/src",
+        "//qtox/src:core",
         "//qtox/util",
     ],
 )
@@ -60,6 +61,7 @@ cc_library(
     tags = ["qt"],
     deps = [
         "//qtox/src",
+        "//qtox/src:core",
         "@qt//:qt_core",
     ],
 )
@@ -79,6 +81,7 @@ UI_TESTS = ["loginscreen_test"]
         "//c-toxcore",
         "//qtox:res_lib",
         "//qtox/src",
+        "//qtox/src:core",
         "//qtox/util",
         "@qt//:qt_core",
         "@qt//:qt_gui",
@@ -173,6 +176,7 @@ qt_test(
     deps = [
         ":dbutility",
         "//qtox/src",
+        "//qtox/src:core",
         "@qt//:qt_core",
     ],
 )


### PR DESCRIPTION
Move `core` to its own library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/692)
<!-- Reviewable:end -->
