### PR TITLE
refactor: Extract ChatManager from Widget to separate model from UI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,8 @@ set(${BINARY_NAME}_SOURCES
     src/model/about/iaboutfriend.h
     src/model/chathistory.cpp
     src/model/chathistory.h
+    src/model/chatmanager.cpp
+    src/model/chatmanager.h
     src/model/chatlogitem.cpp
     src/model/chatlogitem.h
     src/model/chatroom/friendchatroom.cpp

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -30,6 +30,7 @@ qt_moc(
         "model/about/aboutfriend.h",
         "model/chat.h",
         "model/chathistory.h",
+        "model/chatmanager.h",
         "model/chatroom/conferenceroom.h",
         "model/chatroom/friendchatroom.h",
         "model/conference.h",

--- a/src/model/chatmanager.cpp
+++ b/src/model/chatmanager.cpp
@@ -1,0 +1,354 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024-2026 The TokTok team.
+ * Copyright © 2014-2019 by The qTox Project Contributors
+ */
+
+#include "chatmanager.h"
+
+#include "src/conferencelist.h"
+#include "src/core/core.h"
+#include "src/core/coreav.h"
+#include "src/friendlist.h"
+#include "src/model/chathistory.h"
+#include "src/model/chatroom/conferenceroom.h"
+#include "src/model/chatroom/friendchatroom.h"
+#include "src/model/conference.h"
+#include "src/model/friend.h"
+#include "src/persistence/profile.h"
+#include "src/persistence/settings.h"
+
+#include <QCoreApplication>
+
+#include <cassert>
+
+ChatManager::ChatManager(Profile& profile_, Settings& settings_, FriendList& friendList_,
+                         ConferenceList& conferenceList_, IDialogsManager* dialogsManager_,
+                         QObject* parent)
+    : QObject(parent)
+    , profile(profile_)
+    , settings(settings_)
+    , friendList(friendList_)
+    , conferenceList(conferenceList_)
+    , dialogsManager(dialogsManager_)
+    , sharedMessageProcessorParams(
+          std::make_unique<MessageProcessor::SharedParams>(Core::getMaxMessageSize()))
+{
+}
+
+void ChatManager::connectToCore(Core& core_)
+{
+    core = &core_;
+
+    sharedMessageProcessorParams->setPublicKey(core->getSelfPublicKey().toString());
+
+    connect(core, &Core::friendAdded, this, &ChatManager::onFriendAdded);
+    connect(core, &Core::friendStatusChanged, this, &ChatManager::onFriendStatusChanged);
+    connect(core, &Core::friendStatusMessageChanged, this, &ChatManager::onFriendStatusMessageChanged);
+    connect(core, &Core::friendUsernameChanged, this, &ChatManager::onFriendUsernameChanged);
+    connect(core, &Core::friendMessageReceived, this, &ChatManager::onFriendMessageReceived);
+    connect(core, &Core::receiptReceived, this, &ChatManager::onReceiptReceived);
+    connect(core, &Core::conferenceMessageReceived, this, &ChatManager::onConferenceMessageReceived);
+    connect(core, &Core::emptyConferenceCreated, this, &ChatManager::onEmptyConferenceCreated);
+    connect(core, &Core::conferenceJoined, this, &ChatManager::onConferenceJoined);
+    connect(core, &Core::conferencePeerlistChanged, this, &ChatManager::onConferencePeerlistChanged);
+    connect(core, &Core::conferencePeerNameChanged, this, &ChatManager::onConferencePeerNameChanged);
+    connect(core, &Core::conferenceTitleChanged, this, &ChatManager::onConferenceTitleChanged);
+}
+
+FriendMessageDispatcher* ChatManager::getFriendDispatcher(const ToxPk& friendPk) const
+{
+    auto it = friendMessageDispatchers.find(friendPk);
+    if (it == friendMessageDispatchers.end()) {
+        return nullptr;
+    }
+    return it->get();
+}
+
+ChatHistory* ChatManager::getFriendChatLog(const ToxPk& friendPk) const
+{
+    auto it = friendChatLogs.find(friendPk);
+    if (it == friendChatLogs.end()) {
+        return nullptr;
+    }
+    return it->get();
+}
+
+std::shared_ptr<FriendChatroom> ChatManager::getFriendChatroom(const ToxPk& friendPk) const
+{
+    auto it = friendChatRooms.find(friendPk);
+    if (it == friendChatRooms.end()) {
+        return nullptr;
+    }
+    return *it;
+}
+
+ConferenceMessageDispatcher* ChatManager::getConferenceDispatcher(const ConferenceId& id) const
+{
+    auto it = conferenceMessageDispatchers.find(id);
+    if (it == conferenceMessageDispatchers.end()) {
+        return nullptr;
+    }
+    return it->get();
+}
+
+IChatLog* ChatManager::getConferenceChatLog(const ConferenceId& id) const
+{
+    auto it = conferenceLogs.find(id);
+    if (it == conferenceLogs.end()) {
+        return nullptr;
+    }
+    return it->get();
+}
+
+std::shared_ptr<ConferenceRoom> ChatManager::getConferenceRoom(const ConferenceId& id) const
+{
+    auto it = conferenceRooms.find(id);
+    if (it == conferenceRooms.end()) {
+        return nullptr;
+    }
+    return *it;
+}
+
+MessageProcessor::SharedParams& ChatManager::getSharedMessageProcessorParams()
+{
+    return *sharedMessageProcessorParams;
+}
+
+void ChatManager::removeFriend(const ToxPk& friendPk)
+{
+    Friend* f = friendList.findFriend(friendPk);
+    if (f == nullptr) {
+        return;
+    }
+
+    core->removeFriend(f->getId());
+
+    // Aliases aren't supported for non-friend peers in conferences, revert to basic username.
+    for (Conference* c : conferenceList.getAllConferences()) {
+        if (c->getPeerList().contains(friendPk)) {
+            c->updateUsername(friendPk, f->getUserName());
+        }
+    }
+
+    friendMessageDispatchers.remove(friendPk);
+    friendChatLogs.remove(friendPk);
+    friendChatRooms.remove(friendPk);
+}
+
+void ChatManager::removeConference(const ConferenceId& conferenceId)
+{
+    Conference* c = conferenceList.findConference(conferenceId);
+    if (c == nullptr) {
+        return;
+    }
+
+    core->removeConference(c->getId());
+
+    conferenceMessageDispatchers.remove(conferenceId);
+    conferenceLogs.remove(conferenceId);
+    conferenceRooms.remove(conferenceId);
+}
+
+void ChatManager::removeFriendModel(const ToxPk& friendPk)
+{
+    friendMessageDispatchers.remove(friendPk);
+    friendChatLogs.remove(friendPk);
+    friendChatRooms.remove(friendPk);
+}
+
+void ChatManager::removeConferenceModel(const ConferenceId& conferenceId)
+{
+    conferenceMessageDispatchers.remove(conferenceId);
+    conferenceLogs.remove(conferenceId);
+    conferenceRooms.remove(conferenceId);
+}
+
+void ChatManager::onFriendAdded(uint32_t friendId, const ToxPk& friendPk)
+{
+    assert(core != nullptr);
+    settings.updateFriendAddress(friendPk.toString());
+
+    Friend* newFriend = friendList.addFriend(friendId, friendPk, settings);
+    auto chatroom =
+        std::make_shared<FriendChatroom>(newFriend, dialogsManager, *core, settings, conferenceList);
+    auto friendMessageDispatcher =
+        std::make_shared<FriendMessageDispatcher>(*newFriend,
+                                                  MessageProcessor(*sharedMessageProcessorParams),
+                                                  *core);
+
+    auto* history = profile.getHistory();
+    auto chatHistory =
+        std::make_shared<ChatHistory>(*newFriend, history, *core, settings,
+                                      *friendMessageDispatcher, friendList, conferenceList);
+
+    friendMessageDispatchers[friendPk] = friendMessageDispatcher;
+    friendChatLogs[friendPk] = chatHistory;
+    friendChatRooms[friendPk] = chatroom;
+
+    emit friendAdded(newFriend, chatroom, friendMessageDispatcher, chatHistory);
+}
+
+void ChatManager::onFriendStatusChanged(uint32_t friendId, Status::Status status)
+{
+    const auto& friendPk = friendList.id2Key(friendId);
+    Friend* f = friendList.findFriend(friendPk);
+    if (f == nullptr) {
+        return;
+    }
+
+    f->setStatus(status);
+}
+
+void ChatManager::onFriendStatusMessageChanged(uint32_t friendId, const QString& message)
+{
+    const auto& friendPk = friendList.id2Key(friendId);
+    Friend* f = friendList.findFriend(friendPk);
+    if (f == nullptr) {
+        return;
+    }
+
+    QString str = message;
+    str.replace('\n', ' ').remove('\r').remove(QChar('\0'));
+    f->setStatusMessage(str);
+}
+
+void ChatManager::onFriendUsernameChanged(uint32_t friendId, const QString& username)
+{
+    const auto& friendPk = friendList.id2Key(friendId);
+    Friend* f = friendList.findFriend(friendPk);
+    if (f == nullptr) {
+        return;
+    }
+
+    QString str = username;
+    str.replace('\n', ' ').remove('\r').remove(QChar('\0'));
+    f->setName(str);
+}
+
+void ChatManager::onFriendMessageReceived(uint32_t friendId, const QString& message, bool isAction)
+{
+    const auto& friendKey = friendList.id2Key(friendId);
+    Friend* f = friendList.findFriend(friendKey);
+    if (f == nullptr) {
+        return;
+    }
+
+    friendMessageDispatchers[f->getPublicKey()]->onMessageReceived(isAction, message);
+}
+
+void ChatManager::onReceiptReceived(uint32_t friendId, ReceiptNum receipt)
+{
+    const auto& friendKey = friendList.id2Key(friendId);
+    Friend* f = friendList.findFriend(friendKey);
+    if (f == nullptr) {
+        return;
+    }
+
+    friendMessageDispatchers[f->getPublicKey()]->onReceiptReceived(receipt);
+}
+
+void ChatManager::onConferenceMessageReceived(uint32_t conferencenumber, uint32_t peernumber,
+                                              const QString& message, bool isAction)
+{
+    const ConferenceId& conferenceId = conferenceList.id2Key(conferencenumber);
+    assert(conferenceList.findConference(conferenceId));
+
+    const ToxPk author = core->getConferencePeerPk(conferencenumber, peernumber);
+
+    conferenceMessageDispatchers[conferenceId]->onMessageReceived(author, isAction, message);
+}
+
+void ChatManager::onEmptyConferenceCreated(uint32_t conferenceNum, const ConferenceId& id,
+                                           const QString& title)
+{
+    Conference* conference = createConference(conferenceNum, id);
+    if (conference == nullptr) {
+        return;
+    }
+    if (title.isEmpty()) {
+        emit conferenceNeedsName(id);
+    } else {
+        conference->setTitle(QString(), title);
+    }
+}
+
+void ChatManager::onConferenceJoined(uint32_t conferenceNum, const ConferenceId& id)
+{
+    createConference(conferenceNum, id);
+}
+
+void ChatManager::onConferencePeerlistChanged(uint32_t conferencenumber)
+{
+    const ConferenceId& conferenceId = conferenceList.id2Key(conferencenumber);
+    Conference* c = conferenceList.findConference(conferenceId);
+    assert(c);
+    c->regeneratePeerList();
+}
+
+void ChatManager::onConferencePeerNameChanged(uint32_t conferencenumber, const ToxPk& peerPk,
+                                              const QString& newName)
+{
+    const ConferenceId& conferenceId = conferenceList.id2Key(conferencenumber);
+    Conference* c = conferenceList.findConference(conferenceId);
+    assert(c);
+
+    const QString setName = friendList.decideNickname(peerPk, newName);
+    c->updateUsername(peerPk, newName);
+}
+
+void ChatManager::onConferenceTitleChanged(uint32_t conferencenumber, const QString& author,
+                                           const QString& title)
+{
+    const ConferenceId& conferenceId = conferenceList.id2Key(conferencenumber);
+    Conference* c = conferenceList.findConference(conferenceId);
+    assert(c);
+
+    c->setTitle(author, title);
+}
+
+Conference* ChatManager::createConference(uint32_t conferencenumber, const ConferenceId& conferenceId)
+{
+    assert(core != nullptr);
+
+    Conference* c = conferenceList.findConference(conferenceId);
+    if (c != nullptr) {
+        qWarning() << "Conference already exists";
+        return c;
+    }
+
+    const auto conferenceName =
+        QCoreApplication::translate("ChatManager", "Conference #%1").arg(conferencenumber);
+    const bool enabled = core->getConferenceAvEnabled(conferencenumber);
+    Conference* newConference =
+        conferenceList.addConference(*core, conferencenumber, conferenceId, conferenceName, enabled,
+                                     core->getUsername(), friendList);
+    assert(newConference);
+
+    if (enabled) {
+        connect(newConference, &Conference::userLeft, this, [this, newConference](const ToxPk& user) {
+            CoreAV* av = core->getAv();
+            assert(av);
+            av->invalidateConferenceCallPeerSource(*newConference, user);
+        });
+    }
+
+    auto chatroom = std::make_shared<ConferenceRoom>(newConference, dialogsManager, *core, friendList);
+    auto messageDispatcher =
+        std::make_shared<ConferenceMessageDispatcher>(*newConference,
+                                                      MessageProcessor(*sharedMessageProcessorParams),
+                                                      *core, *core, settings);
+
+    auto* history = profile.getHistory();
+    auto chatHistory = std::make_shared<ChatHistory>(*newConference, history, *core, settings,
+                                                     *messageDispatcher, friendList, conferenceList);
+
+    connect(core, &Core::usernameSet, newConference, &Conference::setSelfName);
+
+    conferenceMessageDispatchers[conferenceId] = messageDispatcher;
+    conferenceLogs[conferenceId] = chatHistory;
+    conferenceRooms[conferenceId] = chatroom;
+
+    emit conferenceAdded(newConference, chatroom, messageDispatcher, chatHistory);
+
+    return newConference;
+}

--- a/src/model/chatmanager.h
+++ b/src/model/chatmanager.h
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © 2024-2026 The TokTok team.
+ * Copyright © 2014-2019 by The qTox Project Contributors
+ */
+
+#pragma once
+
+#include "src/core/conferenceid.h"
+#include "src/core/receiptnum.h"
+#include "src/core/toxpk.h"
+#include "src/model/conferencemessagedispatcher.h"
+#include "src/model/friendmessagedispatcher.h"
+#include "src/model/message.h"
+
+#include <QMap>
+#include <QObject>
+
+#include <memory>
+
+class ChatHistory;
+class Conference;
+class ConferenceList;
+class ConferenceRoom;
+class Core;
+class Friend;
+class FriendChatroom;
+class FriendList;
+class IChatLog;
+class IDialogsManager;
+class Profile;
+class Settings;
+
+class ChatManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    ChatManager(Profile& profile, Settings& settings, FriendList& friendList,
+                ConferenceList& conferenceList, IDialogsManager* dialogsManager,
+                QObject* parent = nullptr);
+
+    void connectToCore(Core& core);
+
+    FriendMessageDispatcher* getFriendDispatcher(const ToxPk& friendPk) const;
+    ChatHistory* getFriendChatLog(const ToxPk& friendPk) const;
+    std::shared_ptr<FriendChatroom> getFriendChatroom(const ToxPk& friendPk) const;
+    ConferenceMessageDispatcher* getConferenceDispatcher(const ConferenceId& id) const;
+    IChatLog* getConferenceChatLog(const ConferenceId& id) const;
+    std::shared_ptr<ConferenceRoom> getConferenceRoom(const ConferenceId& id) const;
+
+    MessageProcessor::SharedParams& getSharedMessageProcessorParams();
+
+    void removeFriend(const ToxPk& friendPk);
+    void removeConference(const ConferenceId& conferenceId);
+    void removeFriendModel(const ToxPk& friendPk);
+    void removeConferenceModel(const ConferenceId& conferenceId);
+
+signals:
+    void friendAdded(Friend* f, std::shared_ptr<FriendChatroom> chatroom,
+                     std::shared_ptr<FriendMessageDispatcher> dispatcher,
+                     std::shared_ptr<ChatHistory> chatLog);
+    void friendRemoved(const ToxPk& friendPk);
+    void conferenceAdded(Conference* c, std::shared_ptr<ConferenceRoom> chatroom,
+                         std::shared_ptr<ConferenceMessageDispatcher> dispatcher,
+                         std::shared_ptr<IChatLog> chatLog);
+    void conferenceRemoved(const ConferenceId& conferenceId);
+    void conferenceNeedsName(const ConferenceId& conferenceId);
+
+private slots:
+    void onFriendAdded(uint32_t friendId, const ToxPk& friendPk);
+    void onFriendStatusChanged(uint32_t friendId, Status::Status status);
+    void onFriendStatusMessageChanged(uint32_t friendId, const QString& message);
+    void onFriendUsernameChanged(uint32_t friendId, const QString& username);
+
+    void onFriendMessageReceived(uint32_t friendId, const QString& message, bool isAction);
+    void onReceiptReceived(uint32_t friendId, ReceiptNum receipt);
+    void onConferenceMessageReceived(uint32_t conferenceNum, uint32_t peerNum,
+                                     const QString& message, bool isAction);
+
+    void onEmptyConferenceCreated(uint32_t conferenceNum, const ConferenceId& id, const QString& title);
+    void onConferenceJoined(uint32_t conferenceNum, const ConferenceId& id);
+    void onConferencePeerlistChanged(uint32_t conferenceNum);
+    void onConferencePeerNameChanged(uint32_t conferenceNum, const ToxPk& peerPk,
+                                     const QString& newName);
+    void onConferenceTitleChanged(uint32_t conferenceNum, const QString& author, const QString& title);
+
+private:
+    Conference* createConference(uint32_t conferenceNum, const ConferenceId& conferenceId);
+
+    Profile& profile;
+    Core* core = nullptr;
+    Settings& settings;
+    FriendList& friendList;
+    ConferenceList& conferenceList;
+    IDialogsManager* dialogsManager;
+
+    std::unique_ptr<MessageProcessor::SharedParams> sharedMessageProcessorParams;
+
+    QMap<ToxPk, std::shared_ptr<FriendMessageDispatcher>> friendMessageDispatchers;
+    QMap<ToxPk, std::shared_ptr<ChatHistory>> friendChatLogs;
+    QMap<ToxPk, std::shared_ptr<FriendChatroom>> friendChatRooms;
+
+    QMap<ConferenceId, std::shared_ptr<ConferenceMessageDispatcher>> conferenceMessageDispatchers;
+    QMap<ConferenceId, std::shared_ptr<IChatLog>> conferenceLogs;
+    QMap<ConferenceId, std::shared_ptr<ConferenceRoom>> conferenceRooms;
+};

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -44,6 +44,7 @@
 #include "src/friendlist.h"
 #include "src/ipc.h"
 #include "src/model/chathistory.h"
+#include "src/model/chatmanager.h"
 #include "src/model/chatroom/conferenceroom.h"
 #include "src/model/chatroom/friendchatroom.h"
 #include "src/model/conference.h"
@@ -258,8 +259,11 @@ void Widget::init()
 
     core = &profile.getCore();
 
-    sharedMessageProcessorParams =
-        std::make_unique<MessageProcessor::SharedParams>(Core::getMaxMessageSize());
+    chatManager = std::make_unique<ChatManager>(profile, settings, *friendList, *conferenceList,
+                                                contentDialogManager.get(), this);
+    connect(chatManager.get(), &ChatManager::friendAdded, this, &Widget::onFriendModelAdded);
+    connect(chatManager.get(), &ChatManager::conferenceAdded, this, &Widget::onConferenceModelAdded);
+    connect(chatManager.get(), &ChatManager::conferenceNeedsName, this, &Widget::onConferenceNeedsName);
 
     chatListWidget =
         new FriendListWidget(*core, this, settings, style, *messageBoxManager, *friendList,
@@ -717,27 +721,20 @@ void Widget::onSelfAvatarLoaded(const QPixmap& pic)
 void Widget::onCoreChanged(Core& core_)
 {
     core = &core_;
+
+    // Model signal handlers are connected via ChatManager.
+    chatManager->connectToCore(core_);
+
+    // UI-specific Core signal connections.
     connect(core, &Core::connected, this, &Widget::onConnected);
     connect(core, &Core::disconnected, this, &Widget::onDisconnected);
     connect(core, &Core::statusSet, this, &Widget::onStatusSet);
     connect(core, &Core::usernameSet, this, &Widget::setUsername);
     connect(core, &Core::statusMessageSet, this, &Widget::setStatusMessage);
-    connect(core, &Core::friendAdded, this, &Widget::addFriend);
     connect(core, &Core::failedToAddFriend, this, &Widget::addFriendFailed);
-    connect(core, &Core::friendUsernameChanged, this, &Widget::onFriendUsernameChanged);
-    connect(core, &Core::friendStatusChanged, this, &Widget::onCoreFriendStatusChanged);
-    connect(core, &Core::friendStatusMessageChanged, this, &Widget::onFriendStatusMessageChanged);
     connect(core, &Core::friendRequestReceived, this, &Widget::onFriendRequestReceived);
-    connect(core, &Core::friendMessageReceived, this, &Widget::onFriendMessageReceived);
-    connect(core, &Core::receiptReceived, this, &Widget::onReceiptReceived);
     connect(core, &Core::conferenceInviteReceived, this, &Widget::onConferenceInviteReceived);
-    connect(core, &Core::conferenceMessageReceived, this, &Widget::onConferenceMessageReceived);
-    connect(core, &Core::conferencePeerlistChanged, this, &Widget::onConferencePeerlistChanged);
-    connect(core, &Core::conferencePeerNameChanged, this, &Widget::onConferencePeerNameChanged);
-    connect(core, &Core::conferenceTitleChanged, this, &Widget::onConferenceTitleChanged);
     connect(core, &Core::conferencePeerAudioPlaying, this, &Widget::onConferencePeerAudioPlaying);
-    connect(core, &Core::emptyConferenceCreated, this, &Widget::onEmptyConferenceCreated);
-    connect(core, &Core::conferenceJoined, this, &Widget::onConferenceJoined);
     connect(core, &Core::friendTypingChanged, this, &Widget::onFriendTypingChanged);
     connect(core, &Core::conferenceSentFailed, this, &Widget::onConferenceSendFailed);
     connect(core, &Core::usernameSet, this, &Widget::refreshPeerListsLocal);
@@ -746,8 +743,6 @@ void Widget::onCoreChanged(Core& core_)
     connect(this, &Widget::friendRequested, core, &Core::requestFriendship);
     connect(this, &Widget::friendRequestAccepted, core, &Core::acceptFriendRequest);
     connect(this, &Widget::changeConferenceTitle, core, &Core::changeConferenceTitle);
-
-    sharedMessageProcessorParams->setPublicKey(core->getSelfPublicKey().toString());
 }
 
 void Widget::onConnected()
@@ -1025,7 +1020,7 @@ void Widget::setUsername(const QString& username)
             Qt::convertFromPlainText(username, Qt::WhiteSpaceNormal)); // for overlength names
     }
 
