### PR TITLE
fix: Destroy UI forms before model objects on shutdown.

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1731,18 +1731,20 @@ void Widget::removeFriend(Friend* f, bool fake)
         lastDialog->removeFriend(friendPk);
     }
 
+    friendWidgets.remove(friendPk);
+
+    // Delete ChatForm before ChatManager removes the model, because
+    // ChatForm holds references to chatLog and chatState owned by ChatManager.
+    auto* chatForm = chatForms[friendPk];
+    chatForms.remove(friendPk);
+    delete chatForm;
+
     if (!fake) {
         chatManager->removeFriend(friendPk);
     } else {
         chatManager->removeFriendModel(friendPk);
     }
     friendList->removeFriend(friendPk, settings, fake);
-
-    friendWidgets.remove(friendPk);
-
-    auto* chatForm = chatForms[friendPk];
-    chatForms.remove(friendPk);
-    delete chatForm;
 
     delete f;
     if ((contentLayout != nullptr) && contentLayout->mainHead->layout()->isEmpty()) {
@@ -2000,13 +2002,6 @@ void Widget::removeConference(Conference* c, bool fake)
         onAddClicked();
     }
 
-    if (!fake) {
-        chatManager->removeConference(conferenceId);
-    } else {
-        chatManager->removeConferenceModel(conferenceId);
-    }
-    conferenceList->removeConference(conferenceId, fake);
-
     ContentDialog* contentDialog = contentDialogManager->getConferenceDialog(conferenceId);
     if (contentDialog != nullptr) {
         contentDialog->removeConference(conferenceId);
@@ -2015,6 +2010,10 @@ void Widget::removeConference(Conference* c, bool fake)
     chatListWidget->removeConferenceWidget(widget); // deletes widget
 
     conferenceWidgets.remove(conferenceId);
+    conferenceAlertConnections.remove(conferenceId);
+
+    // Destroy ConferenceForm before ChatManager removes the model, because
+    // ~ConferenceForm() calls addSystemInfoMessage() which accesses chatLog.
     auto conferenceFormIt = conferenceForms.find(conferenceId);
     if (conferenceFormIt == conferenceForms.end()) {
         qWarning() << "Tried to remove conference" << conferencenumber
@@ -2022,7 +2021,13 @@ void Widget::removeConference(Conference* c, bool fake)
         return;
     }
     conferenceForms.erase(conferenceFormIt);
-    conferenceAlertConnections.remove(conferenceId);
+
+    if (!fake) {
+        chatManager->removeConference(conferenceId);
+    } else {
+        chatManager->removeConferenceModel(conferenceId);
+    }
+    conferenceList->removeConference(conferenceId, fake);
 
     delete c;
     if ((contentLayout != nullptr) && contentLayout->mainHead->layout()->isEmpty()) {


### PR DESCRIPTION
`ChatManager` owns the `IChatLog` and `FriendChatState` that `ChatForm` and `ConferenceForm` hold by reference. Destroying the model first left dangling references, causing a use-after-free when form destructors accessed them (e.g. `ConferenceForm::~ConferenceForm` adding a "left conference" system message).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/qTox/695)
<!-- Reviewable:end -->