-    sharedMessageProcessorParams->onUserNameSet(username);
+    chatManager->getSharedMessageProcessorParams().onUserNameSet(username);
 }
 
 void Widget::onStatusMessageChanged(const QString& newStatusMessage)
@@ -1196,7 +1191,7 @@ void Widget::dispatchFile(ToxFile file)
     }
 
     const auto senderPk = (file.direction == ToxFile::SENDING) ? core->getSelfPublicKey() : pk;
-    friendChatLogs[pk]->onFileUpdated(senderPk, file);
+    chatManager->getFriendChatLog(pk)->onFileUpdated(senderPk, file);
 
     filesForm->onFileUpdated(file);
 }
@@ -1226,40 +1221,23 @@ void Widget::onRejectCall(uint32_t friendId)
     av->cancelCall(friendId);
 }
 
-void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
+void Widget::onFriendModelAdded(Friend* newFriend, std::shared_ptr<FriendChatroom> chatroom,
+                                std::shared_ptr<FriendMessageDispatcher> friendMessageDispatcher,
+                                std::shared_ptr<ChatHistory> chatHistory)
 {
-    assert(core != nullptr);
-    settings.updateFriendAddress(friendPk.toString());
+    const ToxPk& friendPk = newFriend->getPublicKey();
 
-    Friend* newFriend = friendList->addFriend(friendId, friendPk, settings);
-    auto* rawChatroom =
-        new FriendChatroom(newFriend, contentDialogManager.get(), *core, settings, *conferenceList);
-    const std::shared_ptr<FriendChatroom> chatroom(rawChatroom);
     const auto compact = settings.getCompactLayout();
     auto* widget =
         new FriendWidget(chatroom, compact, settings, style, *messageBoxManager, profile, this);
     connectFriendWidget(*widget);
-    auto* history = profile.getHistory();
 
-    auto friendMessageDispatcher =
-        std::make_shared<FriendMessageDispatcher>(*newFriend,
-                                                  MessageProcessor(*sharedMessageProcessorParams),
-                                                  *core);
-
-    // Note: We do not have to connect the message dispatcher signals since
-    // ChatHistory hooks them up in a very specific order
-    auto chatHistory =
-        std::make_shared<ChatHistory>(*newFriend, history, *core, settings,
-                                      *friendMessageDispatcher, *friendList, *conferenceList);
     auto* friendForm =
         new ChatForm(profile, newFriend, *chatHistory, *friendMessageDispatcher, *documentCache,
                      *smileyPack, cameraSource, settings, style, *messageBoxManager,
                      *contentDialogManager, *friendList, *conferenceList, this);
     connect(friendForm, &ChatForm::updateFriendActivity, this, &Widget::updateFriendActivity);
 
-    friendMessageDispatchers[friendPk] = friendMessageDispatcher;
-    friendChatLogs[friendPk] = chatHistory;
-    friendChatRooms[friendPk] = chatroom;
     friendWidgets[friendPk] = widget;
     chatForms[friendPk] = friendForm;
 
@@ -1282,6 +1260,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
     connect(newFriend, &Friend::aliasChanged, this, &Widget::onFriendAliasChanged);
     connect(newFriend, &Friend::displayedNameChanged, this, &Widget::onFriendDisplayedNameChanged);
     connect(newFriend, &Friend::statusChanged, this, &Widget::onFriendStatusChanged);
+    connect(newFriend, &Friend::statusMessageChanged, this, &Widget::onFriendStatusMessageUpdated);
 
     connect(friendForm, &ChatForm::incomingNotification, this, &Widget::incomingNotification);
     connect(friendForm, &ChatForm::outgoingNotification, this, &Widget::outgoingNotification);
@@ -1321,20 +1300,6 @@ void Widget::addFriendFailed(const ToxPk& userId, const QString& errorInfo)
     QMessageBox::critical(nullptr, "Error", info);
 }
 
-void Widget::onCoreFriendStatusChanged(uint32_t friendId, Status::Status status)
-{
-    const auto& friendPk = friendList->id2Key(friendId);
-    Friend* f = friendList->findFriend(friendPk);
-    if (f == nullptr) {
-        return;
-    }
-
-    f->setStatus(status);
-
-    // Any widget behavior will be triggered based off of the status
-    // transformations done by the Friend class
-}
-
 void Widget::onFriendStatusChanged(const ToxPk& friendPk, Status::Status status)
 {
     FriendWidget* widget = friendWidgets[friendPk];
@@ -1353,20 +1318,10 @@ void Widget::onFriendStatusChanged(const ToxPk& friendPk, Status::Status status)
     contentDialogManager->updateFriendStatus(friendPk);
 }
 
-void Widget::onFriendStatusMessageChanged(uint32_t friendId, const QString& message)
+void Widget::onFriendStatusMessageUpdated(const ToxPk& friendPk, const QString& message)
 {
-    const auto& friendPk = friendList->id2Key(friendId);
-    Friend* f = friendList->findFriend(friendPk);
-    if (f == nullptr) {
-        return;
-    }
-
-    QString str = message;
-    str.replace('\n', ' ').remove('\r').remove(QChar('\0'));
-    f->setStatusMessage(str);
-
-    friendWidgets[friendPk]->setStatusMsg(str);
-    chatForms[friendPk]->setStatusMessage(str);
+    friendWidgets[friendPk]->setStatusMsg(message);
+    chatForms[friendPk]->setStatusMessage(message);
 }
 
 void Widget::onFriendDisplayedNameChanged(const QString& displayed)
@@ -1385,19 +1340,6 @@ void Widget::onFriendDisplayedNameChanged(const QString& displayed)
     }
 
     chatListWidget->itemsChanged();
-}
-
-void Widget::onFriendUsernameChanged(uint32_t friendId, const QString& username)
-{
-    const auto& friendPk = friendList->id2Key(friendId);
-    Friend* f = friendList->findFriend(friendPk);
-    if (f == nullptr) {
-        return;
-    }
-
-    QString str = username;
-    str.replace('\n', ' ').remove('\r').remove(QChar('\0'));
-    f->setName(str);
 }
 
 void Widget::onFriendAliasChanged(const ToxPk& friendId, const QString& alias)
@@ -1472,28 +1414,6 @@ void Widget::openDialog(GenericChatroomWidget* widget, bool newWindow)
     }
 }
 
-void Widget::onFriendMessageReceived(uint32_t friendNumber, const QString& message, bool isAction)
-{
-    const auto& friendId = friendList->id2Key(friendNumber);
-    Friend* f = friendList->findFriend(friendId);
-    if (f == nullptr) {
-        return;
-    }
-
-    friendMessageDispatchers[f->getPublicKey()]->onMessageReceived(isAction, message);
-}
-
-void Widget::onReceiptReceived(uint32_t friendId, ReceiptNum receipt)
-{
-    const auto& friendKey = friendList->id2Key(friendId);
-    Friend* f = friendList->findFriend(friendKey);
-    if (f == nullptr) {
-        return;
-    }
-
-    friendMessageDispatchers[f->getPublicKey()]->onReceiptReceived(receipt);
-}
-
 void Widget::addFriendDialog(const Friend* frnd, ContentDialog* dialog)
 {
     const ToxPk& friendPk = frnd->getPublicKey();
@@ -1506,7 +1426,7 @@ void Widget::addFriendDialog(const Friend* frnd, ContentDialog* dialog)
     }
 
     auto* form = chatForms[friendPk];
-    auto chatroom = friendChatRooms[friendPk];
+    auto chatroom = chatManager->getFriendChatroom(friendPk);
     FriendWidget* friendWidget = contentDialogManager->addFriendToDialog(dialog, chatroom, form);
 
     friendWidget->setStatusMsg(widget->getStatusMsg());
@@ -1559,7 +1479,7 @@ void Widget::addConferenceDialog(const Conference* conference, ContentDialog* di
     }
 
     auto* chatForm = conferenceForms[conferenceId].data();
-    auto chatroom = conferenceRooms[conferenceId];
+    auto chatroom = chatManager->getConferenceRoom(conferenceId);
     auto* conferenceWidget = contentDialogManager->addConferenceToDialog(dialog, chatroom, chatForm);
 
     auto removeConference = qOverload<const ConferenceId&>(&Widget::removeConference);
@@ -1811,16 +1731,12 @@ void Widget::removeFriend(Friend* f, bool fake)
         lastDialog->removeFriend(friendPk);
     }
 
-    friendList->removeFriend(friendPk, settings, fake);
     if (!fake) {
-        core->removeFriend(f->getId());
-        // aliases aren't supported for non-friend peers in conferences, revert to basic username
-        for (Conference* c : conferenceList->getAllConferences()) {
-            if (c->getPeerList().contains(friendPk)) {
-                c->updateUsername(friendPk, f->getUserName());
-            }
-        }
+        chatManager->removeFriend(friendPk);
+    } else {
+        chatManager->removeFriendModel(friendPk);
     }
+    friendList->removeFriend(friendPk, settings, fake);
 
     friendWidgets.remove(friendPk);
 
@@ -2037,52 +1953,6 @@ void Widget::onConferenceInviteAccepted(const ConferenceInvite& inviteInfo)
     }
 }
 
-void Widget::onConferenceMessageReceived(uint32_t conferencenumber, uint32_t peernumber,
-                                         const QString& message, bool isAction)
-{
-    const ConferenceId& conferenceId = conferenceList->id2Key(conferencenumber);
-    assert(conferenceList->findConference(conferenceId));
-
-    const ToxPk author = core->getConferencePeerPk(conferencenumber, peernumber);
-
-    conferenceMessageDispatchers[conferenceId]->onMessageReceived(author, isAction, message);
-}
-
-void Widget::onConferencePeerlistChanged(uint32_t conferencenumber)
-{
-    const ConferenceId& conferenceId = conferenceList->id2Key(conferencenumber);
-    Conference* c = conferenceList->findConference(conferenceId);
-    assert(c);
-    c->regeneratePeerList();
-}
-
-void Widget::onConferencePeerNameChanged(uint32_t conferencenumber, const ToxPk& peerPk,
-                                         const QString& newName)
-{
-    const ConferenceId& conferenceId = conferenceList->id2Key(conferencenumber);
-    Conference* c = conferenceList->findConference(conferenceId);
-    assert(c);
-
-    const QString setName = friendList->decideNickname(peerPk, newName);
-    c->updateUsername(peerPk, newName);
-}
-
-void Widget::onConferenceTitleChanged(uint32_t conferencenumber, const QString& author,
-                                      const QString& title)
-{
-    const ConferenceId& conferenceId = conferenceList->id2Key(conferencenumber);
-    Conference* c = conferenceList->findConference(conferenceId);
-    assert(c);
-
-    ConferenceWidget* widget = conferenceWidgets[conferenceId];
-    if (widget->isActive()) {
-        formatWindowTitle(title);
-    }
-
-    c->setTitle(author, title);
-    chatListWidget->itemsChanged();
-}
-
 void Widget::titleChangedByUser(const QString& title)
 {
     const auto* conference = qobject_cast<Conference*>(sender());
@@ -2130,15 +2000,18 @@ void Widget::removeConference(Conference* c, bool fake)
         onAddClicked();
     }
 
+    if (!fake) {
+        chatManager->removeConference(conferenceId);
+    } else {
+        chatManager->removeConferenceModel(conferenceId);
+    }
     conferenceList->removeConference(conferenceId, fake);
+
     ContentDialog* contentDialog = contentDialogManager->getConferenceDialog(conferenceId);
     if (contentDialog != nullptr) {
         contentDialog->removeConference(conferenceId);
     }
 
-    if (!fake) {
-        core->removeConference(conferencenumber);
-    }
     chatListWidget->removeConferenceWidget(widget); // deletes widget
 
     conferenceWidgets.remove(conferenceId);
@@ -2162,46 +2035,14 @@ void Widget::removeConference(const ConferenceId& conferenceId)
     removeConference(conferenceList->findConference(conferenceId));
 }
 
-Conference* Widget::createConference(uint32_t conferencenumber, const ConferenceId& conferenceId)
+void Widget::onConferenceModelAdded(Conference* newConference, std::shared_ptr<ConferenceRoom> chatroom,
+                                    std::shared_ptr<ConferenceMessageDispatcher> messageDispatcher,
+                                    std::shared_ptr<IChatLog> chatHistory)
 {
-    assert(core != nullptr);
-
-    Conference* c = conferenceList->findConference(conferenceId);
-    if (c != nullptr) {
-        qWarning() << "Conference already exists";
-        return c;
-    }
-
-    const auto conferenceName = tr("Conference #%1").arg(conferencenumber);
-    const bool enabled = core->getConferenceAvEnabled(conferencenumber);
-    Conference* newConference =
-        conferenceList->addConference(*core, conferencenumber, conferenceId, conferenceName,
-                                      enabled, core->getUsername(), *friendList);
-    assert(newConference);
-
-    if (enabled) {
-        connect(newConference, &Conference::userLeft, this, [this, newConference](const ToxPk& user) {
-            CoreAV* av = core->getAv();
-            assert(av);
-            av->invalidateConferenceCallPeerSource(*newConference, user);
-        });
-    }
-    auto* rawChatroom =
-        new ConferenceRoom(newConference, contentDialogManager.get(), *core, *friendList);
-    const std::shared_ptr<ConferenceRoom> chatroom(rawChatroom);
+    const ConferenceId& conferenceId = newConference->getPersistentId();
 
     const auto compact = settings.getCompactLayout();
     auto* widget = new ConferenceWidget(chatroom, compact, settings, style, this);
-    auto messageDispatcher =
-        std::make_shared<ConferenceMessageDispatcher>(*newConference,
-                                                      MessageProcessor(*sharedMessageProcessorParams),
-                                                      *core, *core, settings);
-
-    auto* history = profile.getHistory();
-    // Note: We do not have to connect the message dispatcher signals since
-    // ChatHistory hooks them up in a very specific order
-    auto chatHistory = std::make_shared<ChatHistory>(*newConference, history, *core, settings,
-                                                     *messageDispatcher, *friendList, *conferenceList);
 
     auto notifyReceivedConnection =
         connect(messageDispatcher.get(), &IMessageDispatcher::messageReceived, this,
@@ -2221,10 +2062,7 @@ Conference* Widget::createConference(uint32_t conferencenumber, const Conference
                                     *messageBoxManager, *friendList, *conferenceList);
     connect(&settings, &Settings::nameColorsChanged, form, &GenericChatForm::setColorizedNames);
     form->setColorizedNames(settings.getEnableConferencesColor());
-    conferenceMessageDispatchers[conferenceId] = messageDispatcher;
-    conferenceLogs[conferenceId] = chatHistory;
     conferenceWidgets[conferenceId] = widget;
-    conferenceRooms[conferenceId] = chatroom;
     conferenceForms[conferenceId] = QSharedPointer<ConferenceForm>(form);
 
     chatListWidget->addConferenceWidget(widget);
@@ -2239,35 +2077,28 @@ Conference* Widget::createConference(uint32_t conferencenumber, const Conference
             [this, conferenceId]() { removeConference(conferenceId); });
     connect(widget, &ConferenceWidget::chatroomWidgetClicked, form, &GenericChatForm::focusInput);
     connect(newConference, &Conference::titleChangedByUser, this, &Widget::titleChangedByUser);
-    connect(core, &Core::usernameSet, newConference, &Conference::setSelfName);
+    connect(newConference, &Conference::titleChanged, this,
+            [this, conferenceId](const QString& /* author */, const QString& title) {
+                ConferenceWidget* w = conferenceWidgets[conferenceId];
+                if (w->isActive()) {
+                    formatWindowTitle(title);
+                }
+                chatListWidget->itemsChanged();
+            });
 
     connect(form, &ConferenceForm::startConferenceCallNotification, this,
             &Widget::onStartConferenceCall);
     connect(form, &ConferenceForm::endConferenceCallNotification, this, &Widget::onEndConferenceCall);
-
-    return newConference;
 }
 
-void Widget::onEmptyConferenceCreated(uint32_t conferencenumber, const ConferenceId& conferenceId,
-                                      const QString& title)
+void Widget::onConferenceNeedsName(const ConferenceId& conferenceId)
 {
-    Conference* conference = createConference(conferencenumber, conferenceId);
-    if (conference == nullptr) {
-        return;
-    }
-    if (title.isEmpty()) {
-        // Only rename conference if conferences are visible.
-        if (conferencesVisible()) {
-            conferenceWidgets[conferenceId]->editName();
+    if (conferencesVisible()) {
+        auto it = conferenceWidgets.find(conferenceId);
+        if (it != conferenceWidgets.end()) {
+            it.value()->editName();
         }
-    } else {
-        conference->setTitle(QString(), title);
     }
-}
-
-void Widget::onConferenceJoined(uint32_t conferenceNum, const ConferenceId& conferenceId)
-{
-    createConference(conferenceNum, conferenceId);
 }
 
 /**
@@ -2513,7 +2344,10 @@ void Widget::clearAllReceipts()
 {
     const QList<Friend*> friends = friendList->getAllFriends();
     for (Friend* f : friends) {
-        friendMessageDispatchers[f->getPublicKey()]->clearOutgoingMessages();
+        auto* dispatcher = chatManager->getFriendDispatcher(f->getPublicKey());
+        if (dispatcher != nullptr) {
+            dispatcher->clearOutgoingMessages();
+        }
     }
 }
 

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -14,8 +14,6 @@
 #include "src/core/toxfile.h"
 #include "src/core/toxid.h"
 #include "src/core/toxpk.h"
-#include "src/model/conferencemessagedispatcher.h"
-#include "src/model/friendmessagedispatcher.h"
 #include "src/model/notificationgenerator.h"
 #include "src/platform/desktop_notifications/desktopnotify.h"
 #include "src/widget/form/debugwidget.h"
@@ -26,11 +24,14 @@
 #include <QSystemTrayIcon>
 #include <QUrl>
 
+#include <memory>
+
 namespace Ui {
 class MainWindow;
 }
 
 class AddFriendForm;
+class ChatManager;
 class AlSink;
 class Camera;
 class ChatForm;
@@ -50,7 +51,9 @@ class ConferenceRoom;
 class ConferenceInvite;
 class ConferenceInviteForm;
 class ConferenceWidget;
+class ConferenceMessageDispatcher;
 class DocumentCache;
+class FriendMessageDispatcher;
 class MaskablePixmapWidget;
 class ProfileForm;
 class ProfileInfo;
@@ -161,30 +164,15 @@ public slots:
     void onSelfAvatarLoaded(const QPixmap& pic);
     void setUsername(const QString& username);
     void setStatusMessage(const QString& statusMessage);
-    void addFriend(uint32_t friendId, const ToxPk& friendPk);
     void addFriendFailed(const ToxPk& userId, const QString& errorInfo = QString());
-    void onCoreFriendStatusChanged(uint32_t friendId, Status::Status status);
     void onFriendStatusChanged(const ToxPk& friendPk, Status::Status status);
-    void onFriendStatusMessageChanged(uint32_t friendId, const QString& message);
+    void onFriendStatusMessageUpdated(const ToxPk& friendPk, const QString& message);
     void onFriendDisplayedNameChanged(const QString& displayed);
-    void onFriendUsernameChanged(uint32_t friendId, const QString& username);
     void onFriendAliasChanged(const ToxPk& friendId, const QString& alias);
-    void onFriendMessageReceived(uint32_t friendNumber, const QString& message, bool isAction);
-    void onReceiptReceived(uint32_t friendId, ReceiptNum receipt);
     void onFriendRequestReceived(const ToxPk& friendPk, const QString& message);
     void onFileReceiveRequested(const ToxFile& file);
-    void onEmptyConferenceCreated(uint32_t conferencenumber, const ConferenceId& conferenceId,
-                                  const QString& title);
-    void onConferenceJoined(uint32_t conferenceNum, const ConferenceId& conferenceId);
     void onConferenceInviteReceived(const ConferenceInvite& inviteInfo);
     void onConferenceInviteAccepted(const ConferenceInvite& inviteInfo);
-    void onConferenceMessageReceived(uint32_t conferencenumber, uint32_t peernumber,
-                                     const QString& message, bool isAction);
-    void onConferencePeerlistChanged(uint32_t conferencenumber);
-    void onConferencePeerNameChanged(uint32_t conferencenumber, const ToxPk& peerPk,
-                                     const QString& newName);
-    void onConferenceTitleChanged(uint32_t conferencenumber, const QString& author,
-                                  const QString& title);
     void titleChangedByUser(const QString& title);
     void onConferencePeerAudioPlaying(uint32_t conferencenumber, ToxPk peerPk);
     void onConferenceSendFailed(uint32_t conferencenumber);
@@ -252,6 +240,14 @@ private slots:
     void updateFriendActivity(const Friend& frnd);
     void registerContentDialog(ContentDialog& contentDialog) const;
 
+    void onFriendModelAdded(Friend* newFriend, std::shared_ptr<FriendChatroom> chatroom,
+                            std::shared_ptr<FriendMessageDispatcher> dispatcher,
+                            std::shared_ptr<ChatHistory> chatHistory);
+    void onConferenceModelAdded(Conference* newConference, std::shared_ptr<ConferenceRoom> chatroom,
+                                std::shared_ptr<ConferenceMessageDispatcher> dispatcher,
+                                std::shared_ptr<IChatLog> chatHistory);
+    void onConferenceNeedsName(const ConferenceId& conferenceId);
+
 private:
     // QMainWindow overrides
     bool eventFilter(QObject* obj, QEvent* event) final;
@@ -264,7 +260,6 @@ private:
     bool newMessageAlert(QWidget* currentWindow, bool isActive, bool sound = true, bool notify = true);
     void setActiveToolMenuButton(ActiveToolMenuButton newActiveButton);
     void hideMainForms(GenericChatroomWidget* chatroomWidget);
-    Conference* createConference(uint32_t conferencenumber, const ConferenceId& conferenceId);
     void removeFriend(Friend* f, bool fake = false);
     void removeConference(Conference* c, bool fake = false);
     void saveWindowGeometry();
@@ -343,32 +338,23 @@ private:
     Settings& settings;
 
     QMap<ToxPk, FriendWidget*> friendWidgets;
-    // Shared pointer because QMap copies stuff all over the place
-    QMap<ToxPk, std::shared_ptr<FriendMessageDispatcher>> friendMessageDispatchers;
     // Stop gap method of linking our friend messages back to a conference id.
     // Eventual goal is to have a notification manager that works on
     // Messages hooked up to message dispatchers but we aren't there
     // yet
     QMap<ToxPk, QMetaObject::Connection> friendAlertConnections;
-    QMap<ToxPk, std::shared_ptr<ChatHistory>> friendChatLogs;
-    QMap<ToxPk, std::shared_ptr<FriendChatroom>> friendChatRooms;
     QMap<ToxPk, ChatForm*> chatForms;
 
     QMap<ConferenceId, ConferenceWidget*> conferenceWidgets;
-    QMap<ConferenceId, std::shared_ptr<ConferenceMessageDispatcher>> conferenceMessageDispatchers;
-
     // Stop gap method of linking our conference messages back to a conference id.
     // Eventual goal is to have a notification manager that works on
     // Messages hooked up to message dispatchers but we aren't there
     // yet
     QMap<ConferenceId, QMetaObject::Connection> conferenceAlertConnections;
-    QMap<ConferenceId, std::shared_ptr<IChatLog>> conferenceLogs;
-    QMap<ConferenceId, std::shared_ptr<ConferenceRoom>> conferenceRooms;
     QMap<ConferenceId, QSharedPointer<ConferenceForm>> conferenceForms;
     Core* core = nullptr;
 
-
-    std::unique_ptr<MessageProcessor::SharedParams> sharedMessageProcessorParams;
+    std::unique_ptr<ChatManager> chatManager;
     std::unique_ptr<NotificationGenerator> notificationGenerator;
     std::unique_ptr<DesktopNotify> notifier;
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -68,26 +68,34 @@ cc_library(
 
 UI_TESTS = ["loginscreen_test"]
 
+MEDIUM_TESTS = [
+    "chatwidget_test",
+    "core_test",
+    "posixsignalnotifier_test",
+]
+
+TEST_DEPS = [
+    ":dbutility",
+    ":mock",
+    "//c-toxcore",
+    "//qtox:res_lib",
+    "//qtox/src",
+    "//qtox/src:core",
+    "//qtox/util",
+    "@qt//:qt_core",
+    "@qt//:qt_gui",
+    "@qt//:qt_network",
+    "@qt//:qt_widgets",
+]
+
 [qt_test(
     name = src[src.rindex("/") + 1:-4],
-    size = "small",
+    size = "medium" if src[src.rindex("/") + 1:-4] in MEDIUM_TESTS else "small",
     src = src,
     copts = COPTS,
     mocopts = ["-Iqtox"],
     tags = ["ui"] if src[src.rindex("/") + 1:-4] in UI_TESTS else [],
-    deps = [
-        ":dbutility",
-        ":mock",
-        "//c-toxcore",
-        "//qtox:res_lib",
-        "//qtox/src",
-        "//qtox/src:core",
-        "//qtox/util",
-        "@qt//:qt_core",
-        "@qt//:qt_gui",
-        "@qt//:qt_network",
-        "@qt//:qt_widgets",
-    ],
+    deps = TEST_DEPS,
 ) for src in glob(
     ["**/*_test.cpp"],
     exclude = [

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -819,6 +819,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">محادثة جماعية #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3289,10 +3296,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Contacts</source>
         <translation>جهات الاتصال</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">محادثة جماعية #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -786,6 +786,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Групавы чат № %1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3207,10 +3214,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>Шукаць кантакты</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Групавы чат № %1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/ber.ts
+++ b/translations/ber.ts
@@ -751,6 +751,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">ⴰⵙⴰⵔⴰⴳ #%1.</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3080,10 +3087,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation type="unfinished">ⵔⵣⵓ ⵅⴼ ⵉⵏⴻⵔⵎⵉⵙⴻⵏ</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">ⴰⵙⴰⵔⴰⴳ #%1.</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -752,6 +752,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Групов разговор №%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3020,10 +3027,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Your name</source>
         <translation>Вашето име</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Групов разговор №%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/bn.ts
+++ b/translations/bn.ts
@@ -912,6 +912,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>সম্মেলন #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3728,11 +3735,6 @@ number here may cause the scroll bar to disappear.</source>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">পরিচিতি অনুসন্ধান করুন</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">সম্মেলন #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/ca.ts
+++ b/translations/ca.ts
@@ -912,6 +912,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Conferència #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3737,11 +3744,6 @@ aquí pot fer que la barra de desplaçament desaparegui.</translation>
         <source>Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Contactes</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Conferència #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -759,6 +759,13 @@ takže můžete soubor uložit i v systému Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Skupinová konverzace #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3127,10 +3134,6 @@ chatu:</translation>
     <message>
         <source>Your name</source>
         <translation>Vaše jméno</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Skupinová konverzace #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -836,6 +836,13 @@ så du kan gemme filen på Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Konference #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3519,11 +3526,6 @@ størrelse</translation>
     <message>
         <source>Search Contacts</source>
         <translation>Søg i Kontakter</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Konference #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -752,6 +752,13 @@ um die Datei unter Windows speichern zu können.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Konferenz #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3081,10 +3088,6 @@ Bildlaufleiste verschwindet.</translation>
     <message>
         <source>Search Contacts</source>
         <translation>Kontakte durchsuchen</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Konferenz #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -792,6 +792,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Ομαδική συνομιλία #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3234,10 +3241,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Contacts</source>
         <translation>Επαφές</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Ομαδική συνομιλία #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -862,6 +862,13 @@ do vi povas konservi la dosieron en Vindozo.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Grupbabilejo #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3454,10 +3461,6 @@ okolo:</translation>
     <message>
         <source>Your name</source>
         <translation>Via nomo</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Grupbabilejo #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -752,6 +752,13 @@ para que puedas guardar el archivo en windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Grupo #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3081,10 +3088,6 @@ desplazamiento.</translation>
         <source>Logout</source>
         <comment>Tray action menu to logout user</comment>
         <translation>Cerrar sesión</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Grupo #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -758,6 +758,13 @@ ja sa saad seda faili nüüd Windowsis salvestada.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Grupivestlus #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3129,10 +3136,6 @@ logi:</translation>
     <message>
         <source>Contacts</source>
         <translation>Kontaktid</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Grupivestlus #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -783,6 +783,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">چت گروهی #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3192,10 +3199,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>جست و جوی مخاطبین</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">چت گروهی #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -758,6 +758,13 @@ joten voit tallentaa tiedoston Windowsissa.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Ryhmäkeskustelu #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3124,10 +3131,6 @@ loki:</translation>
     <message>
         <source>Contacts</source>
         <translation>Yhteystiedot</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Ryhmäkeskustelu #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -751,6 +751,13 @@ afin que vous puissiez enregistrer le fichier sur windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>conférence #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3075,10 +3082,6 @@ Un nombre trop faible ici peut entraîner la disparition de la barre de défilem
         <source>Logout</source>
         <comment>Tray action menu to logout user</comment>
         <translation>Déconnexion</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>conférence #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -784,6 +784,13 @@ para que poida gardar o ficheiro en Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Grupo de charla #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3196,10 +3203,6 @@ de chat:</translation>
     <message>
         <source>Search Contacts</source>
         <translation>Buscar contactos</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Grupo de charla #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -896,6 +896,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>ועידה #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3706,11 +3713,6 @@ number here may cause the scroll bar to disappear.</source>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">חפש אנשי קשר</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ועידה #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -784,6 +784,13 @@ tako da možete spremiti datoteku na Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Grupno čavrljanje br. %1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3134,10 +3141,6 @@ azgovora:</translation>
     <message>
         <source>Your name</source>
         <translation>Tvoje ime</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Grupno čavrljanje br. %1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -782,6 +782,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">#%1. csoport</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3128,10 +3135,6 @@ napló:</translation>
     <message>
         <source>Your name</source>
         <translation>Név</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">#%1. csoport</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -898,6 +898,13 @@ svo þú getur vistað skrána á Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Ráðstefna #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3704,11 +3711,6 @@ spjalldagskrár</translation>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Leita í tengiliðum</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Ráðstefna #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -751,6 +751,13 @@ in modo da poter salvare il file su Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Gruppo #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3080,10 +3087,6 @@ chat:</translation>
     <message>
         <source>Your name</source>
         <translation>qTox User</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Gruppo #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -753,6 +753,13 @@ Windows にファイルを保存できるようになります。</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>グループチャット #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3010,10 +3017,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Your name</source>
         <translation>名前</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>グループチャット #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/jbo.ts
+++ b/translations/jbo.ts
@@ -749,6 +749,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">nungirzu #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3059,10 +3066,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation type="unfinished">sisku loi jikca</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">nungirzu #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -910,6 +910,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>ಸಮ್ಮೇಳನ #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3717,11 +3724,6 @@ number here may cause the scroll bar to disappear.</source>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">ಸಂಪರ್ಕಗಳನ್ನು ಹುಡುಕಿ</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">ಸಮ್ಮೇಳನ #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -824,6 +824,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">그룹채팅 #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3547,10 +3554,6 @@ number here may cause the scroll bar to disappear.</source>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">연락처 검색</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">그룹채팅 #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/li.ts
+++ b/translations/li.ts
@@ -918,6 +918,13 @@ zodet geer ut bestand op Windows kin opsjlaon.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Conferentie #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3700,11 +3707,6 @@ chatlogboek</translation>
         <comment>title of the window</comment>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Debug</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Conferentie #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -759,6 +759,13 @@ tad dabar galite įrašyti failą Windows sistemoje.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Grupės pokalbis Nr. %1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3133,10 +3140,6 @@ gabalo dydis</translation>
     <message>
         <source>Your name</source>
         <translation>Jūsų vardas</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Grupės pokalbis Nr. %1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -766,6 +766,13 @@ lai varētu saglabāt failus Windows operētājsistēmā.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Konference #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3206,11 +3213,6 @@ mazs skaitlis var izraisīt ritjoslas pazušanu.</translation>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Meklēt kontaktos</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Konference #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -794,6 +794,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Групен разговор #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3254,10 +3261,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>Пребарај контакти</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Групен разговор #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/nb_NO.ts
+++ b/translations/nb_NO.ts
@@ -760,6 +760,13 @@ slik at du kan lagre filen på Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Gruppesludring #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3106,10 +3113,6 @@ logg:</translation>
     <message>
         <source>Your name</source>
         <translation>Ditt navn</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Gruppesludring #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -756,6 +756,13 @@ zodat u het bestand op Windows kunt opslaan.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Conferentie #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3092,10 +3099,6 @@ ek:</translation>
     <message>
         <source>Your name</source>
         <translation>Je naam</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Conferentie #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -796,6 +796,13 @@ zodat ge het bestand op Windows kunt opslaan.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Groepsgesprek #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3281,10 +3288,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>Contacten doorzoeken</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Groepsgesprek #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -759,6 +759,13 @@ więc możesz zapisać ten plik na systemie Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Konferencja #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3093,10 +3100,6 @@ Zbyt mała liczba może spowodować zniknięcie paska przewijania.</translation>
     <message>
         <source>Contacts</source>
         <translation>Kontakty</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Konferencja #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/pr.ts
+++ b/translations/pr.ts
@@ -752,6 +752,13 @@ so ye can stash th&apos; file on Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Crew #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3076,10 +3083,6 @@ here may cause th&apos; scroll bar ta vanish.</translation>
     <message>
         <source>Search Contacts</source>
         <translation>Search Hearties</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Crew #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -758,6 +758,13 @@ de forma que possa guardar o ficheiro no Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Conversa em grupo #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3105,10 +3112,6 @@ papo:</translation>
     <message>
         <source>Your name</source>
         <translation>O seu nome</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Conversa em grupo #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -752,6 +752,13 @@ de forma que você possa salvar o arquivo no Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Conferência #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3082,10 +3089,6 @@ Um número muito baixo aqui pode fazer com que a barra de rolagem desapareça.</
     <message>
         <source>Search Contacts</source>
         <translation>Buscar Contatos</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Conferência #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -758,6 +758,13 @@ astfel încât să puteți salva fișierul pe Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Conferința #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3109,10 +3116,6 @@ chat:</translation>
     <message>
         <source>Search Contacts</source>
         <translation>Căutare contacte</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Conferința #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -754,6 +754,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Конференция #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3086,10 +3093,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Status</source>
         <translation>Статус</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Конференция #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -915,6 +915,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>සම්මන්ත්‍රණය #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3734,11 +3741,6 @@ number here may cause the scroll bar to disappear.</source>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">සම්බන්ධතා සොයන්න</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">සම්මන්ත්‍රණය #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -760,6 +760,13 @@ so you can save the file on Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Skupinový chat %1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3120,10 +3127,6 @@ zhovoru:</translation>
     <message>
         <source>Search Contacts</source>
         <translation>Vyhľadávanie kontaktov</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Skupinový chat %1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -801,6 +801,13 @@ tako da lahko datoteko shranite v sistem Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Konferenca #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3315,11 +3322,6 @@ klepeta:</translation>
     <message>
         <source>Your name</source>
         <translation type="unfinished">Tvoje ime</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Konferenca #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -910,6 +910,13 @@ kështu që mund ta ruani skedarin në Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Konferenca #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3732,11 +3739,6 @@ bisedës:</translation>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Kërko Kontaktet</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Konferenca #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -785,6 +785,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Групно ћаскање #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3198,10 +3205,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>Претражи контакте</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Групно ћаскање #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -748,6 +748,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Grupno ćaskanje #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3057,10 +3064,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>Pretraži kontakte</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Grupno ćaskanje #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -759,6 +759,13 @@ så att du kan spara filen i Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Gruppchatt #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3078,10 +3085,6 @@ för lågt nummer här kan göra att rullningslisten försvinner.</translation>
     <message>
         <source>Your name</source>
         <translation>Ditt namn</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Gruppchatt #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -917,6 +917,13 @@ kwa hivyo unaweza kuhifadhi faili kwenye Windows.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Mkutano #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3737,11 +3744,6 @@ gumzo:</translation>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">Tafuta Anwani</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">Mkutano #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -752,6 +752,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>மாநாடு #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3082,10 +3089,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>தொடர்புகளைத் தேடுங்கள்</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>மாநாடு #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -760,6 +760,13 @@ geçersiz karakterler _ olarak değiştirildi.</translation>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Grup sohbeti #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3106,10 +3113,6 @@ günlüğü:</translation>
     <message>
         <source>Contacts</source>
         <translation>Kişiler</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Grup sohbeti #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -794,6 +794,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">توپ سۆھبەت #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3247,10 +3254,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>ئالاقىداش ئىزدەش</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">توپ سۆھبەت #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -752,6 +752,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>Конференція #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3087,10 +3094,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Your name</source>
         <translation>Ваше ім&apos;я</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>Конференція #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -891,6 +891,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>کانفرنس #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3707,11 +3714,6 @@ number here may cause the scroll bar to disappear.</source>
         <source>Search Contacts</source>
         <translatorcomment>Automated translation.</translatorcomment>
         <translation type="unfinished">رابطے تلاش کریں۔</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translatorcomment>Automated translation.</translatorcomment>
-        <translation type="unfinished">کانفرنس #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/vi.ts
+++ b/translations/vi.ts
@@ -758,6 +758,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">Nhómchat #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3111,10 +3118,6 @@ chuyện:</translation>
     <message>
         <source>Search Contacts</source>
         <translation>Tìm kiếm liên hệ</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">Nhómchat #%1</translation>
     </message>
     <message>
         <source>Show</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -755,6 +755,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation>会议 #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3046,10 +3053,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Status</source>
         <translation>状态</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation>会议 #%1</translation>
     </message>
     <message>
         <source>Create new conference...</source>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -847,6 +847,13 @@ so you can save the file on Windows.</source>
     </message>
 </context>
 <context>
+    <name>ChatManager</name>
+    <message>
+        <source>Conference #%1</source>
+        <translation type="unfinished">群組聊天 #%1</translation>
+    </message>
+</context>
+<context>
     <name>ChatTextEdit</name>
     <message>
         <source>Type your message here...</source>
@@ -3574,10 +3581,6 @@ number here may cause the scroll bar to disappear.</source>
     <message>
         <source>Search Contacts</source>
         <translation>搜尋聯絡人</translation>
-    </message>
-    <message>
-        <source>Conference #%1</source>
-        <translation type="unfinished">群組聊天 #%1</translation>
     </message>
     <message>
         <source>Show</source>


### PR DESCRIPTION
Move per-friend and per-conference model state (dispatchers, chat logs, chatrooms) and Core signal handlers for lifecycle/message-routing from Widget into a new ChatManager class. Widget keeps all UI state and creates UI elements in response to ChatManager signals.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/694)
<!-- Reviewable:end -->
